### PR TITLE
feat: easier transactional commits

### DIFF
--- a/tests/builders/tests/integration/create-record-test.ts
+++ b/tests/builders/tests/integration/create-record-test.ts
@@ -12,7 +12,6 @@ import type { Cache } from '@warp-drive/core-types/cache';
 import type { ResourceKey } from '@warp-drive/core-types/identifier';
 import type { CollectionResourceDataDocument, SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 import type { ApiError } from '@warp-drive/core-types/spec/error';
-import type { SingleResourceDocument } from '@warp-drive/core-types/spec/json-api-raw';
 import { module, test } from '@warp-drive/diagnostic';
 import { setupTest } from '@warp-drive/diagnostic/ember';
 
@@ -183,9 +182,11 @@ module('Integration - createRecord', function (hooks) {
         // @ts-expect-error TS doesn't handle overload forwarding
         return super.didCommit(cacheKey, result);
       }
-      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${key.lid}`);
-        return super.commitWasRejected(key, errors);
+      commitWasRejected(cacheKey: ResourceKey | ResourceKey[], errors?: ApiError[]): void {
+        assert.step(
+          `commitWasRejected ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`
+        );
+        return super.commitWasRejected(cacheKey, errors);
       }
     }
 

--- a/tests/builders/tests/integration/create-record-test.ts
+++ b/tests/builders/tests/integration/create-record-test.ts
@@ -10,7 +10,7 @@ import DataStore, { CacheHandler, recordIdentifierFor } from '@ember-data/store'
 import type { CacheCapabilitiesManager, ModelSchema } from '@ember-data/store/types';
 import type { Cache } from '@warp-drive/core-types/cache';
 import type { ResourceKey } from '@warp-drive/core-types/identifier';
-import type { SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
+import type { CollectionResourceDataDocument, SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 import type { ApiError } from '@warp-drive/core-types/spec/error';
 import type { SingleResourceDocument } from '@warp-drive/core-types/spec/json-api-raw';
 import { module, test } from '@warp-drive/diagnostic';
@@ -69,12 +69,25 @@ module('Integration - createRecord', function (hooks) {
         assert.step(`willCommit ${key.lid}`);
         return super.willCommit(key, null);
       }
-      override didCommit(
-        committedIdentifier: ResourceKey,
-        result: StructuredDataDocument<SingleResourceDocument>
-      ): SingleResourceDataDocument {
-        assert.step(`didCommit ${committedIdentifier.lid}`);
-        return super.didCommit(committedIdentifier, result);
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
+        assert.step(`didCommit ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`);
+        // @ts-expect-error TS doesn't handle overload forwarding
+        return super.didCommit(cacheKey, result);
       }
       override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
         assert.step(`commitWasRejected ${key.lid}`);
@@ -150,12 +163,25 @@ module('Integration - createRecord', function (hooks) {
         assert.step(`willCommit ${key.lid}`);
         return super.willCommit(key, null);
       }
-      override didCommit(
-        committedIdentifier: ResourceKey,
-        result: StructuredDataDocument<SingleResourceDocument>
-      ): SingleResourceDataDocument {
-        assert.step(`didCommit ${committedIdentifier.lid}`);
-        return super.didCommit(committedIdentifier, result);
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
+        assert.step(`didCommit ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`);
+        // @ts-expect-error TS doesn't handle overload forwarding
+        return super.didCommit(cacheKey, result);
       }
       override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
         assert.step(`commitWasRejected ${key.lid}`);

--- a/tests/builders/tests/integration/delete-record-test.ts
+++ b/tests/builders/tests/integration/delete-record-test.ts
@@ -12,7 +12,6 @@ import type { Cache } from '@warp-drive/core-types/cache';
 import type { ResourceKey } from '@warp-drive/core-types/identifier';
 import type { CollectionResourceDataDocument, SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 import type { ApiError } from '@warp-drive/core-types/spec/error';
-import type { SingleResourceDocument } from '@warp-drive/core-types/spec/json-api-raw';
 import { module, test } from '@warp-drive/diagnostic';
 import { setupTest } from '@warp-drive/diagnostic/ember';
 
@@ -89,9 +88,11 @@ module('Integration - deleteRecord', function (hooks) {
         // @ts-expect-error TS doesn't handle overload forwarding
         return super.didCommit(cacheKey, result);
       }
-      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${key.lid}`);
-        return super.commitWasRejected(key, errors);
+      commitWasRejected(cacheKey: ResourceKey | ResourceKey[], errors?: ApiError[]): void {
+        assert.step(
+          `commitWasRejected ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`
+        );
+        return super.commitWasRejected(cacheKey, errors);
       }
     }
 
