### PR TITLE
Include param should always reference array in docs

### DIFF
--- a/guides/requests/examples/0-basic-usage.md
+++ b/guides/requests/examples/0-basic-usage.md
@@ -138,7 +138,7 @@ import fetch from './fetch';
 
 // ... execute a request
 const { content: collection } = await fetch.request(query('company', {
-  include: 'ceo',
+  include: ['ceo'],
   fields: {
     company: 'name',
     employee: ['name', 'profileImage']
@@ -182,7 +182,7 @@ import { query } from '@ember-data/json-api/request';
 
 // ... execute a request
 const { content: collection } = await store.request(query('company', {
-  include: 'ceo',
+  include: ['ceo'],
   fields: {
     company: 'name',
     employee: ['name', 'profileImage']
@@ -249,7 +249,7 @@ import fetch from './fetch';
 // ... execute a request
 try {
   const result = await fetch.request(query('company', {
-    include: 'ceo',
+    include: ['ceo'],
     fields: {
       company: 'name',
       employee: ['name', 'profileImage']

--- a/packages/store/src/-private/store-service.ts
+++ b/packages/store/src/-private/store-service.ts
@@ -1278,7 +1278,7 @@ export class Store extends BaseClass {
     ```app/routes/post.js
     export default class PostRoute extends Route {
       model(params) {
-        return this.store.findRecord('post', params.post_id, { include: 'comments' });
+        return this.store.findRecord('post', params.post_id, { include: ['comments'] });
       }
     }
     ```
@@ -1305,15 +1305,17 @@ export class Store extends BaseClass {
     In this case, the post's comments would then be available in your template as
     `model.comments`.
 
-    Multiple relationships can be requested using an `include` parameter consisting of a
-    comma-separated list (without white-space) while nested relationships can be specified
-    using a dot-separated sequence of relationship names. So to request both the post's
+    Multiple relationships can be requested using an `include` parameter consisting
+    of a list of relationship names, while nested relationships can be specified using a
+    dot-separated sequence of relationship names. So to request both the post's
     comments and the authors of those comments the request would look like this:
 
     ```app/routes/post.js
     export default class PostRoute extends Route {
       model(params) {
-        return this.store.findRecord('post', params.post_id, { include: 'comments,comments.author' });
+        return this.store.findRecord('post', params.post_id, {
+          include: ['comments', 'comments.author']
+        });
       }
     }
     ```
@@ -1930,19 +1932,19 @@ export class Store extends BaseClass {
     ```app/routes/posts.js
     export default class PostsRoute extends Route {
       model() {
-        return this.store.findAll('post', { include: 'comments' });
+        return this.store.findAll('post', { include: ['comments'] });
       }
     }
     ```
     Multiple relationships can be requested using an `include` parameter consisting of a
-    comma-separated list (without white-space) while nested relationships can be specified
+    list of relationship names, while nested relationships can be specified
     using a dot-separated sequence of relationship names. So to request both the posts'
     comments and the authors of those comments the request would look like this:
 
     ```app/routes/posts.js
     export default class PostsRoute extends Route {
       model() {
-        return this.store.findAll('post', { include: 'comments,comments.author' });
+        return this.store.findAll('post', { include: ['comments', 'comments.author'] });
       }
     }
     ```


### PR DESCRIPTION
Due to confusion described in https://github.com/emberjs/data/issues/9502 we should update docs and maybe internal usage

TODO:
- [ ] Add lint rule with autofix 
- [ ] Verify all docs updated 
- [ ] Verify guides updated https://github.com/ember-learn/guides-source/pull/2048
