### PR TITLE
Add `unknownProperty` and `size` to `IgnoredGlobalFields` list

### DIFF
--- a/warp-drive-packages/core/src/reactive/-private/record.ts
+++ b/warp-drive-packages/core/src/reactive/-private/record.ts
@@ -28,7 +28,7 @@ import { peekManagedObject } from './fields/managed-object.ts';
 import type { SchemaService } from './schema.ts';
 import { Checkout, Commit, Context, Destroy } from './symbols.ts';
 
-const IgnoredGlobalFields = new Set<string>(['length', 'nodeType', 'then', 'setInterval', 'document', STRUCTURED]);
+const IgnoredGlobalFields = new Set<string>(['length', 'nodeType', 'then', 'setInterval', 'document', 'unknownProperty', 'size', STRUCTURED]);
 const symbolList = [Context, Destroy, RecordStore, Checkout, Commit];
 const RecordSymbols = new Set(symbolList);
 


### PR DESCRIPTION
fix #10096

While using `isEmpty` and `@ember/utils` with schema-record i was running into error `Error: No field named unknownProperty on user.`

To resolve this issue we need to add `unknownProperty` and `size` to `IgnoredGlobalFields`