### PR TITLE
Missing Context Param in Code Example for setTestId

### DIFF
--- a/packages/holodeck/README.md
+++ b/packages/holodeck/README.md
@@ -163,7 +163,7 @@ const MockHost = `https://${window.location.hostname}:${Number(window.location.p
 setConfig({ host: MockHost });
 
 QUnit.hooks.beforeEach(function (assert) {
-  setTestId(assert.test.testId);
+  setTestId(this, assert.test.testId);
 });
 QUnit.hooks.afterEach(function (assert) {
   setTestId(null);


### PR DESCRIPTION
This context parameter is necessary in QUnit as well, not just other test launchers.

<!-- Thank you for opening up this PR! -->

If this PR updates API docs, preview them by:

- install [bun](https://bun.sh/docs/installation) (if needed)
- install [volta](https://docs.volta.sh/guide/getting-started) and configure it for [pnpm](https://docs.volta.sh/advanced/pnpm) (if needed)
- run `pnpm install` in the root (if needed)
- run `pnpm preview` in the root

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.
