### PR TITLE
Fixing broken links in docs

### DIFF
--- a/packages/store/addon/-private/store-service.ts
+++ b/packages/store/addon/-private/store-service.ts
@@ -134,12 +134,12 @@ export interface CreateRecordProperties {
   The store provides multiple ways to create new record objects. They have
   some subtle differences in their use which are detailed below:
 
-  [createRecord](../methods/createRecord?anchor=createRecord) is used for creating new
+  [createRecord](./classes/Store/methods?anchor=createRecord) is used for creating new
   records on the client side. This will return a new record in the
   `created.uncommitted` state. In order to persist this record to the
   backend, you will need to call `record.save()`.
 
-  [push](../methods/push?anchor=push) is used to notify Ember Data's store of new or
+  [push](./methods/push?anchor=push) is used to notify Ember Data's store of new or
   updated records that exist in the backend. This will return a record
   in the `loaded.saved` state. The primary use-case for `store#push` is
   to notify Ember Data about record updates (full or partial) that happen
@@ -147,7 +147,7 @@ export interface CreateRecordProperties {
   [SSE](http://dev.w3.org/html5/eventsource/) or [Web
   Sockets](http://www.w3.org/TR/2009/WD-websockets-20091222/)).
 
-  [pushPayload](../methods/pushPayload?anchor=pushPayload) is a convenience wrapper for
+  [pushPayload](./methods/pushPayload?anchor=pushPayload) is a convenience wrapper for
   `store#push` that will deserialize payloads if the
   Serializer implements a `pushPayload` method.
 


### PR DESCRIPTION
When I try to click links that I'm touching in this PR on the page: https://api.emberjs.com/ember-data/4.6/classes/Store

I will get to: https://api.emberjs.com/ember-data/4.6/methods/createRecord?anchor=createRecord which fails with: `Cannot GET /ember-data/4.6/methods/createRecord`.

etc.

I'm not 100% sure this is correct. I just hand-crafted this PR straight from github following the existing paths. If someone can double-check that would be awesome.

<!--

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).

-->

## Description

## Type of PR

What kind of change is this?

- [ ] refactor
- [ ] internal bugfix
- [x] user-facing bugfix
- [ ] new feature
- [ ] deprecation
- [ ] documentation
- [ ] something else (please describe)
- [ ] tests

## Notes for the release

Does this PR need to be described in the Ember release blog post? Please briefly describe what should be shared.