@@ -199,9 +200,11 @@ module('Integration - deleteRecord', function (hooks) {
         // @ts-expect-error TS doesn't handle overload forwarding
         return super.didCommit(cacheKey, result);
       }
-      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${key.lid}`);
-        return super.commitWasRejected(key, errors);
+      commitWasRejected(cacheKey: ResourceKey | ResourceKey[], errors?: ApiError[]): void {
+        assert.step(
+          `commitWasRejected ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`
+        );
+        return super.commitWasRejected(cacheKey, errors);
       }
     }
 

--- a/tests/builders/tests/integration/delete-record-test.ts
+++ b/tests/builders/tests/integration/delete-record-test.ts
@@ -10,7 +10,7 @@ import DataStore, { CacheHandler, recordIdentifierFor } from '@ember-data/store'
 import type { CacheCapabilitiesManager, ModelSchema } from '@ember-data/store/types';
 import type { Cache } from '@warp-drive/core-types/cache';
 import type { ResourceKey } from '@warp-drive/core-types/identifier';
-import type { SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
+import type { CollectionResourceDataDocument, SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 import type { ApiError } from '@warp-drive/core-types/spec/error';
 import type { SingleResourceDocument } from '@warp-drive/core-types/spec/json-api-raw';
 import { module, test } from '@warp-drive/diagnostic';
@@ -69,12 +69,25 @@ module('Integration - deleteRecord', function (hooks) {
         assert.step(`willCommit ${key.lid}`);
         return super.willCommit(key, null);
       }
-      override didCommit(
-        committedIdentifier: ResourceKey,
-        result: StructuredDataDocument<SingleResourceDocument>
-      ): SingleResourceDataDocument {
-        assert.step(`didCommit ${committedIdentifier.lid}`);
-        return super.didCommit(committedIdentifier, result);
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
+        assert.step(`didCommit ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`);
+        // @ts-expect-error TS doesn't handle overload forwarding
+        return super.didCommit(cacheKey, result);
       }
       override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
         assert.step(`commitWasRejected ${key.lid}`);
@@ -166,12 +179,25 @@ module('Integration - deleteRecord', function (hooks) {
         assert.step(`willCommit ${key.lid}`);
         return super.willCommit(key, null);
       }
-      override didCommit(
-        committedIdentifier: ResourceKey,
-        result: StructuredDataDocument<SingleResourceDocument>
-      ): SingleResourceDataDocument {
-        assert.step(`didCommit ${committedIdentifier.lid}`);
-        return super.didCommit(committedIdentifier, result);
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
+        assert.step(`didCommit ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`);
+        // @ts-expect-error TS doesn't handle overload forwarding
+        return super.didCommit(cacheKey, result);
       }
       override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
         assert.step(`commitWasRejected ${key.lid}`);

--- a/tests/builders/tests/integration/update-record-test.ts
+++ b/tests/builders/tests/integration/update-record-test.ts
@@ -10,9 +10,8 @@ import DataStore, { CacheHandler, recordIdentifierFor } from '@ember-data/store'
 import type { CacheCapabilitiesManager, ModelSchema } from '@ember-data/store/types';
 import type { Cache } from '@warp-drive/core-types/cache';
 import type { ResourceKey } from '@warp-drive/core-types/identifier';
-import type { SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
+import type { CollectionResourceDataDocument, SingleResourceDataDocument } from '@warp-drive/core-types/spec/document';
 import type { ApiError } from '@warp-drive/core-types/spec/error';
-import type { SingleResourceDocument } from '@warp-drive/core-types/spec/json-api-raw';
 import { module, test } from '@warp-drive/diagnostic';
 import { setupTest } from '@warp-drive/diagnostic/ember';
 
@@ -69,12 +68,25 @@ module('Integration - updateRecord', function (hooks) {
         assert.step(`willCommit ${key.lid}`);
         return super.willCommit(key, null);
       }
-      override didCommit(
-        committedIdentifier: ResourceKey,
-        result: StructuredDataDocument<SingleResourceDocument>
-      ): SingleResourceDataDocument {
-        assert.step(`didCommit ${committedIdentifier.lid}`);
-        return super.didCommit(committedIdentifier, result);
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
+        assert.step(`didCommit ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`);
+        // @ts-expect-error TS doesn't handle overload forwarding
+        return super.didCommit(cacheKey, result);
       }
       override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
         assert.step(`commitWasRejected ${key.lid}`);
@@ -151,12 +163,25 @@ module('Integration - updateRecord', function (hooks) {
         assert.step(`willCommit ${key.lid}`);
         return super.willCommit(key, null);
       }
-      override didCommit(
-        committedIdentifier: ResourceKey,
-        result: StructuredDataDocument<SingleResourceDocument>
-      ): SingleResourceDataDocument {
-        assert.step(`didCommit ${committedIdentifier.lid}`);
-        return super.didCommit(committedIdentifier, result);
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
+        assert.step(`didCommit ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`);
+        // @ts-expect-error TS doesn't handle overload forwarding
+        return super.didCommit(cacheKey, result);
       }
       override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
         assert.step(`commitWasRejected ${key.lid}`);

--- a/tests/builders/tests/integration/update-record-test.ts
+++ b/tests/builders/tests/integration/update-record-test.ts
@@ -183,9 +183,11 @@ module('Integration - updateRecord', function (hooks) {
         // @ts-expect-error TS doesn't handle overload forwarding
         return super.didCommit(cacheKey, result);
       }
-      override commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
-        assert.step(`commitWasRejected ${key.lid}`);
-        return super.commitWasRejected(key, errors);
+      commitWasRejected(cacheKey: ResourceKey | ResourceKey[], errors?: ApiError[]): void {
+        assert.step(
+          `commitWasRejected ${Array.isArray(cacheKey) ? cacheKey.map((k) => k.lid).join(',') : cacheKey.lid}`
+        );
+        return super.commitWasRejected(cacheKey, errors);
       }
     }
 

--- a/tests/main/tests/integration/cache/spec-cache-errors-test.ts
+++ b/tests/main/tests/integration/cache/spec-cache-errors-test.ts
@@ -125,10 +125,22 @@ class TestCache implements Cache {
   }
   willCommit(identifier: ResourceKey): void {}
   didCommit(
-    identifier: ResourceKey,
-    response: StructuredDataDocument<SingleResourceDocument>
-  ): SingleResourceDataDocument {
-    return { data: identifier as PersistedResourceKey };
+    cacheKey: ResourceKey,
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey | ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument | SingleResourceDataDocument {
+    return { data: cacheKey as PersistedResourceKey };
   }
   commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
     this._errors = errors;

--- a/tests/main/tests/integration/cache/spec-cache-state-test.ts
+++ b/tests/main/tests/integration/cache/spec-cache-state-test.ts
@@ -148,8 +148,24 @@ class TestCache implements Cache {
     return {};
   }
   willCommit(identifier: ResourceKey): void {}
-  didCommit(identifier: ResourceKey, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
-    return { data: identifier as PersistedResourceKey };
+
+  didCommit(
+    cacheKey: ResourceKey,
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey | ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument | SingleResourceDataDocument {
+    return { data: cacheKey as PersistedResourceKey };
   }
   commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
     this._errors = errors;

--- a/tests/main/tests/integration/cache/spec-cache-test.ts
+++ b/tests/main/tests/integration/cache/spec-cache-test.ts
@@ -153,8 +153,24 @@ class TestCache implements Cache {
     return {};
   }
   willCommit(identifier: ResourceKey): void {}
-  didCommit(identifier: ResourceKey, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
-    return { data: identifier as PersistedResourceKey };
+
+  didCommit(
+    cacheKey: ResourceKey,
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey | ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+  ): SingleResourceDataDocument | CollectionResourceDataDocument {
+    return { data: cacheKey as PersistedResourceKey };
   }
   commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
     this._errors = errors;
@@ -323,10 +339,25 @@ module('integration/record-data - Custom Cache Implementations', function (hooks
         calledRollbackAttributes++;
       }
 
-      override didCommit(identifier: PersistedResourceKey, result: StructuredDataDocument<unknown>) {
+      didCommit(
+        cacheKey: ResourceKey,
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<SingleResourceDataDocument> | null
+      ): SingleResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument> | null
+      ): CollectionResourceDataDocument;
+      didCommit(
+        cacheKey: ResourceKey | ResourceKey[],
+        result: StructuredDataDocument<CollectionResourceDataDocument | SingleResourceDataDocument> | null
+      ): CollectionResourceDataDocument | SingleResourceDataDocument {
         calledDidCommit++;
         isNew = false;
-        return { data: identifier };
+        return { data: cacheKey as PersistedResourceKey };
       }
 
       override isNew() {

--- a/warp-drive-packages/core/src/store/-private/cache-handler/handler.ts
+++ b/warp-drive-packages/core/src/store/-private/cache-handler/handler.ts
@@ -255,10 +255,16 @@ function updateCacheForSuccess<T>(
   let response: ResourceDataDocument | null = null;
   if (isMutation(request)) {
     if (Array.isArray(request.records)) {
-      store.cache.didCommit(request.records, document as StructuredDataDocument<CollectionResourceDataDocument>);
+      response = store.cache.didCommit(
+        request.records,
+        document as StructuredDataDocument<CollectionResourceDataDocument>
+      );
     } else if (request.data?.record) {
       // legacy fallback, the data option should no longer be used for this
-      store.cache.didCommit(request.data.record, document as StructuredDataDocument<SingleResourceDataDocument>);
+      response = store.cache.didCommit(
+        request.data.record,
+        document as StructuredDataDocument<SingleResourceDataDocument>
+      );
 
       // a mutation combined with a 204 has no cache impact when no known records were involved
       // a createRecord with a 201 with an empty response and no known records should similarly

--- a/warp-drive-packages/core/src/store/-private/cache-handler/handler.ts
+++ b/warp-drive-packages/core/src/store/-private/cache-handler/handler.ts
@@ -248,9 +248,11 @@ function updateCacheForSuccess<T>(
 ) {
   let response: ResourceDataDocument | null = null;
   if (isMutation(request)) {
-    const record = request.data?.record || request.records?.[0];
-    if (record) {
-      response = store.cache.didCommit(record, document) as ResourceDataDocument;
+    if (Array.isArray(request.records)) {
+      store.cache.didCommit(request.records, document);
+    } else if (request.data?.record) {
+      // legacy fallback, the data option should no longer be used for this
+      store.cache.didCommit(request.data.record, document);
 
       // a mutation combined with a 204 has no cache impact when no known records were involved
       // a createRecord with a 201 with an empty response and no known records should similarly
@@ -310,9 +312,14 @@ function updateCacheForError<T>(
         ? (error.content.errors as ApiError[])
         : undefined;
 
-    const record = context.request.data?.record || context.request.records?.[0];
-
-    store.cache.commitWasRejected(record, errors);
+    if (Array.isArray(context.request.records)) {
+      store.cache.commitWasRejected(context.request.records, errors);
+    } else if (context.request.data?.record) {
+      // legacy fallback, the data option should no longer be used for this
+      store.cache.commitWasRejected(context.request.data.record, errors);
+    } else {
+      store.cache.put(error) as ResourceErrorDocument;
+    }
   } else {
     response = store.cache.put(error) as ResourceErrorDocument;
     return maybeUpdateUiObjects(store, context.request, options, response);
@@ -367,14 +374,14 @@ function fetchContentAndHydrate<T>(
   let isMut = false;
   if (isMutation(context.request)) {
     isMut = true;
-    // TODO should we handle multiple records in request.records by iteratively calling willCommit for each
-    const record = context.request.data?.record || context.request.records?.[0];
-    assert(
-      `Expected to receive a list of records included in the ${context.request.op} request`,
-      record || !shouldHydrate
-    );
-    if (record) {
-      store.cache.willCommit(record, context);
+
+    if (Array.isArray(context.request.records)) {
+      context.request.records.forEach((record) => {
+        store.cache.willCommit(record, context);
+      });
+    } else if (context.request.data?.record) {
+      // legacy fallback, the data option should no longer be used for this
+      store.cache.willCommit(context.request.data.record, context);
     }
   }
 

--- a/warp-drive-packages/core/src/store/-private/cache-handler/handler.ts
+++ b/warp-drive-packages/core/src/store/-private/cache-handler/handler.ts
@@ -11,7 +11,13 @@ import type {
   StructuredErrorDocument,
 } from '../../../types/request.ts';
 import { EnableHydration, SkipCache } from '../../../types/request.ts';
-import type { ResourceDataDocument, ResourceDocument, ResourceErrorDocument } from '../../../types/spec/document.ts';
+import type {
+  CollectionResourceDataDocument,
+  ResourceDataDocument,
+  ResourceDocument,
+  ResourceErrorDocument,
+  SingleResourceDataDocument,
+} from '../../../types/spec/document.ts';
 import type { ApiError } from '../../../types/spec/error.ts';
 import type { ResourceIdentifierObject } from '../../../types/spec/json-api-raw.ts';
 import type { RequestSignature } from '../../../types/symbols.ts';
@@ -249,10 +255,10 @@ function updateCacheForSuccess<T>(
   let response: ResourceDataDocument | null = null;
   if (isMutation(request)) {
     if (Array.isArray(request.records)) {
-      store.cache.didCommit(request.records, document);
+      store.cache.didCommit(request.records, document as StructuredDataDocument<CollectionResourceDataDocument>);
     } else if (request.data?.record) {
       // legacy fallback, the data option should no longer be used for this
-      store.cache.didCommit(request.data.record, document);
+      store.cache.didCommit(request.data.record, document as StructuredDataDocument<SingleResourceDataDocument>);
 
       // a mutation combined with a 204 has no cache impact when no known records were involved
       // a createRecord with a 201 with an empty response and no known records should similarly

--- a/warp-drive-packages/core/src/store/-private/managers/cache-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-manager.ts
@@ -6,7 +6,11 @@ import type { LocalRelationshipOperation } from '../../../types/graph.ts';
 import type { RequestKey, ResourceKey } from '../../../types/identifier.ts';
 import type { Value } from '../../../types/json/raw.ts';
 import type { StructuredDataDocument, StructuredDocument } from '../../../types/request.ts';
-import type { ResourceDocument, SingleResourceDataDocument } from '../../../types/spec/document.ts';
+import type {
+  CollectionResourceDataDocument,
+  ResourceDocument,
+  SingleResourceDataDocument,
+} from '../../../types/spec/document.ts';
 import type { ApiError } from '../../../types/spec/error.ts';
 import type { StoreRequestContext } from '../cache-handler/handler.ts';
 
@@ -291,7 +295,23 @@ export class CacheManager implements Cache {
    *
    * @public
    */
-  didCommit(key: ResourceKey | ResourceKey[], result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+  didCommit(
+    key: ResourceKey,
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    key: ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    key: ResourceKey[],
+    result: StructuredDataDocument<CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument;
+  didCommit(
+    key: ResourceKey | ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument | SingleResourceDataDocument {
+    // @ts-expect-error TS doesn't enable proxying overload calls
     return this.___cache.didCommit(key, result);
   }
 

--- a/warp-drive-packages/core/src/store/-private/managers/cache-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-manager.ts
@@ -281,7 +281,7 @@ export class CacheManager implements Cache {
    * @public
    * @param key
    */
-  willCommit(key: ResourceKey, context: StoreRequestContext): void {
+  willCommit(key: ResourceKey | ResourceKey[], context: StoreRequestContext): void {
     this.___cache.willCommit(key, context);
   }
 
@@ -291,7 +291,7 @@ export class CacheManager implements Cache {
    *
    * @public
    */
-  didCommit(key: ResourceKey, result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
+  didCommit(key: ResourceKey | ResourceKey[], result: StructuredDataDocument<unknown>): SingleResourceDataDocument {
     return this.___cache.didCommit(key, result);
   }
 
@@ -301,7 +301,7 @@ export class CacheManager implements Cache {
    *
    * @public
    */
-  commitWasRejected(key: ResourceKey, errors?: ApiError[]): void {
+  commitWasRejected(key: ResourceKey | ResourceKey[], errors?: ApiError[]): void {
     this.___cache.commitWasRejected(key, errors);
   }
 

--- a/warp-drive-packages/core/src/types/cache.ts
+++ b/warp-drive-packages/core/src/types/cache.ts
@@ -282,7 +282,7 @@ export interface Cache {
    *
    * @public
    */
-  willCommit(cacheKey: ResourceKey, context: RequestContext | null): void;
+  willCommit(cacheKey: ResourceKey | ResourceKey[], context: RequestContext | null): void;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource
@@ -292,7 +292,10 @@ export interface Cache {
    * @param the primary ResourceKey that was operated on
    * @param data - a document in the cache format containing any updated data
    */
-  didCommit(cacheKey: ResourceKey, result: StructuredDataDocument<unknown> | null): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey | ResourceKey[],
+    result: StructuredDataDocument<unknown> | null
+  ): SingleResourceDataDocument;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource
@@ -300,7 +303,7 @@ export interface Cache {
    *
    * @public
    */
-  commitWasRejected(cacheKey: ResourceKey, errors?: ApiError[]): void;
+  commitWasRejected(cacheKey: ResourceKey | ResourceKey[], errors?: ApiError[]): void;
 
   /**
    * [LIFECYCLE] Signals to the cache that all data for a resource

--- a/warp-drive-packages/core/src/types/cache.ts
+++ b/warp-drive-packages/core/src/types/cache.ts
@@ -7,7 +7,7 @@ import type { RequestKey, ResourceKey } from './identifier.ts';
 import type { Value } from './json/raw.ts';
 import type { TypeFromInstanceOrString } from './record.ts';
 import type { RequestContext, StructuredDataDocument, StructuredDocument } from './request.ts';
-import type { ResourceDocument, SingleResourceDataDocument } from './spec/document.ts';
+import type { CollectionResourceDataDocument, ResourceDocument, SingleResourceDataDocument } from './spec/document.ts';
 import type { ApiError } from './spec/error.ts';
 
 /**
@@ -293,9 +293,17 @@ export interface Cache {
    * @param data - a document in the cache format containing any updated data
    */
   didCommit(
-    cacheKey: ResourceKey | ResourceKey[],
-    result: StructuredDataDocument<unknown> | null
+    cacheKey: ResourceKey,
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
   ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    cacheKey: ResourceKey[],
+    result: StructuredDataDocument<CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument;
 
   /**
    * [LIFECYCLE] Signals to the cache that a resource

--- a/warp-drive-packages/experiments/src/data-worker/cache-handler.ts
+++ b/warp-drive-packages/experiments/src/data-worker/cache-handler.ts
@@ -136,6 +136,7 @@ function updateCacheForSuccess<T>(
   if (isMutation(request)) {
     const record = request.data?.record || request.records?.[0];
     if (record) {
+      // @ts-expect-error while this is valid, we should update the CacheHandler for transactional saves
       response = store.cache.didCommit(record, document) as ResourceDataDocument;
 
       // a mutation combined with a 204 has no cache impact when no known records were involved

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -834,57 +834,13 @@ export class JSONAPICache implements Cache {
    * @category Resource Lifecycle
    * @public
    */
-  willCommit(identifier: ResourceKey, _context: RequestContext | null): void {
-    const cached = this.__peek(identifier, false);
-
-    /*
-      if we have multiple saves in flight at once then
-      we have information loss no matter what. This
-      attempts to lose the least information.
-
-      If we were to clear inflightAttrs, previous requests
-      would not be able to use it during their didCommit.
-
-      If we upsert inflightattrs, previous requests incorrectly
-      see more recent inflight changes as part of their own and
-      will incorrectly mark the new state as the correct remote state.
-
-      We choose this latter behavior to avoid accidentally removing
-      earlier changes.
-
-      If apps do not want this behavior they can either
-      - chain save requests serially vs allowing concurrent saves
-      - move to using a request handler that caches the inflight state
-        on a per-request basis
-      - change their save requests to only send a "PATCH" instead of a "PUT"
-        so that only latest changes are involved in each request, and then also
-        ensure that the API or their handler reflects only those changes back
-        for upsert into the cache.
-    */
-    if (cached.inflightAttrs) {
-      if (cached.localAttrs) {
-        Object.assign(cached.inflightAttrs, cached.localAttrs);
+  willCommit(identifier: ResourceKey | ResourceKey[], _context: RequestContext | null): void {
+    if (Array.isArray(identifier)) {
+      for (const key of identifier) {
+        willCommit(this, key);
       }
     } else {
-      cached.inflightAttrs = cached.localAttrs;
-    }
-    cached.localAttrs = null;
-
-    if (DEBUG) {
-      if (!DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
-        // save off info about saved relationships
-        const fields = getCacheFields(this, identifier);
-        fields.forEach((schema, name) => {
-          if (schema.kind === 'belongsTo') {
-            if (this.__graph._isDirty(identifier, name)) {
-              const relationshipData = this.__graph.getData(identifier, name);
-              const inFlight = (cached.inflightRelationships =
-                cached.inflightRelationships || (Object.create(null) as Record<string, unknown>));
-              inFlight[name] = relationshipData;
-            }
-          }
-        });
-      }
+      willCommit(this, identifier);
     }
   }
 
@@ -898,9 +854,21 @@ export class JSONAPICache implements Cache {
   didCommit(
     committedIdentifier: ResourceKey,
     result: StructuredDataDocument<SingleResourceDocument> | null
-  ): SingleResourceDataDocument {
+  ): SingleResourceDataDocument;
+  didCommit(
+    committedIdentifier: ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDocument> | null
+  ): SingleResourceDataDocument;
+  didCommit(
+    committedIdentifier: ResourceKey[],
+    result: StructuredDataDocument<CollectionResourceDocument> | null
+  ): CollectionResourceDocument;
+  didCommit(
+    committedIdentifier: ResourceKey | ResourceKey[],
+    result: StructuredDataDocument<SingleResourceDocument | CollectionResourceDocument> | null
+  ): CollectionResourceDocument | SingleResourceDataDocument {
     const payload = result ? result.content : null;
-    const operation = result ? result.request.op : null;
+    const operation = result?.request?.op ?? null;
     const data = payload && payload.data;
 
     if (LOG_CACHE) {
@@ -914,112 +882,34 @@ export class JSONAPICache implements Cache {
       }
     }
 
-    if (!data) {
+    const responseIsCollection = Array.isArray(data);
+
+    if (Array.isArray(committedIdentifier)) {
+      // if we get back an array of primary data, we treat each
+      // entry as a separate commit for each identifier
       assert(
-        `Your ${committedIdentifier.type} record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
-        committedIdentifier.id
+        `Expected the array of primary data to match the array of committed identifiers`,
+        !responseIsCollection || data.length === committedIdentifier.length
       );
