### PR TITLE
dx: improve validator terseness and performance

### DIFF
--- a/tests/json-api/tests/validator/report-compaction-test.ts
+++ b/tests/json-api/tests/validator/report-compaction-test.ts
@@ -1,0 +1,152 @@
+import { useRecommendedStore } from '@warp-drive/core';
+import { PRODUCTION } from '@warp-drive/core/build-config/env';
+import { module, skip, test as runTest } from '@warp-drive/diagnostic';
+import { JSONAPICache } from '@warp-drive/json-api';
+
+import { captureLoggedReport } from './utils';
+
+const test = PRODUCTION ? skip : runTest;
+
+function widgetSchema() {
+  return {
+    type: 'widget',
+    legacy: true,
+    identity: { kind: '@id' as const, name: 'id' },
+    fields: [{ kind: 'field' as const, name: 'name' }],
+  };
+}
+
+module('Validator | Report Compaction', function () {
+  test('it collapses a widely repeated identical error down to a single annotated occurrence with a recurrence note', async function (assert) {
+    const capture = captureLoggedReport();
+    const TOTAL = 600;
+    const data = Array.from({ length: TOTAL }, (_, i) => ({
+      type: 'widget',
+      id: String(i),
+      attributes: { name: `Widget ${i}`, bogus: true },
+    }));
+
+    const Store = useRecommendedStore({
+      cache: JSONAPICache,
+      handlers: [
+        {
+          request<T>() {
+            return Promise.resolve({ data }) as Promise<T>;
+          },
+        },
+      ],
+    });
+    const store = new Store();
+    store.schema.registerResources([widgetSchema()]);
+
+    await store.request({ url: '/widgets' });
+    capture.restore();
+
+    const allText = capture.seen.map((v) => (typeof v[0] === 'string' ? v[0] : '')).join('\n');
+
+    const found = capture.seen.some(
+      (v) => typeof v[0] === 'string' && v[0].startsWith(`${TOTAL} errors and 0 warnings found`)
+    );
+    assert.true(found, `the header reports all ${TOTAL} occurrences even though only one is annotated inline`);
+
+    const recurrenceMatches = allText.match(/\(recurs \d+ more times\)/g) ?? [];
+    assert.equal(recurrenceMatches.length, 1, 'exactly one recurrence note is printed for the repeated error');
+    assert.true(
+      allText.includes(`(recurs ${TOTAL - 1} more times)`),
+      'the recurrence note reports the correct number of remaining occurrences'
+    );
+
+    const annotationCount = (allText.match(/❌/g) ?? []).length;
+    assert.equal(annotationCount, 1, 'only the first occurrence of the repeated error is annotated inline');
+  });
+
+  test('it collapses long stretches of error-free source into skip markers', async function (assert) {
+    const capture = captureLoggedReport();
+    // enough clean resources before and after the single bad one that the
+    // gaps are far larger than the default context window
+    const data = [
+      ...Array.from({ length: 100 }, (_, i) => ({
+        type: 'widget',
+        id: `before-${i}`,
+        attributes: { name: `Widget ${i}` },
+      })),
+      { type: 'widget', id: 'the-bad-one', attributes: { name: 'Bad Widget', bogus: true } },
+      ...Array.from({ length: 100 }, (_, i) => ({
+        type: 'widget',
+        id: `after-${i}`,
+        attributes: { name: `Widget ${i}` },
+      })),
+    ];
+
+    const Store = useRecommendedStore({
+      cache: JSONAPICache,
+      handlers: [
+        {
+          request<T>() {
+            return Promise.resolve({ data }) as Promise<T>;
+          },
+        },
+      ],
+    });
+    const store = new Store();
+    store.schema.registerResources([widgetSchema()]);
+
+    await store.request({ url: '/widgets' });
+    capture.restore();
+
+    const allText = capture.seen.map((v) => (typeof v[0] === 'string' ? v[0] : '')).join('\n');
+
+    const skipMatches = [...allText.matchAll(/\.\.\. (\d+) lines? skipped \(no errors\) \.\.\./g)];
+    assert.equal(skipMatches.length, 2, 'a skip marker is printed both before and after the single annotated error');
+
+    const annotationCount = (allText.match(/❌/g) ?? []).length;
+    assert.equal(annotationCount, 1, 'the single error is still annotated inline despite the surrounding compaction');
+  });
+
+  test('it caps the number of distinct issues shown and reports what was omitted', async function (assert) {
+    const capture = captureLoggedReport();
+    const PAIR_COUNT = 60; // more than the default maxDistinctIssues of 50
+    // duplicate-resource messages embed the specific `type:id` and occurrence
+    // paths involved, so every occurrence here produces a distinct message
+    const data: Array<{ type: string; id: string; attributes: { name: string } }> = [];
+    for (let i = 0; i < PAIR_COUNT; i++) {
+      data.push({ type: 'widget', id: String(i), attributes: { name: `Widget ${i}` } });
+      data.push({ type: 'widget', id: String(i), attributes: { name: `Widget ${i} (duplicate)` } });
+    }
+
+    const Store = useRecommendedStore({
+      cache: JSONAPICache,
+      handlers: [
+        {
+          request<T>() {
+            return Promise.resolve({ data }) as Promise<T>;
+          },
+        },
+      ],
+    });
+    const store = new Store();
+    store.schema.registerResources([widgetSchema()]);
+
+    await store.request({ url: '/widgets' });
+    capture.restore();
+
+    const allText = capture.seen.map((v) => (typeof v[0] === 'string' ? v[0] : '')).join('\n');
+
+    const TOTAL_ERRORS = PAIR_COUNT * 2;
+    const found = capture.seen.some(
+      (v) => typeof v[0] === 'string' && v[0].startsWith(`${TOTAL_ERRORS} errors and 0 warnings found`)
+    );
+    assert.true(found, `the header reports all ${TOTAL_ERRORS} occurrences even though most are not shown`);
+
+    const notShownMatch = allText.match(/\.\.\. and (\d+) more distinct issues? \((\d+) occurrences?\) not shown \.\.\./);
+    assert.true(!!notShownMatch, 'a trailing note reports the distinct issues that were omitted');
+
+    if (notShownMatch) {
+      const [, hiddenGroups, hiddenOccurrences] = notShownMatch;
+      // every duplicate-resource message here is unique, so each hidden
+      // group corresponds to exactly one hidden occurrence
+      assert.equal(hiddenGroups, String(TOTAL_ERRORS - 50), 'the correct number of distinct issues is reported as hidden');
+      assert.equal(hiddenOccurrences, hiddenGroups, 'each hidden distinct issue here has exactly one occurrence');
+    }
+  });
+});

