### PR TITLE
fix: account for * re-exports in lint map

### DIFF
--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.js
@@ -7,6 +7,7 @@
 const path = require('path');
 
 const RULE_ID = 'warp-drive.no-legacy-imports';
+const UNMAPPED_EXPORT_ID = 'warp-drive.no-legacy-imports.unmapped-export';
 
 // TODO: determine where this thing should live long-term
 function buildMapping() {
@@ -35,24 +36,50 @@ function buildMapping() {
    * (possibly renamed, possibly default<->named) export to use from it.
    */
   const lookup = new Map();
+  // All legacy module specifiers we have any bookkeeping for at all, whether or not
+  // every export of theirs has a known replacement yet.
+  const knownModules = new Set();
+  // module -> Set<replacement module>, used to derive a fallback below.
+  const moduleTargets = new Map();
 
   if (Array.isArray(mappingArray)) {
     for (const entry of mappingArray) {
-      // Only consider non-type exports and entries that have a clear replacement
-      if (!entry || entry.typeOnly) continue;
-      const srcMod = entry.module;
-      const exp = entry.export;
+      if (!entry || !entry.module || !entry.export) continue;
+      knownModules.add(entry.module);
+
       const replModule = entry.replacement && entry.replacement.module;
       const replExport = entry.replacement && entry.replacement.export;
-      if (!srcMod || !exp || !replModule || !replExport) continue;
-      lookup.set(`${srcMod}::${exp}`, { module: replModule, export: replExport });
+      if (!replModule || !replExport) continue;
+
+      lookup.set(`${entry.module}::${entry.export}`, { module: replModule, export: replExport });
+
+      let targets = moduleTargets.get(entry.module);
+      if (!targets) {
+        targets = new Set();
+        moduleTargets.set(entry.module, targets);
+      }
+      targets.add(replModule);
     }
   }
 
-  return lookup;
+  // A module-level fallback: only safe when every export we know about for a given
+  // legacy module funnels into the exact same replacement module. This lets us route
+  // exports added since the mapping was last generated (e.g. new types exposed via
+  // `export *`) without having to enumerate every token by name. Modules that
+  // legitimately split across multiple replacement modules (e.g. some tokens go to
+  // `@warp-drive/core`, others to `@warp-drive/ember`) are left out on purpose —
+  // guessing wrong there would silently produce an incorrect rewrite.
+  const moduleFallback = new Map();
+  for (const [mod, targets] of moduleTargets) {
+    if (targets.size === 1) {
+      moduleFallback.set(mod, [...targets][0]);
+    }
+  }
+
+  return { lookup, moduleFallback, knownModules };
 }
 
-const MAPPING = buildMapping();
+const { lookup: MAPPING, moduleFallback: MODULE_FALLBACK, knownModules: KNOWN_MODULES } = buildMapping();
 
 /** @param {import('eslint').Rule.RuleContext} context */
 function createHelpers(context) {
@@ -72,7 +99,7 @@ function createHelpers(context) {
   }
 
   /**
-   * @typedef {{ spec: any, originalExportName: string | null, targetExportName: string | null, isType: boolean }} SpecifierDescriptor
+   * @typedef {{ spec: any, originalExportName: string | null, targetExportName: string | null, isType: boolean, unresolved: boolean }} SpecifierDescriptor
    */
 
   /** @returns {Record<string, SpecifierDescriptor[]>} */
@@ -86,14 +113,33 @@ function createHelpers(context) {
       if (!expName) {
         // namespace or unknown – keep under original module, verbatim
         groups[moduleName] ||= [];
-        groups[moduleName].push({ spec, originalExportName: null, targetExportName: null, isType });
+        groups[moduleName].push({ spec, originalExportName: null, targetExportName: null, isType, unresolved: false });
         continue;
       }
+
       const target = MAPPING.get(`${moduleName}::${expName}`);
-      const targetModule = target ? target.module : moduleName; // unknowns remain under original module
-      const targetExportName = target ? target.export : expName; // unknowns keep their own export name
+      let targetModule = moduleName;
+      let targetExportName = expName;
+      let unresolved = false;
+
+      if (target) {
+        targetModule = target.module;
+        targetExportName = target.export;
+      } else {
+        const fallbackModule = MODULE_FALLBACK.get(moduleName);
+        if (fallbackModule) {
+          // Not individually tracked, but this legacy module's known exports all funnel
+          // into a single replacement module, so route this one the same way.
+          targetModule = fallbackModule;
+        } else if (KNOWN_MODULES.has(moduleName)) {
+          // We actively track this legacy module but have no idea where this particular
+          // export goes (added after the mapping was generated, or genuinely ambiguous).
+          unresolved = true;
+        }
+      }
+
       groups[targetModule] ||= [];
-      groups[targetModule].push({ spec, originalExportName: expName, targetExportName, isType });
+      groups[targetModule].push({ spec, originalExportName: expName, targetExportName, isType, unresolved });
     }
     return groups;
   }
@@ -105,6 +151,16 @@ function createHelpers(context) {
       // (e.g. default -> a named export, or a named export -> a different name).
       return groups[mod].some((d) => d.originalExportName && d.targetExportName !== d.originalExportName);
     });
