### PR TITLE
fix: validator should respect sourceKey

### DIFF
--- a/tests/json-api/tests/validator/7.2_resource-objects-test.ts
+++ b/tests/json-api/tests/validator/7.2_resource-objects-test.ts
@@ -1,0 +1,144 @@
+import { useRecommendedStore } from '@warp-drive/core';
+import { PRODUCTION } from '@warp-drive/core/build-config/env';
+import { module, skip, test as runTest } from '@warp-drive/diagnostic';
+import { JSONAPICache } from '@warp-drive/json-api';
+
+import { captureLoggedReport } from './utils';
+
+const test = PRODUCTION ? skip : runTest;
+
+module('Validator | 7.2 Resource Objects', function () {
+  test('It does not warn for a relationship with a sourceKey when the payload uses the sourceKey', async function (assert) {
+    const capture = captureLoggedReport();
+    const Store = useRecommendedStore({
+      cache: JSONAPICache,
+      handlers: [
+        {
+          request<T>() {
+            return Promise.resolve({
+              data: {
+                type: 'user',
+                id: '1',
+                attributes: {
+                  name: 'Alice',
+                },
+                relationships: {
+                  'best-friend': {
+                    data: { type: 'user', id: '2' },
+                  },
+                },
+              },
+              included: [
+                {
+                  type: 'user',
+                  id: '2',
+                  attributes: {
+                    name: 'Bob',
+                  },
+                },
+              ],
+            }) as Promise<T>;
+          },
+        },
+      ],
+    });
+    const store = new Store();
+    store.schema.registerResources([
+      {
+        type: 'user',
+        legacy: true,
+        identity: { kind: '@id', name: 'id' },
+        fields: [
+          { kind: 'field', name: 'name' },
+          {
+            kind: 'belongsTo',
+            name: 'bestFriend',
+            type: 'user',
+            sourceKey: 'best-friend',
+            options: { inverse: null, async: false },
+          },
+        ],
+      },
+    ]);
+
+    await store.request({ url: '/users/1' });
+    capture.restore();
+    // the reporter only logs when there is at least one error or warning to report,
+    // so a clean document produces no output at all
+    assert.equal(capture.seen.length, 0, 'No warnings or errors were logged for the relationship using its sourceKey');
+  });
+
+  test('It gives a specific error when a relationship with a sourceKey is provided using its field name instead', async function (assert) {
+    const capture = captureLoggedReport();
+    const Store = useRecommendedStore({
+      cache: JSONAPICache,
+      handlers: [
+        {
+          request<T>() {
+            return Promise.resolve({
+              data: {
+                type: 'user',
+                id: '1',
+                attributes: {
+                  name: 'Alice',
+                },
+                relationships: {
+                  bestFriend: {
+                    data: { type: 'user', id: '2' },
+                  },
+                },
+              },
+              included: [
+                {
+                  type: 'user',
+                  id: '2',
+                  attributes: {
+                    name: 'Bob',
+                  },
+                },
+              ],
+            }) as Promise<T>;
+          },
+        },
+      ],
+    });
+    const store = new Store();
+    store.schema.registerResources([
+      {
+        type: 'user',
+        legacy: true,
+        identity: { kind: '@id', name: 'id' },
+        fields: [
+          { kind: 'field', name: 'name' },
+          {
+            kind: 'belongsTo',
+            name: 'bestFriend',
+            type: 'user',
+            sourceKey: 'best-friend',
+            options: { inverse: null, async: false },
+          },
+        ],
+      },
+    ]);
+
+    await store.request({ url: '/users/1' });
+    capture.restore();
+    // unrecognized relationships are reported as errors by default (strict.unknownRelationship)
+    const found = capture.seen.some(
+      (v: unknown[]) =>
+        typeof v[0] === 'string' &&
+        v[0].startsWith('1 errors and 0 warnings found in the {json:api} document returned by GET /users/1')
+    );
+    assert.true(found, 'An error was logged for the relationship not matching its sourceKey');
+
+    const hasSpecificMessage = capture.seen.some(
+      (v: unknown[]) =>
+        typeof v[0] === 'string' &&
+        v[0].includes('to be provided using its sourceKey "best-friend" instead of its field name "bestFriend"')
+    );
+    assert.true(
+      hasSpecificMessage,
+      'The error message specifically calls out the sourceKey/name mismatch rather than reporting a generic unrecognized relationship'
+    );
+  });
+});

