### PR TITLE
docs: First mention of @warp-drive/build-config

### DIFF
--- a/guides/configuration/index.md
+++ b/guides/configuration/index.md
@@ -24,6 +24,24 @@ For most projects, the configuration is done inside of the project's babel confi
 For ember apps that still have an `ember-cli-build` file, this plugin comes built-in to the
 toolchain and all you need to do is provide it the desired configuration in `ember-cli-build`.
 
+::: code-group
+
+```sh [pnpm]
+pnpm add -E @warp-drive/build-config@latest;
+```
+
+```sh [npm]
+npm add -E @warp-drive/build-config@latest;
+```
+
+```sh [yarn]
+yarn add -E @warp-drive/build-config@latest;
+```
+
+```sh [bun]
+bun add --exact @warp-drive/build-config@latest;
+```
+
 ::: tabs key:paradigm
 
 == Simple Config


### PR DESCRIPTION
This is the first place in guides when `@warp-drive/build-config` is mentioned & used. The user had no chance to install the package yet. Not sure if this is the best place.