+  }
+
+  function collectUnresolvedExportNames(groups) {
+    const names = [];
+    for (const mod of Object.keys(groups)) {
+      for (const d of groups[mod]) {
+        if (d.unresolved) names.push(d.originalExportName);
+      }
+    }
+    return names;
   }
 
   function buildSpecifierText(descriptor) {
@@ -152,6 +208,7 @@ function createHelpers(context) {
     getQuoteChar,
     groupImportSpecifiersByTarget,
     hasAnyMappedTarget,
+    collectUnresolvedExportNames,
     buildImportTextForGroup,
   };
 }
@@ -170,6 +227,9 @@ module.exports = {
     },
     messages: {
       [RULE_ID]: 'Rewrite import from "{{from}}" to modern modules.',
+      [UNMAPPED_EXPORT_ID]:
+        'Import{{plural}} "{{tokens}}" from legacy module "{{from}}" ha{{pluralVerb}} no known modern replacement yet. ' +
+        'This import was left as-is and needs manual migration.',
     },
   },
 
@@ -183,28 +243,47 @@ module.exports = {
 
       const groups = helpers.groupImportSpecifiersByTarget(fromModule, node.specifiers, declarationIsTypeOnly);
       const hasMapped = helpers.hasAnyMappedTarget(groups, fromModule);
-      if (!hasMapped) return;
+      const unresolvedNames = helpers.collectUnresolvedExportNames(groups);
 
-      const groupKeys = Object.keys(groups);
+      if (!hasMapped && !unresolvedNames.length) return;
+
       const quote = helpers.getQuoteChar(node);
 
-      // Rebuild every group's specifier text from scratch (rather than only swapping the
-      // module string) since a replacement export may differ in name and/or default-vs-named
-      // kind from the original specifier.
-      context.report({
-        node,
-        messageId: RULE_ID,
-        data: { kind: 'import', from: fromModule },
-        fix(fixer) {
-          const pieces = [];
-          for (const mod of groupKeys) {
-            const text = helpers.buildImportTextForGroup(mod, groups[mod], quote);
-            if (text) pieces.push(text);
-          }
-          const replacement = pieces.join('\n');
-          return fixer.replaceText(node, replacement);
-        },
-      });
+      if (hasMapped) {
+        const groupKeys = Object.keys(groups);
+        // Rebuild every group's specifier text from scratch (rather than only swapping the
+        // module string) since a replacement export may differ in name and/or default-vs-named
+        // kind from the original specifier.
+        context.report({
+          node,
+          messageId: RULE_ID,
+          data: { kind: 'import', from: fromModule },
+          fix(fixer) {
+            const pieces = [];
+            for (const mod of groupKeys) {
+              const text = helpers.buildImportTextForGroup(mod, groups[mod], quote);
+              if (text) pieces.push(text);
+            }
+            const replacement = pieces.join('\n');
+            return fixer.replaceText(node, replacement);
+          },
+        });
+      }
+
+      if (unresolvedNames.length) {
+        // No fixer: we don't know where these tokens belong, so flag them for a human
+        // instead of silently leaving the legacy import in place.
+        context.report({
+          node,
+          messageId: UNMAPPED_EXPORT_ID,
+          data: {
+            from: fromModule,
+            tokens: unresolvedNames.join(', '),
+            plural: unresolvedNames.length > 1 ? 's' : '',
+            pluralVerb: unresolvedNames.length > 1 ? 've' : 's',
+          },
+        });
+      }
     }
 
     return {

--- a/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-legacy-imports.md
@@ -38,6 +38,21 @@ import { findRecord } from '@warp-drive/utilities/rest';
 - Namespace imports, export-all (`export * from`), re-exports with `from`, CommonJS `require`,
   and dynamic imports are out of scope for v1 (no report).
 
+## Unmapped exports
+
+The embedded mapping is a point-in-time snapshot; it doesn't automatically pick up exports
+added afterward. Rather than silently leaving such an import untouched:
+
+- If every export we've ever tracked for a legacy module funnels into the same replacement
+  module, an untracked token from that module is routed there too (same export name, no
+  guessing at a rename).
+- If a legacy module is known but its tracked exports funnel into more than one replacement
+  module (e.g. some tokens move to `@warp-drive/core`, others to `@warp-drive/ember`), an
+  untracked token from it can't be routed safely. It is reported without an autofix so it
+  gets manual attention instead of being silently skipped.
+- Imports from modules this rule has no bookkeeping for at all (e.g. third-party packages)
+  are still ignored entirely, as before.
+
 ## Notes
 
 - Deduplication of existing imports from a replacement module is not performed in v1.

--- a/packages/eslint-plugin-warp-drive/tests/no-legacy-imports.js
+++ b/packages/eslint-plugin-warp-drive/tests/no-legacy-imports.js
@@ -19,6 +19,7 @@ const eslintTester = new RuleTester({
 });
 
 const msg = 'warp-drive.no-legacy-imports';
+const unmappedMsg = 'warp-drive.no-legacy-imports.unmapped-export';
 
 // Note: These tests depend on the monorepo having a mapping entry for the given module/export.
 // We select cases present in public-exports-mapping-5.5.enriched.json.
@@ -55,10 +56,12 @@ eslintTester.run('no-legacy-imports', rule, {
       output: `import Model from '@warp-drive/legacy/model';`,
       errors: [{ messageId: msg }],
     },
-    // Mixed specifiers split: some known, some unknown (stay at original)
+    // A token with no per-export mapping entry ("Unknown") is still routed to
+    // '@warp-drive/legacy/model' via the module-level fallback (regression for #10394),
+    // since every other known export of '@ember-data/model' funnels there too.
     {
       code: `import Model, { hasMany, Unknown } from '@ember-data/model';`,
-      output: `import Model, { hasMany } from '@warp-drive/legacy/model';\nimport { Unknown } from '@ember-data/model';`,
+      output: `import Model, { hasMany, Unknown } from '@warp-drive/legacy/model';`,
       errors: [{ messageId: msg }],
     },
     // Default import whose replacement is a named export must be rewritten to a
@@ -84,6 +87,29 @@ eslintTester.run('no-legacy-imports', rule, {
       code: `import Store from '@ember-data/store';`,
       output: `import { Store } from '@warp-drive/core';`,
       errors: [{ messageId: msg }],
+    },
+    // Type-only exports (interfaces/type aliases) are now tracked too, not just value
+    // exports (regression for #10394 — "we added exports, mostly types").
+    {
+      code: `import { CachePolicy } from '@ember-data/store';`,
+      output: `import { CachePolicy } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
+    // A token never individually recorded in the mapping is routed via the module-level
+    // fallback, since every known export of '@ember-data/store' funnels into
+    // '@warp-drive/core' (regression for #10394).
+    {
+      code: `import { TotallyMadeUpExportName } from '@ember-data/store';`,
+      output: `import { TotallyMadeUpExportName } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
+    // '@ember-data/request' legitimately splits across two replacement modules
+    // (RequestManager -> '@warp-drive/core', others -> '@warp-drive/ember'), so an
+    // unrecognized token from it has no safe fallback and is flagged instead of guessed
+    // (regression for #10394 — "we don't error ... we should").
+    {
+      code: `import { TotallyMadeUpExportName } from '@ember-data/request';`,
+      errors: [{ messageId: unmappedMsg }],
     },
   ],
 });
@@ -119,6 +145,14 @@ tsTester.run('no-legacy-imports (type-only imports)', rule, {
     {
       code: `import { type CacheHandler, recordIdentifierFor } from '@ember-data/store';`,
       output: `import { type CacheHandler, recordIdentifierFor } from '@warp-drive/core';`,
+      errors: [{ messageId: msg }],
+    },
+    // A type-only-declared export (an interface, tracked with typeOnly: true in the
+    // mapping data) is now rewritten too, combined with `import type` preservation
+    // (regression for #10394).
+    {
+      code: `import type { CachePolicy } from '@ember-data/store';`,
+      output: `import type { CachePolicy } from '@warp-drive/core';`,
       errors: [{ messageId: msg }],
     },
   ],


### PR DESCRIPTION
Closes #10394

`no-legacy-imports` only knew about exports that were individually enumerated in a point-in-time mapping snapshot. Exports added since — mostly types, often exposed only via `export *` — had no entry, so imports of them were silently left untouched instead of being rewritten or flagged.

- Type-only exports (interfaces/type aliases) were previously excluded from the mapping lookup wholesale; they're now tracked like any other export.
- When every export we've ever tracked for a legacy module funnels into the same replacement module, an untracked token from that module is now routed there too via a module-level fallback, instead of requiring every export to be enumerated one-by-one.
- When a legacy module is known but genuinely ambiguous (its tracked exports split across more than one replacement module) and a token can't be resolved either way, the import is now reported — without an autofix — so it gets manual attention instead of being silently skipped.

Verified against the two real apps that enable this rule (`tests/legacy`, `tests/core`) — no new lint findings introduced.