--- a/tests/json-api/tests/validator/report-compaction-test.ts
+++ b/tests/json-api/tests/validator/report-compaction-test.ts
@@ -138,14 +138,20 @@ module('Validator | Report Compaction', function () {
     );
     assert.true(found, `the header reports all ${TOTAL_ERRORS} occurrences even though most are not shown`);
 
-    const notShownMatch = allText.match(/\.\.\. and (\d+) more distinct issues? \((\d+) occurrences?\) not shown \.\.\./);
+    const notShownMatch = allText.match(
+      /\.\.\. and (\d+) more distinct issues? \((\d+) occurrences?\) not shown \.\.\./
+    );
     assert.true(!!notShownMatch, 'a trailing note reports the distinct issues that were omitted');
 
     if (notShownMatch) {
       const [, hiddenGroups, hiddenOccurrences] = notShownMatch;
       // every duplicate-resource message here is unique, so each hidden
       // group corresponds to exactly one hidden occurrence
-      assert.equal(hiddenGroups, String(TOTAL_ERRORS - 50), 'the correct number of distinct issues is reported as hidden');
+      assert.equal(
+        hiddenGroups,
+        String(TOTAL_ERRORS - 50),
+        'the correct number of distinct issues is reported as hidden'
+      );
       assert.equal(hiddenOccurrences, hiddenGroups, 'each hidden distinct issue here has exactly one occurrence');
     }
   });

