### PR TITLE
fix: account for type-only imports in lint fix

### DIFF
--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
@@ -72,25 +72,28 @@ function createHelpers(context) {
   }
 
   /**
-   * @typedef {{ spec: any, originalExportName: string | null, targetExportName: string | null }} SpecifierDescriptor
+   * @typedef {{ spec: any, originalExportName: string | null, targetExportName: string | null, isType: boolean }} SpecifierDescriptor
    */
 
   /** @returns {Record<string, SpecifierDescriptor[]>} */
-  function groupImportSpecifiersByTarget(moduleName, specifiers) {
+  function groupImportSpecifiersByTarget(moduleName, specifiers, declarationIsTypeOnly) {
     const groups = Object.create(null);
     for (const spec of specifiers) {
       const expName = getImportExportNameFromImportSpecifier(spec);
+      // A specifier is type-only if the whole declaration is `import type ...`
+      // or if it carries its own inline `type` modifier (e.g. `{ type Foo }`).
+      const isType = declarationIsTypeOnly || spec.importKind === 'type';
       if (!expName) {
         // namespace or unknown – keep under original module, verbatim
         groups[moduleName] ||= [];
-        groups[moduleName].push({ spec, originalExportName: null, targetExportName: null });
+        groups[moduleName].push({ spec, originalExportName: null, targetExportName: null, isType });
         continue;
       }
       const target = MAPPING.get(`${moduleName}::${expName}`);
       const targetModule = target ? target.module : moduleName; // unknowns remain under original module
       const targetExportName = target ? target.export : expName; // unknowns keep their own export name
       groups[targetModule] ||= [];
-      groups[targetModule].push({ spec, originalExportName: expName, targetExportName });
+      groups[targetModule].push({ spec, originalExportName: expName, targetExportName, isType });
     }
     return groups;
   }
@@ -107,24 +110,30 @@ function createHelpers(context) {
   function buildSpecifierText(descriptor) {
     if (descriptor.targetExportName == null) {
       // namespace or unrecognized specifier – keep it exactly as written
-      return { kind: 'verbatim', text: sourceCode.getText(descriptor.spec) };
+      return { kind: 'verbatim', text: sourceCode.getText(descriptor.spec), isType: descriptor.isType };
     }
     const localName = descriptor.spec.local.name;
     if (descriptor.targetExportName === 'default') {
-      return { kind: 'default', text: localName };
+      return { kind: 'default', text: localName, isType: descriptor.isType };
     }
     const text =
       descriptor.targetExportName === localName
         ? descriptor.targetExportName
         : `${descriptor.targetExportName} as ${localName}`;
-    return { kind: 'named', text };
+    return { kind: 'named', text, isType: descriptor.isType };
   }
 
   function buildImportTextForGroup(groupModule, descriptors, quote) {
     const rendered = descriptors.map(buildSpecifierText);
+    // If every specifier landing in this group is type-only, hoist the `type`
+    // modifier onto the declaration itself instead of repeating it per-specifier.
+    const wholeImportIsType = rendered.length > 0 && rendered.every((r) => r.isType);
+
     const defaults = rendered.filter((r) => r.kind === 'default').map((r) => r.text);
     const verbatim = rendered.filter((r) => r.kind === 'verbatim').map((r) => r.text);
-    const named = rendered.filter((r) => r.kind === 'named').map((r) => r.text);
+    const named = rendered
+      .filter((r) => r.kind === 'named')
+      .map((r) => (r.isType && !wholeImportIsType ? `type ${r.text}` : r.text));
 
     const segments = [];
     if (defaults.length) segments.push(defaults.join(', '));
@@ -135,7 +144,8 @@ function createHelpers(context) {
       return '';
     }
 
-    return ['import ', segments.join(', '), ' from ', quote, groupModule, quote, ';'].join('');
+    const importKeyword = wholeImportIsType ? 'import type ' : 'import ';
+    return [importKeyword, segments.join(', '), ' from ', quote, groupModule, quote, ';'].join('');
   }
 
   return {
@@ -169,8 +179,9 @@ module.exports = {
     function handleImportDeclaration(node) {
       if (!node.source || !node.source.value || !node.specifiers || node.specifiers.length === 0) return;
       const fromModule = String(node.source.value);
+      const declarationIsTypeOnly = node.importKind === 'type';
 
-      const groups = helpers.groupImportSpecifiersByTarget(fromModule, node.specifiers);
+      const groups = helpers.groupImportSpecifiersByTarget(fromModule, node.specifiers, declarationIsTypeOnly);
       const hasMapped = helpers.hasAnyMappedTarget(groups, fromModule);
       if (!hasMapped) return;
 

--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.md
@@ -32,9 +32,11 @@ import { findRecord } from '@warp-drive/utilities/rest';
 ## Scope (v1)
 
 - Static imports only.
-- Default and named specifiers are supported.
+- Default and named specifiers are supported, including TypeScript `import type` declarations
+  and inline `type` specifiers (e.g. `import { type Foo } from '...'`); their type-only-ness
+  is preserved across the rewrite.
 - Namespace imports, export-all (`export * from`), re-exports with `from`, CommonJS `require`,
-  dynamic imports, and type-only handling are out of scope for v1 (no report).
+  and dynamic imports are out of scope for v1 (no report).
 
 ## Notes
 

--- a/packages/eslint-plugin-warp-drive/tests/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/tests/no-legacy-imports.js
@@ -79,5 +79,47 @@ eslintTester.run('no-legacy-imports', rule, {
       output: `import { RESTAdapter as Adapter } from '@warp-drive/legacy/adapter/rest';`,
       errors: [{ messageId: msg }],
     },
+    // Default import whose replacement is a named export (regression for #10399)
+    {
+      code: `import Store from '@ember-data/store';`,
+      output: `import { Store } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
+  ],
+});
+
+// `import type` is TypeScript-only syntax; @babel/eslint-parser above doesn't parse it,
+// so these cases need @typescript-eslint/parser (regression for #10399).
+const tsTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+});
+
+tsTester.run('no-legacy-imports (type-only imports)', rule, {
+  valid: [],
+  invalid: [
+    // A type-only default import converted to a named export must stay type-only,
+    // and must become a named import rather than keeping the default form.
+    {
+      code: `import type Store from '@ember-data/store';`,
+      output: `import type { Store } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
+    // A lone inline `type` specifier is hoisted to a declaration-level `import type`.
+    {
+      code: `import { type CacheHandler } from '@ember-data/store';`,
+      output: `import type { CacheHandler } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
+    // When only some named specifiers are type-only, the inline `type` modifier
+    // is preserved per-specifier rather than hoisted to the declaration.
+    {
+      code: `import { type CacheHandler, recordIdentifierFor } from '@ember-data/store';`,
+      output: `import { type CacheHandler, recordIdentifierFor } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
   ],
 });


### PR DESCRIPTION
resolves #10399 

the linked issue had already been fixed by other lint fixes, but investigating turned up that we weren't handling type-only imports as well as we should.

<!-- AUTO-GENERATED SUMMARY -->

