### PR TITLE
Isolated repro for #7691

### DIFF
--- a/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
+++ b/packages/-ember-data/tests/integration/adapter/rest-adapter-test.js
@@ -1283,6 +1283,59 @@ module('integration/adapter/rest_adapter - REST Adapter', function (hooks) {
     assert.deepEqual(comments.toArray(), [comment1, comment2, comment3], 'The correct records are in the array');
   });
 
+  test('findHasMany - can push the smae record in twice and fetch the link', async function (assert) {
+    adapter.shouldBackgroundReloadRecord = () => false;
+    Post.reopen({ comments: DS.hasMany('comment', { async: true }) });
+
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        attributes: {
+          name: 'Rails is omakase',
+        },
+        relationships: {
+          comments: {
+            links: {
+              related: '/posts/1/comments',
+            },
+          },
+        },
+      },
+    });
+
+    store.push({
+      data: {
+        type: 'post',
+        id: '1',
+        attributes: {
+          name: 'Rails is omakase',
+        },
+        relationships: {
+          comments: {
+            links: {
+              related: '/posts/1/comments',
+            },
+          },
+        },
+      },
+    });
+
+    let post = store.peekRecord('post', '1');
+
+    ajaxResponse({
+      comments: [
+        { id: 1, name: 'FIRST' },
+        { id: 2, name: 'Rails is unagi' },
+        { id: 3, name: 'What is omakase?' },
+      ],
+    });
+
+    let comments = await post.get('comments');
+    assert.equal(comments.length, 3, 'The correct records are in the array');
+  
+  });
+
   test('findHasMany - passes buildURL the requestType', async function (assert) {
     assert.expect(2);
     adapter.shouldBackgroundReloadRecord = () => false;


### PR DESCRIPTION
A narrow test case for #7691 that shows that pushing a record twice no longer fetches the link