### PR TITLE
fix: holodeck replay should respect query params

### DIFF
--- a/packages/holodeck/server/utils.js
+++ b/packages/holodeck/server/utils.js
@@ -59,7 +59,8 @@ export function getNiceUrl(url) {
   const urlObj = new URL(url);
   urlObj.searchParams.delete('__xTestId');
   urlObj.searchParams.delete('__xTestRequestNumber');
-  return (urlObj.pathname + urlObj.searchParams.toString()).slice(1);
+  const params = urlObj.searchParams.toString();
+  return (urlObj.pathname + (params ? `?${params}` : '')).slice(1);
 }
 
 /*

--- a/tests/ember-data__request/tests/integration/fetch-handler-test.ts
+++ b/tests/ember-data__request/tests/integration/fetch-handler-test.ts
@@ -75,6 +75,40 @@ module('RequestManager | Fetch Handler', function (hooks) {
     );
   });
 
+  test('Supports GET requests with search params', async function (assert) {
+    const manager = new RequestManager();
+    manager.use([new MockServerHandler(this), Fetch]);
+
+    await GET(this, 'users?name=Chris', () => ({
+      data: [
+        {
+          id: '1',
+          type: 'user',
+          attributes: {
+            name: 'Chris Thoburn',
+          },
+        },
+      ],
+    }));
+
+    const doc = await manager.request({ url: buildBaseURL({ resourcePath: 'users' }) + '?name=Chris' });
+    assert.deepEqual(
+      doc.content,
+      {
+        data: [
+          {
+            id: '1',
+            type: 'user',
+            attributes: {
+              name: 'Chris Thoburn',
+            },
+          },
+        ],
+      },
+      'The response is processed correctly'
+    );
+  });
+
   test('Supports HEAD requests', async function (assert) {
     const manager = new RequestManager();
     manager.use([new MockServerHandler(this), Fetch]);


### PR DESCRIPTION
resolves #10504

## Problem

Registering a mock with query params (e.g. `/test?param=1`) always resulted in `MOCK_NOT_FOUND` when replayed.

The cache key is built from a URL string at two different points, and they disagreed once query params were involved:

- **Registration**: built directly from the raw `url` in the mock payload (e.g. `test?param=1`), `?` intact.
- **Replay**: built from `getNiceUrl(req.url)`, which reconstructed the URL as `pathname + searchParams.toString()` with no separator — so `/test?param=1` became `testparam=1` after stripping the internal `__xTestId`/`__xTestRequestNumber` tracking params.

Since `server/node.js` and `server/bun.js` both share this helper, the bug affected both server backends.

## Fix

`getNiceUrl` now re-inserts the `?` when search params remain after stripping the tracking params, so the replay-side cache key matches the registration-side one again.

## Testing

- Verified directly that the registration-side raw url (`test?param=1`) now equals the replay-side `getNiceUrl` output for a request like `.../test?param=1&__xTestId=...&__xTestRequestNumber=...`.
- Confirmed the no-query-param path (e.g. `users/1`) is unaffected.
- Confirmed multi-param ordering is preserved (`users?name=Chris&age=30`).
- Added a regression test, `Supports GET requests with search params`, in `tests/ember-data__request/tests/integration/fetch-handler-test.ts`, mocking and requesting a URL with a query string end-to-end through `MockServerHandler` + `Fetch`.