--- a/warp-drive-packages/json-api/src/-private/validator/utils.ts
+++ b/warp-drive-packages/json-api/src/-private/validator/utils.ts
@@ -440,6 +440,17 @@ export class Reporter {
       }
     }
 
+    // extend the first/last range to the document boundary when the
+    // leading/trailing stretch is too small for a skip marker to be worth it
+    const firstRange = ranges[0];
+    if (firstRange && firstRange[0] - 1 <= MERGE_GAP + 1) {
+      firstRange[0] = 1;
+    }
+    const lastRangeOverall = ranges[ranges.length - 1];
+    if (lastRangeOverall && lines.length - lastRangeOverall[1] <= MERGE_GAP + 1) {
+      lastRangeOverall[1] = lines.length;
+    }
+
     // render into chunks so that no single `console.log` call has to spread
     // more than `this.maxLines` worth of rendered lines as colorization
     // args.
@@ -455,19 +466,27 @@ export class Reporter {
       renderedCount++;
     };
 
+    const pushSkipMarker = (gap: number) => {
+      nextLine(
+        colorize
+          ? `%c... ${gap} line${gap === 1 ? '' : 's'} skipped (no errors) ...%c`
+          : `... ${gap} line${gap === 1 ? '' : 's'} skipped (no errors) ...`,
+        ['color: grey; font-style: italic;', 'color: inherit; background-color: transparent;']
+      );
+    };
+
     const LINE_SIZE = String(lines.length).length;
     for (let r = 0; r < ranges.length; r++) {
       const [rangeStart, rangeEnd] = ranges[r];
 
-      if (r > 0) {
+      if (r === 0) {
+        if (rangeStart > 1) {
+          pushSkipMarker(rangeStart - 1);
+        }
+      } else {
         const gap = rangeStart - ranges[r - 1][1] - 1;
         if (gap > 0) {
-          nextLine(
-            colorize
-              ? `%c... ${gap} line${gap === 1 ? '' : 's'} skipped (no errors) ...%c`
-              : `... ${gap} line${gap === 1 ? '' : 's'} skipped (no errors) ...`,
-            ['color: grey; font-style: italic;', 'color: inherit; background-color: transparent;']
-          );
+          pushSkipMarker(gap);
         }
       }
 
@@ -502,6 +521,11 @@ export class Reporter {
           }
         }
       }