-    }
-
-    const { cacheKeyManager } = this._capabilities;
-    const existingId = committedIdentifier.id;
-    const identifier: ResourceKey =
-      operation !== 'deleteRecord' && data
-        ? cacheKeyManager.updateRecordIdentifier(committedIdentifier, data)
-        : committedIdentifier;
-
-    const cached = this.__peek(identifier, false);
-    if (cached.isDeleted) {
-      this.__graph.push({
-        op: 'deleteRecord',
-        record: identifier,
-        isNew: false,
-      });
-      cached.isDeletionCommitted = true;
-      this._capabilities.notifyChange(identifier, 'removed', null);
-      // TODO @runspired should we early exit here?
-    }
-
-    if (DEBUG) {
-      if (cached.isNew && !identifier.id && (typeof data?.id !== 'string' || data.id.length > 0)) {
-        const error = new Error(`Expected an id ${String(identifier)} in response ${JSON.stringify(data)}`);
-        //@ts-expect-error
-        error.isAdapterError = true;
-        //@ts-expect-error
-        error.code = 'InvalidError';
-        throw error;
-      }
-    }
-
-    const fields = getCacheFields(this, identifier);
-    cached.isNew = false;
-    let newCanonicalAttributes: ExistingResourceObject['attributes'];
-    if (data) {
-      if (data.id && !cached.id) {
-        cached.id = data.id;
-      }
-      if (identifier === committedIdentifier && identifier.id !== existingId) {
-        this._capabilities.notifyChange(identifier, 'identity', null);
-      }
-
-      assert(
-        `Expected the ID received for the primary '${identifier.type}' resource being saved to match the current id '${cached.id}' but received '${identifier.id}'.`,
-        identifier.id === cached.id
-      );
-
-      if (data.relationships) {
-        if (DEBUG) {
-          if (!DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
-            // assert against bad API behavior where a belongsTo relationship
-            // is saved but the return payload indicates a different final state.
-            fields.forEach((field, name) => {
-              if (field.kind === 'belongsTo') {
-                const relationshipData = data.relationships![name]?.data;
-                if (relationshipData !== undefined) {
-                  const inFlightData = cached.inflightRelationships?.[name] as SingleResourceRelationship;
-                  if (!inFlightData || !('data' in inFlightData)) {
-                    return;
-                  }
-                  const actualData = relationshipData
-                    ? this._capabilities.cacheKeyManager.getOrCreateRecordIdentifier(relationshipData)
-                    : null;
-                  assert(
-                    `Expected the resource relationship '<${identifier.type}>.${name}' on ${
-                      identifier.lid
-                    } to be saved as ${inFlightData.data ? inFlightData.data.lid : '<null>'} but it was saved as ${
-                      actualData ? actualData.lid : '<null>'
-                    }`,
-                    inFlightData.data === actualData
-                  );
-                }
-              }
-            });
-            cached.inflightRelationships = null;
-          }
+      if (responseIsCollection) {
+        for (let i = 0; i < committedIdentifier.length; i++) {
+          const identifier = committedIdentifier[i];
+          didCommit(this, identifier, data[i] ?? null, operation);
         }
-        setupRelationships(this.__graph, fields, identifier, data);
+        // but if we get back no data or a single entry, we apply
+        // the change back to the original identifier
+      } else {
+        for (let i = 0; i < committedIdentifier.length; i++) {
+          const identifier = committedIdentifier[i];
+          didCommit(this, identifier, i === 0 ? data : null, operation);
+        }
       }
-      newCanonicalAttributes = data.attributes;
+    } else {
+      didCommit(this, committedIdentifier, data as ExistingResourceObject | null, operation);
     }
-    const changedKeys = newCanonicalAttributes && calculateChangedKeys(cached, newCanonicalAttributes, fields);
-
-    cached.remoteAttrs = Object.assign(
-      cached.remoteAttrs || (Object.create(null) as Record<string, unknown>),
-      cached.inflightAttrs,
-      newCanonicalAttributes
-    );
-    cached.inflightAttrs = null;
-    patchLocalAttributes(cached, changedKeys);
-
-    if (cached.errors) {
-      cached.errors = null;
-      this._capabilities.notifyChange(identifier, 'errors', null);
-    }
-
-    if (changedKeys?.size) notifyAttributes(this._capabilities, identifier, changedKeys);
-    this._capabilities.notifyChange(identifier, 'state', null);
 
     const included = payload && payload.included;
+    const { cacheKeyManager } = this._capabilities;
     if (included) {
       for (let i = 0, length = included.length; i < length; i++) {
         putOne(this, cacheKeyManager, included[i]);
@@ -1027,7 +917,7 @@ export class JSONAPICache implements Cache {
     }
 
     return {
-      data: identifier as PersistedResourceKey,
+      data: committedIdentifier as PersistedResourceKey,
     };
   }
 
@@ -1038,25 +928,15 @@ export class JSONAPICache implements Cache {
    * @category Resource Lifecycle
    * @public
    */
-  commitWasRejected(identifier: ResourceKey, errors?: ApiError[]): void {
-    const cached = this.__peek(identifier, false);
-    if (cached.inflightAttrs) {
-      const keys = Object.keys(cached.inflightAttrs);
-      if (keys.length > 0) {
-        const attrs = (cached.localAttrs =
-          cached.localAttrs || (Object.create(null) as Record<string, Value | undefined>));
-        for (let i = 0; i < keys.length; i++) {
-          if (attrs[keys[i]] === undefined) {
-            attrs[keys[i]] = cached.inflightAttrs[keys[i]];
-          }
-        }
+  commitWasRejected(identifier: ResourceKey | ResourceKey[], errors?: ApiError[]): void {
+    if (Array.isArray(identifier)) {
+      for (let i = 0; i < identifier.length; i++) {
+        commitDidError(this, identifier[i], errors && i === 0 ? errors : null);
       }
-      cached.inflightAttrs = null;
+      return;
     }
-    if (errors) {
-      cached.errors = errors;
-    }
-    this._capabilities.notifyChange(identifier, 'errors', null);
+
+    return commitDidError(this, identifier, errors || null);
   }
 
   /**
@@ -2476,4 +2356,191 @@ function getCacheFields(
     string,
     Exclude<CacheableFieldSchema, IdentityField>
   >;
+}
+
+function commitDidError(cache: JSONAPICache, identifier: ResourceKey, errors: ApiError[] | null): void {
+  const cached = cache.__peek(identifier, false);
+  if (cached.inflightAttrs) {
+    const keys = Object.keys(cached.inflightAttrs);
+    if (keys.length > 0) {
+      const attrs = (cached.localAttrs =
+        cached.localAttrs || (Object.create(null) as Record<string, Value | undefined>));
+      for (let i = 0; i < keys.length; i++) {
+        if (attrs[keys[i]] === undefined) {
+          attrs[keys[i]] = cached.inflightAttrs[keys[i]];
+        }
+      }
+    }
+    cached.inflightAttrs = null;
+  }
+  if (errors) {
+    cached.errors = errors;
+  }
+  cache._capabilities.notifyChange(identifier, 'errors', null);
+}
+
+function didCommit(
+  cache: JSONAPICache,
+  committedIdentifier: ResourceKey,
+  data: ExistingResourceObject | null,
+  op: string | null
+): void {
+  if (!data) {
+    assert(
+      `Your ${committedIdentifier.type} record was saved to the server, but the response does not have an id and no id has been set client side. Records must have ids. Please update the server response to provide an id in the response or generate the id on the client side either before saving the record or while normalizing the response.`,
+      committedIdentifier.id
+    );
+  }
+
+  const { cacheKeyManager } = cache._capabilities;
+  const existingId = committedIdentifier.id;
+  const identifier: ResourceKey =
+    op !== 'deleteRecord' && data
+      ? cacheKeyManager.updateRecordIdentifier(committedIdentifier, data)
+      : committedIdentifier;
+
+  const cached = cache.__peek(identifier, false);
+  if (cached.isDeleted) {
+    cache.__graph.push({
+      op: 'deleteRecord',
+      record: identifier,
+      isNew: false,
+    });
+    cached.isDeletionCommitted = true;
+    cache._capabilities.notifyChange(identifier, 'removed', null);
+    // TODO @runspired should we early exit here?
+  }
+
+  if (DEBUG) {
+    if (cached.isNew && !identifier.id && (typeof data?.id !== 'string' || data.id.length > 0)) {
+      const error = new Error(`Expected an id ${String(identifier)} in response ${JSON.stringify(data)}`);
+      //@ts-expect-error
+      error.isAdapterError = true;
+      //@ts-expect-error
+      error.code = 'InvalidError';
+      throw error;
+    }
+  }
+
+  const fields = getCacheFields(cache, identifier);
+  cached.isNew = false;
+  let newCanonicalAttributes: ExistingResourceObject['attributes'];
+  if (data) {
+    if (data.id && !cached.id) {
+      cached.id = data.id;
+    }
+    if (identifier === committedIdentifier && identifier.id !== existingId) {
+      cache._capabilities.notifyChange(identifier, 'identity', null);
+    }
+
+    assert(
+      `Expected the ID received for the primary '${identifier.type}' resource being saved to match the current id '${cached.id}' but received '${identifier.id}'.`,
+      identifier.id === cached.id
+    );
+
+    if (data.relationships) {
+      if (DEBUG) {
+        if (!DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
+          // assert against bad API behavior where a belongsTo relationship
+          // is saved but the return payload indicates a different final state.
+          fields.forEach((field, name) => {
+            if (field.kind === 'belongsTo') {
+              const relationshipData = data.relationships![name]?.data;
+              if (relationshipData !== undefined) {
+                const inFlightData = cached.inflightRelationships?.[name] as SingleResourceRelationship;
+                if (!inFlightData || !('data' in inFlightData)) {
+                  return;
+                }
+                const actualData = relationshipData
+                  ? cache._capabilities.cacheKeyManager.getOrCreateRecordIdentifier(relationshipData)
+                  : null;
+                assert(
+                  `Expected the resource relationship '<${identifier.type}>.${name}' on ${
+                    identifier.lid
+                  } to be saved as ${inFlightData.data ? inFlightData.data.lid : '<null>'} but it was saved as ${
+                    actualData ? actualData.lid : '<null>'
+                  }`,
+                  inFlightData.data === actualData
+                );
+              }
+            }
+          });
+          cached.inflightRelationships = null;
+        }
+      }
+      setupRelationships(cache.__graph, fields, identifier, data);
+    }
+    newCanonicalAttributes = data.attributes;
+  }
+  const changedKeys = newCanonicalAttributes && calculateChangedKeys(cached, newCanonicalAttributes, fields);
+
+  cached.remoteAttrs = Object.assign(
+    cached.remoteAttrs || (Object.create(null) as Record<string, unknown>),
+    cached.inflightAttrs,
+    newCanonicalAttributes
+  );
+  cached.inflightAttrs = null;
+  patchLocalAttributes(cached, changedKeys);
+
+  if (cached.errors) {
+    cached.errors = null;
+    cache._capabilities.notifyChange(identifier, 'errors', null);
+  }
+
+  if (changedKeys?.size) notifyAttributes(cache._capabilities, identifier, changedKeys);
+  cache._capabilities.notifyChange(identifier, 'state', null);
+}
+
+function willCommit(cache: JSONAPICache, identifier: ResourceKey): void {
+  const cached = cache.__peek(identifier, false);
+
+  /*
+      if we have multiple saves in flight at once then
+      we have information loss no matter what. This
+      attempts to lose the least information.
+
+      If we were to clear inflightAttrs, previous requests
+      would not be able to use it during their didCommit.
+
+      If we upsert inflightattrs, previous requests incorrectly
+      see more recent inflight changes as part of their own and
+      will incorrectly mark the new state as the correct remote state.
+
+      We choose this latter behavior to avoid accidentally removing
+      earlier changes.
+
+      If apps do not want this behavior they can either
+      - chain save requests serially vs allowing concurrent saves
+      - move to using a request handler that caches the inflight state
+        on a per-request basis
+      - change their save requests to only send a "PATCH" instead of a "PUT"
+        so that only latest changes are involved in each request, and then also
+        ensure that the API or their handler reflects only those changes back
+        for upsert into the cache.
+    */
+  if (cached.inflightAttrs) {
+    if (cached.localAttrs) {
+      Object.assign(cached.inflightAttrs, cached.localAttrs);
+    }
+  } else {
+    cached.inflightAttrs = cached.localAttrs;
+  }
+  cached.localAttrs = null;
+
+  if (DEBUG) {
+    if (!DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE) {
+      // save off info about saved relationships
+      const fields = getCacheFields(cache, identifier);
+      fields.forEach((schema, name) => {
+        if (schema.kind === 'belongsTo') {
+          if (cache.__graph._isDirty(identifier, name)) {
+            const relationshipData = cache.__graph.getData(identifier, name);
+            const inFlight = (cached.inflightRelationships =
+              cached.inflightRelationships || (Object.create(null) as Record<string, unknown>));
+            inFlight[name] = relationshipData;
+          }
+        }
+      });
+    }
+  }
 }

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -853,20 +853,20 @@ export class JSONAPICache implements Cache {
    */
   didCommit(
     committedIdentifier: ResourceKey,
-    result: StructuredDataDocument<SingleResourceDocument> | null
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
   ): SingleResourceDataDocument;
   didCommit(
     committedIdentifier: ResourceKey[],
-    result: StructuredDataDocument<SingleResourceDocument> | null
+    result: StructuredDataDocument<SingleResourceDataDocument> | null
   ): SingleResourceDataDocument;
   didCommit(
     committedIdentifier: ResourceKey[],
-    result: StructuredDataDocument<CollectionResourceDocument> | null
-  ): CollectionResourceDocument;
+    result: StructuredDataDocument<CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument;
   didCommit(
     committedIdentifier: ResourceKey | ResourceKey[],
-    result: StructuredDataDocument<SingleResourceDocument | CollectionResourceDocument> | null
-  ): CollectionResourceDocument | SingleResourceDataDocument {
+    result: StructuredDataDocument<SingleResourceDataDocument | CollectionResourceDataDocument> | null
+  ): CollectionResourceDataDocument | SingleResourceDataDocument {
     const payload = result ? result.content : null;
     const operation = result?.request?.op ?? null;
     const data = payload && payload.data;

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -883,13 +883,14 @@ export class JSONAPICache implements Cache {
     }
 
     const responseIsCollection = Array.isArray(data);
+    const hasMultipleIdentifiers = Array.isArray(committedIdentifier) && committedIdentifier.length > 1;
 
     if (Array.isArray(committedIdentifier)) {
       // if we get back an array of primary data, we treat each
       // entry as a separate commit for each identifier
       assert(
         `Expected the array of primary data to match the array of committed identifiers`,
-        !responseIsCollection || data.length === committedIdentifier.length
+        !hasMultipleIdentifiers || !responseIsCollection || data.length === committedIdentifier.length
       );
       if (responseIsCollection) {
         for (let i = 0; i < committedIdentifier.length; i++) {
@@ -916,9 +917,15 @@ export class JSONAPICache implements Cache {
       }
     }
 
-    return {
-      data: committedIdentifier as PersistedResourceKey,
-    };
+    return hasMultipleIdentifiers && responseIsCollection
+      ? {
+          data: committedIdentifier as PersistedResourceKey[],
+        }
+      : {
+          data: (Array.isArray(committedIdentifier)
+            ? committedIdentifier[0]
+            : committedIdentifier) as PersistedResourceKey,
+        };
   }
 
   /**


### PR DESCRIPTION
- relaxes the contraint on mutation ops that records must be provided
- performs the associated cache operation for every record listed