### PR TITLE
turn off fastboot tests

### DIFF
--- a/.github/workflows/compat-tests.yml
+++ b/.github/workflows/compat-tests.yml
@@ -16,17 +16,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fastboot:
-    timeout-minutes: 7
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: ./.github/actions/setup
-        with:
-          install: true
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Tests
-        run: pnpm test:fastboot
   vite:
     timeout-minutes: 7
     runs-on: ubuntu-latest


### PR DESCRIPTION
Right now all the PRs that are opened against main are failing on the fastboot tests, and really "fastboot support" is not a concern of a V2 addon any more

I am proposing that we remove this always failing job for now, and if it's something we want to add back later we can 👍 