### PR TITLE
chore: update some broken references in docs

### DIFF
--- a/packages/eslint-plugin-warp-drive/docs/no-invalid-relationships.md
+++ b/packages/eslint-plugin-warp-drive/docs/no-invalid-relationships.md
@@ -24,7 +24,7 @@ This rule disallows:
 
 - `async` may be either `true` or `false`, the historical default when unspecified was `true`
 - `inverse` may be either the name of the field on the model on the other side of the relationship or `null`
-- See the [relationships guide](https://github.com/warp-drive-data/warp-drive/blob/main/guides/relationships/index.md) for more information on valid configurations
+- See the [relationships guide](https://github.com/warp-drive-data/warp-drive/blob/main/guides/the-manual/misc/relational-data/index.md) for more information on valid configurations
 
 ## Examples
 
@@ -53,4 +53,4 @@ export default class FolderModel extends Model {
 ## References
 
 - [Deprecation Guide](https://deprecations.emberjs.com/id/ember-data-deprecate-non-strict-relationships)
-- [Relationship Guide](https://github.com/warp-drive-data/warp-drive/blob/main/guides/relationships/index.md)
+- [Relationship Guide](https://github.com/warp-drive-data/warp-drive/blob/main/guides/the-manual/misc/relational-data/index.md)

--- a/packages/eslint-plugin-warp-drive/src/rules/no-create-record-rerender.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-create-record-rerender.js
@@ -25,7 +25,7 @@ module.exports = {
       description: 'Disallow use of `store.createRecord` in getters, constructors, and class properties',
       category: 'Possible Errors',
       recommended: true,
-      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/rules/no-create-record-rerender.md',
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/no-create-record-rerender.md',
     },
     messages: {
       [messageId]:

--- a/packages/eslint-plugin-warp-drive/src/rules/no-external-request-patterns.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-external-request-patterns.js
@@ -37,7 +37,7 @@ module.exports = {
       description: 'Restricts usage of discouraged non-warp-drive request patterns',
       category: 'Best Practices',
       recommended: true,
-      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/rules/no-external-request-patterns.md',
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/no-external-request-patterns.md',
     },
   },
 

--- a/packages/eslint-plugin-warp-drive/src/rules/no-invalid-relationships.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-invalid-relationships.js
@@ -6,7 +6,7 @@ module.exports = {
       description: 'require inverse to be specified in @belongsTo and @hasMany decorators',
       category: 'Best Practices',
       recommended: true,
-      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/rules/no-invalid-relationships.md',
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/no-invalid-relationships.md',
     },
     schema: [],
   },

--- a/packages/eslint-plugin-warp-drive/src/rules/no-invalid-resource-ids.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-invalid-resource-ids.js
@@ -49,7 +49,7 @@ module.exports = {
       description: 'requires the uses of a resource ID to be strings.',
       category: 'Best Practices',
       recommended: true,
-      url: `https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/rules/no-invalid-resource-ids.md`,
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/no-invalid-resource-ids.md',
     },
     schema: false,
   },

--- a/packages/eslint-plugin-warp-drive/src/rules/no-invalid-resource-types.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-invalid-resource-types.js
@@ -94,7 +94,7 @@ module.exports = {
         'require the uses of resource-type to follow a convention. Configurable, defaults to singular dasherized.',
       category: 'Best Practices',
       recommended: true,
-      url: `https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/rules/no-invalid-resource-types.md`,
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/no-invalid-resource-types.md',
     },
     schema: false,
   },

--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-request-patterns.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-request-patterns.js
@@ -26,7 +26,7 @@ module.exports = {
       description: 'require the use of `store.request()` instead of legacy request patterns',
       category: 'Best Practices',
       recommended: true,
-      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/rules/no-legacy-request-patterns.md',
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/no-legacy-request-patterns.md',
     },
   },
 

--- a/tests/ember-data__graph/README.md
+++ b/tests/ember-data__graph/README.md
@@ -4,7 +4,7 @@ This test-package provides tests for the `@ember-data/graph` package.
 
 ## Running Tests Locally
 
-If you do not already have the project cloned and dependencies installed, you may want to first read [Setting Up The Project](../../contributing/setting-up-the-project.md) 
+If you do not already have the project cloned and dependencies installed, you may want to first read [Setting Up The Project](../../guides/contributing/setting-up-the-project.md)
 
 ```cli
 cd tests/ember-data__graph;


### PR DESCRIPTION
### Description
Update some broken references, realized that they where pointing to `docs/rules` and that was the wrong path now