+    }
+
+    const lastRenderedRange = ranges[ranges.length - 1];
+    if (lastRenderedRange && lastRenderedRange[1] < lines.length) {
+      pushSkipMarker(lines.length - lastRenderedRange[1]);
     }
 
     if (hiddenGroupCount > 0) {

--- a/warp-drive-packages/json-api/src/-private/validator/utils.ts
+++ b/warp-drive-packages/json-api/src/-private/validator/utils.ts
@@ -125,6 +125,33 @@ export class Reporter {
    */
   maxLines = 500;
 
+  /**
+   * The number of source lines to show before/after each reported line when
+   * annotating the document. Stretches of source between annotated lines
+   * that are larger than this get collapsed into a single
+   * `... N lines skipped ...` marker rather than printed in full.
+   */
+  contextLines = 2;
+
+  /**
+   * The number of occurrences of an identical error message to annotate
+   * inline before collapsing the rest. When a message recurs beyond this
+   * count, the last shown occurrence's annotation is suffixed with
+   * `(recurs N more times)` and the remaining occurrences are omitted from
+   * the printed document entirely (though they still count toward the
+   * totals in the summary line).
+   */
+  maxOccurrencesPerGroup = 1;
+
+  /**
+   * The number of distinct error messages to annotate inline before
+   * refusing to show any more. Once this many distinct messages have been
+   * shown, further distinct messages are omitted entirely and rolled up
+   * into a single trailing `... and N more distinct issues ... not shown`
+   * line so nothing is dropped silently.
+   */
+  maxDistinctIssues = 50;
+
   declare _ast: ReturnType<typeof jsonToAst> | undefined;
   declare _jsonStr: string | undefined;
 
@@ -337,65 +364,154 @@ export class Reporter {
           : compareType(a.type, b.type);
     });
 
-    // store the errors in a map by line
-    const errorMap = new Map<number, ErrorReport[]>();
-    for (const error of errors) {
-      const line = error.loc.end.line;
-      if (!errorMap.has(line)) {
-        errorMap.set(line, []);
-      }
-      errorMap.get(line)!.push(error);
-    }
-
-    // splice the errors into the lines, chunking so that no single
-    // `console.log` call has to spread more than `this.maxLines` worth of
-    // source lines (plus their error annotations) as colorization args.
-    const chunks: { text: string[]; colors: string[] }[] = [{ text: [], colors: [] }];
+    // counts reflect every error/warning/info regardless of whether it ends
+    // up annotated inline below, so the header total is always accurate.
     const counts = {
       error: 0,
       warning: 0,
       info: 0,
     };
+    for (const error of errors) {
+      counts[error.type]++;
+    }
+    const contextStr = `${counts.error} errors and ${counts.warning} warnings found in the {json:api} document returned by ${this.contextDocument.request?.method ?? 'GET'} ${this.contextDocument.request?.url}`;
 
-    const LINE_SIZE = String(lines.length).length;
-    for (let i = 0; i < lines.length; i++) {
-      if (i > 0 && i % this.maxLines === 0) {
+    // group identical messages together so repeats can be collapsed down to
+    // a representative sample instead of printed in full.
+    const groups = new Map<string, ErrorReport[]>();
+    for (const error of errors) {
+      let group = groups.get(error.message);
+      if (!group) {
+        group = [];
+        groups.set(error.message, group);
+      }
+      group.push(error);
+    }
+
+    const activeErrors = new Set<ErrorReport>();
+    const recurrenceNoteFor = new Map<ErrorReport, number>();
+    let shownGroupCount = 0;
+    let hiddenGroupCount = 0;
+    let hiddenOccurrenceCount = 0;
+
+    for (const group of groups.values()) {
+      if (shownGroupCount < this.maxDistinctIssues) {
+        shownGroupCount++;
+        const showCount = Math.min(this.maxOccurrencesPerGroup, group.length);
+        for (let i = 0; i < showCount; i++) {
+          activeErrors.add(group[i]);
+        }
+        const extra = group.length - showCount;
+        if (extra > 0) {
+          recurrenceNoteFor.set(group[showCount - 1], extra);
+        }
+      } else {
+        hiddenGroupCount++;
+        hiddenOccurrenceCount += group.length;
+      }
+    }
+
+    // store the active (to-be-annotated) errors in a map by line
+    const errorMap = new Map<number, ErrorReport[]>();
+    for (const error of activeErrors) {
+      const line = error.loc.end.line;
+      let errorsForLine = errorMap.get(line);
+      if (!errorsForLine) {
+        errorsForLine = [];
+        errorMap.set(line, errorsForLine);
+      }
+      errorsForLine.push(error);
+    }
+
+    // determine which stretches of source to display: a window of
+    // `contextLines` around every active error line, merging windows that
+    // are close enough together that a skip marker wouldn't save anything.
+    const MERGE_GAP = 3;
+    const activeLines = Array.from(errorMap.keys()).sort((a, b) => a - b);
+    const ranges: [number, number][] = [];
+    for (const line of activeLines) {
+      const start = Math.max(1, line - this.contextLines);
+      const end = Math.min(lines.length, line + this.contextLines);
+      const lastRange = ranges[ranges.length - 1];
+      if (lastRange && start <= lastRange[1] + MERGE_GAP + 1) {
+        lastRange[1] = Math.max(lastRange[1], end);
+      } else {
+        ranges.push([start, end]);
+      }
+    }
+
+    // render into chunks so that no single `console.log` call has to spread
+    // more than `this.maxLines` worth of rendered lines as colorization
+    // args.
+    const chunks: { text: string[]; colors: string[] }[] = [{ text: [], colors: [] }];
+    let renderedCount = 0;
+    const nextLine = (text: string, lineColors: string[]) => {
+      if (renderedCount > 0 && renderedCount % this.maxLines === 0) {
         chunks.push({ text: [], colors: [] });
       }
       const chunk = chunks[chunks.length - 1];
-      const line = lines[i];
-      chunk.text.push(
-        colorize
-          ? `${String(i + 1).padEnd(LINE_SIZE, ' ')}  \t%c${line}%c`
-          : `${String(i + 1).padEnd(LINE_SIZE, ' ')}  \t${line}`
-      );
-      chunk.colors.push(
-        `color: grey; background-color: transparent;`, // first color sets color
-        `color: inherit; background-color: transparent;` // second color resets the color profile
-      );
-      if (errorMap.has(i + 1)) {
-        const errorsForLine = errorMap.get(i + 1)!;
-        for (const error of errorsForLine) {
-          counts[error.type]++;
-          const { loc, message } = error;
-          const start = loc.end.line === loc.start.line ? loc.start.column - 1 : loc.end.column - 1;
-          const end = loc.end.column - 1;
-          const symbol = error.type === 'error' ? '❌' : error.type === 'warning' ? '⚠️' : 'ℹ️';
-          const errorLine = colorize
-            ? `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}%c^${'~'.repeat(end - start)} %c//%c ${message}%c`
-            : `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}^${'~'.repeat(end - start)} // ${message}`;
-          chunk.text.push(errorLine);
-          chunk.colors.push(
-            error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
-            'color: grey;',
-            error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
-            'color: inherit; background-color: transparent;' // reset color
+      chunk.text.push(text);
+      chunk.colors.push(...lineColors);
+      renderedCount++;
+    };
+
+    const LINE_SIZE = String(lines.length).length;
+    for (let r = 0; r < ranges.length; r++) {
+      const [rangeStart, rangeEnd] = ranges[r];
+
+      if (r > 0) {
+        const gap = rangeStart - ranges[r - 1][1] - 1;
+        if (gap > 0) {
+          nextLine(
+            colorize
+              ? `%c... ${gap} line${gap === 1 ? '' : 's'} skipped (no errors) ...%c`
+              : `... ${gap} line${gap === 1 ? '' : 's'} skipped (no errors) ...`,
+            ['color: grey; font-style: italic;', 'color: inherit; background-color: transparent;']
           );
+        }
+      }
+
+      for (let i = rangeStart; i <= rangeEnd; i++) {
+        const line = lines[i - 1];
+        nextLine(
+          colorize
+            ? `${String(i).padEnd(LINE_SIZE, ' ')}  \t%c${line}%c`
+            : `${String(i).padEnd(LINE_SIZE, ' ')}  \t${line}`,
+          [`color: grey; background-color: transparent;`, `color: inherit; background-color: transparent;`]
+        );
+
+        if (errorMap.has(i)) {
+          for (const error of errorMap.get(i)!) {
+            const { loc } = error;
+            const start = loc.end.line === loc.start.line ? loc.start.column - 1 : loc.end.column - 1;
+            const end = loc.end.column - 1;
+            const symbol = error.type === 'error' ? '❌' : error.type === 'warning' ? '⚠️' : 'ℹ️';
+            const extra = recurrenceNoteFor.get(error);
+            const message = extra ? `${error.message} (recurs ${extra} more time${extra === 1 ? '' : 's'})` : error.message;
+            nextLine(
+              colorize
+                ? `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}%c^${'~'.repeat(end - start)} %c//%c ${message}%c`
+                : `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}^${'~'.repeat(end - start)} // ${message}`,
+              [
+                error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
+                'color: grey;',
+                error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
+                'color: inherit; background-color: transparent;',
+              ]
+            );
+          }
         }
       }
     }
 
-    const contextStr = `${counts.error} errors and ${counts.warning} warnings found in the {json:api} document returned by ${this.contextDocument.request?.method ?? 'GET'} ${this.contextDocument.request?.url}`;
+    if (hiddenGroupCount > 0) {
+      nextLine(
+        colorize
+          ? `%c... and ${hiddenGroupCount} more distinct issue${hiddenGroupCount === 1 ? '' : 's'} (${hiddenOccurrenceCount} occurrence${hiddenOccurrenceCount === 1 ? '' : 's'}) not shown ...%c`
+          : `... and ${hiddenGroupCount} more distinct issues (${hiddenOccurrenceCount} occurrences) not shown ...`,
+        ['color: grey; font-style: italic;', 'color: inherit; background-color: transparent;']
+      );
+    }
 
     chunks.forEach((chunk, index) => {
       const prefix = index === 0 ? `${contextStr}\n\n` : '';

--- a/warp-drive-packages/json-api/src/-private/validator/utils.ts
+++ b/warp-drive-packages/json-api/src/-private/validator/utils.ts
@@ -506,7 +506,9 @@ export class Reporter {
             const end = loc.end.column - 1;
             const symbol = error.type === 'error' ? '❌' : error.type === 'warning' ? '⚠️' : 'ℹ️';
             const extra = recurrenceNoteFor.get(error);
-            const message = extra ? `${error.message} (recurs ${extra} more time${extra === 1 ? '' : 's'})` : error.message;
+            const message = extra
+              ? `${error.message} (recurs ${extra} more time${extra === 1 ? '' : 's'})`
+              : error.message;
             nextLine(
               colorize
                 ? `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}%c^${'~'.repeat(end - start)} %c//%c ${message}%c`

--- a/warp-drive-packages/json-api/src/-private/validator/utils.ts
+++ b/warp-drive-packages/json-api/src/-private/validator/utils.ts
@@ -114,8 +114,36 @@ export class Reporter {
   capabilities: CacheCapabilitiesManager;
   contextDocument: StructuredDocument<ResourceDocument>;
   errors: ErrorReport[] = [];
-  ast: ReturnType<typeof jsonToAst>;
-  jsonStr: string;
+
+  /**
+   * The maximum number of source lines the reporter will annotate and emit
+   * in a single `console.log` call when producing a report. Documents with
+   * more lines than this are chunked across multiple calls so that no
+   * single call ever has to spread an unbounded number of colorization
+   * args (which can exceed engine call-argument/stack limits for very
+   * large payloads).
+   */
+  maxLines = 500;
+
+  declare _ast: ReturnType<typeof jsonToAst> | undefined;
+  declare _jsonStr: string | undefined;
+
+  // lazy: only parse the document into a string/AST if we actually need to
+  // locate an error, warning, or info within it. Clean documents (the vast
+  // majority) never pay this cost.
+  get jsonStr(): string {
+    if (this._jsonStr === undefined) {
+      this._jsonStr = JSON.stringify(this.contextDocument.content, null, 2);
+    }
+    return this._jsonStr;
+  }
+
+  get ast(): ReturnType<typeof jsonToAst> {
+    if (!this._ast) {
+      this._ast = jsonToAst(this.jsonStr, { loc: true });
+    }
+    return this._ast;
+  }
 
   // TODO @runspired make this configurable to consuming apps before
   // activating by default
@@ -171,9 +199,6 @@ export class Reporter {
   constructor(capabilities: CacheCapabilitiesManager, doc: StructuredDocument<ResourceDocument>) {
     this.capabilities = capabilities;
     this.contextDocument = doc;
-
-    this.jsonStr = JSON.stringify(doc.content, null, 2);
-    this.ast = jsonToAst(this.jsonStr, { loc: true });
   }
 
   declare _typeFilter: Fuse<string> | undefined;
@@ -295,14 +320,14 @@ export class Reporter {
   }
 
   report(colorize = true): void {
-    const lines = this.jsonStr.split('\n');
-
     // sort the errors by line, then by column, then by type
     const { errors } = this;
 
     if (!errors.length) {
       return;
     }
+
+    const lines = this.jsonStr.split('\n');
 
     errors.sort((a, b) => {
       return a.loc.end.line < b.loc.end.line
@@ -322,9 +347,10 @@ export class Reporter {
       errorMap.get(line)!.push(error);
     }
 
-    // splice the errors into the lines
-    const errorLines: string[] = [];
-    const colors: string[] = [];
+    // splice the errors into the lines, chunking so that no single
+    // `console.log` call has to spread more than `this.maxLines` worth of
+    // source lines (plus their error annotations) as colorization args.
+    const chunks: { text: string[]; colors: string[] }[] = [{ text: [], colors: [] }];
     const counts = {
       error: 0,
       warning: 0,
@@ -333,13 +359,17 @@ export class Reporter {
 
     const LINE_SIZE = String(lines.length).length;
     for (let i = 0; i < lines.length; i++) {
+      if (i > 0 && i % this.maxLines === 0) {
+        chunks.push({ text: [], colors: [] });
+      }
+      const chunk = chunks[chunks.length - 1];
       const line = lines[i];
-      errorLines.push(
+      chunk.text.push(
         colorize
           ? `${String(i + 1).padEnd(LINE_SIZE, ' ')}  \t%c${line}%c`
           : `${String(i + 1).padEnd(LINE_SIZE, ' ')}  \t${line}`
       );
-      colors.push(
+      chunk.colors.push(
         `color: grey; background-color: transparent;`, // first color sets color
         `color: inherit; background-color: transparent;` // second color resets the color profile
       );
@@ -354,8 +384,8 @@ export class Reporter {
           const errorLine = colorize
             ? `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}%c^${'~'.repeat(end - start)} %c//%c ${message}%c`
             : `${''.padStart(LINE_SIZE, ' ') + symbol}\t${' '.repeat(start)}^${'~'.repeat(end - start)} // ${message}`;
-          errorLines.push(errorLine);
-          colors.push(
+          chunk.text.push(errorLine);
+          chunk.colors.push(
             error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
             'color: grey;',
             error.type === 'error' ? 'color: red;' : error.type === 'warning' ? 'color: orange;' : 'color: blue;',
@@ -366,10 +396,13 @@ export class Reporter {
     }
 
     const contextStr = `${counts.error} errors and ${counts.warning} warnings found in the {json:api} document returned by ${this.contextDocument.request?.method ?? 'GET'} ${this.contextDocument.request?.url}`;
-    const errorString = contextStr + `\n\n` + errorLines.join('\n');
 
-    // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
-    colorize ? console.log(errorString, ...colors) : console.log(errorString);
+    chunks.forEach((chunk, index) => {
+      const prefix = index === 0 ? `${contextStr}\n\n` : '';
+      const chunkString = prefix + chunk.text.join('\n');
+      // eslint-disable-next-line no-console, @typescript-eslint/no-unused-expressions
+      colorize ? console.log(chunkString, ...chunk.colors) : console.log(chunkString);
+    });
 
     if (JSON_API_CACHE_VALIDATION_ERRORS) {
       if (counts.error > 0) {


### PR DESCRIPTION
resolves #10430 

Intended fixes:

- [x] don't unnecessarily parse the json to AST
- [x] chunk log if maxLines exceeded
- [x] reduce log output to surrounding context based on ratio of lines to errors
- [x] reduce number of errors printed based on categorization/similarity when above a configurable threshold

<!-- AUTO-GENERATED SUMMARY -->