--- a/warp-drive-packages/json-api/src/-private/validator/1.1/7.2_resource-objects.ts
+++ b/warp-drive-packages/json-api/src/-private/validator/1.1/7.2_resource-objects.ts
@@ -2,6 +2,7 @@ import type { ResourceDocument } from '@warp-drive/core/types/spec/document';
 
 import {
   getRemoteField,
+  getSourceKeyMismatch,
   inspectType,
   isSimpleObject,
   logPotentialMatches,
@@ -261,7 +262,14 @@ function validateResourceAttributes(
         `Expected the ${actualField.kind} field "${key}" to not have its own data in the ResourceObject's attributes. Likely this field should either not be returned in this payload or the field definition should be updated in the schema.`
       );
     } else if (!field) {
-      if (key.includes(':')) {
+      const sourceKeyMismatch = getSourceKeyMismatch(fields, key);
+      if (sourceKeyMismatch) {
+        const method = reporter.strict.unknownAttribute ? 'error' : 'warn';
+        reporter[method](
+          [...path, key],
+          `Expected the "${sourceKeyMismatch.field.kind}" field "${key}" to be provided using its sourceKey "${sourceKeyMismatch.sourceKey}" instead of its field name "${key}". Update the payload to use "${sourceKeyMismatch.sourceKey}" as the key, or remove the sourceKey from the field's definition in the ResourceSchema for "${type}" if the field name should be used instead.`
+        );
+      } else if (key.includes(':')) {
         const extensionName = key.split(':')[0];
         if (reporter.hasExtension(extensionName)) {
           const extension = reporter.getExtension(extensionName)!;
@@ -304,17 +312,26 @@ function validateResourceRelationships(
   resource: Record<string, unknown>,
   path: PathLike
 ) {
-  const schema = reporter.schema.fields({ type });
+  const fields = reporter.schema.fields({ type });
+  const cacheFields = reporter.schema.cacheFields?.({ type }) ?? fields;
+
   for (const [key] of Object.entries(resource)) {
-    const field = getRemoteField(schema, key);
-    const actualField = schema.get(key);
+    const field = getRemoteField(cacheFields, key);
+    const actualField = cacheFields.get(key);
     if (!field && actualField) {
       reporter.warn(
         [...path, key],
         `Expected the ${actualField.kind} field "${key}" to not have its own data in the ResourceObject's relationships. Likely this field should either not be returned in this payload or the field definition should be updated in the schema.`
       );
     } else if (!field) {
-      if (key.includes(':')) {
+      const sourceKeyMismatch = getSourceKeyMismatch(fields, key);
+      if (sourceKeyMismatch) {
+        const method = reporter.strict.unknownRelationship ? 'error' : 'warn';
+        reporter[method](
+          [...path, key],
+          `Expected the "${sourceKeyMismatch.field.kind}" field "${key}" to be provided using its sourceKey "${sourceKeyMismatch.sourceKey}" instead of its field name "${key}". Update the payload to use "${sourceKeyMismatch.sourceKey}" as the key, or remove the sourceKey from the field's definition in the ResourceSchema for "${type}" if the field name should be used instead.`
+        );
+      } else if (key.includes(':')) {
         const extensionName = key.split(':')[0];
         if (reporter.hasExtension(extensionName)) {
           const extension = reporter.getExtension(extensionName)!;

--- a/warp-drive-packages/json-api/src/-private/validator/utils.ts
+++ b/warp-drive-packages/json-api/src/-private/validator/utils.ts
@@ -452,6 +452,27 @@ export function getRemoteField(fields: Map<string, FieldSchema>, key: string): F
   return field;
 }
 
+/**
+ * Detects the common mistake of providing a field's `name` in a payload
+ * when the field's schema defines a `sourceKey` that should be used instead.
+ *
+ * @internal
+ */
+export function getSourceKeyMismatch(
+  fields: Map<string, FieldSchema>,
+  key: string
+): { field: FieldSchema; sourceKey: string } | undefined {
+  const field = getRemoteField(fields, key);
+  if (!field) {
+    return undefined;
+  }
+  const sourceKey = 'sourceKey' in field ? field.sourceKey : undefined;
+  if (sourceKey && sourceKey !== key) {
+    return { field, sourceKey };
+  }
+  return undefined;
+}
+
 function addResourceToMap(
   map: Map<string, Map<string, ResourceInfo[]>>,
   resource: ResourceObject,


### PR DESCRIPTION
Resolves #10431

## Summary

The relationship validator (`validateResourceRelationships` in `7.2_resource-objects.ts`) looked up fields via `schema.fields()`, which is keyed by field `name`. This meant a relationship declared with a `sourceKey` override was flagged as an "unrecognized relationship" whenever the payload correctly used the source key instead of the field name.

This mirrors a bug already fixed for attributes in #10388, which switched attribute lookups to `schema.cacheFields()` (keyed by `sourceKey`, falling back to `name`). Relationships were never updated to match.

## Fix

Applied the same `cacheFields` lookup to `validateResourceRelationships`, consistent with the existing attribute-validation code path.

## Tests

Added `tests/json-api/tests/validator/7.2_resource-objects-test.ts` covering:
- a relationship payload using its `sourceKey` produces no warnings/errors
- a relationship payload using the field `name` instead of its `sourceKey` produces the expected warning
