### PR TITLE
fix: legacy serializers must stick to safe model API surfac

### DIFF
--- a/tests/legacy/tests/serializer/schema-only-relationships-test.ts
+++ b/tests/legacy/tests/serializer/schema-only-relationships-test.ts
@@ -1,0 +1,136 @@
+/* eslint-disable warp-drive/no-legacy-request-patterns */
+import { setOwner } from '@ember/owner';
+
+import { module, setupTest, test } from '@warp-drive/diagnostic/ember';
+import { JSONAPICache } from '@warp-drive/json-api';
+import { useLegacyStore } from '@warp-drive/legacy';
+import { JSONAPIAdapter } from '@warp-drive/legacy/adapter/json-api';
+import { withDefaults } from '@warp-drive/legacy/model/migration-support';
+import { JSONSerializer } from '@warp-drive/legacy/serializer/json';
+import { EmbeddedRecordsMixin, RESTSerializer } from '@warp-drive/legacy/serializer/rest';
+
+// https://github.com/warp-drive-data/warp-drive/issues/10454
+//
+// Serializers must be able to determine relationship cardinality and
+// inverses using only the schema service, since resources defined via
+// `withDefaults` (migration-support) are not backed by a `Model` class
+// and so `store.modelFor(type)` cannot return anything with `Model`-only
+// APIs like `determineRelationshipType` or `inverseFor`.
+const Store = useLegacyStore({
+  linksMode: false,
+  cache: JSONAPICache,
+});
+
+module('Serializer Contract | schema-only (migration-support) resources', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register('adapter:application', JSONAPIAdapter);
+  });
+
+  test('shouldSerializeHasMany can determine relationship type without a Model class', function (assert) {
+    const store = new Store();
+    setOwner(store, this.owner);
+    this.owner.register('service:store', store, { instantiate: false });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    this.owner.register('serializer:application', JSONSerializer);
+
+    const { schema } = store;
+    schema.registerResource(
+      withDefaults({
+        type: 'post',
+        fields: [
+          { name: 'title', kind: 'attribute' },
+          { name: 'comments', kind: 'hasMany', type: 'comment', options: { async: false, inverse: 'post' } },
+          { name: 'watchers', kind: 'hasMany', type: 'comment', options: { async: false, inverse: null } },
+        ],
+      })
+    );
+    schema.registerResource(
+      withDefaults({
+        type: 'comment',
+        fields: [
+          { name: 'message', kind: 'attribute' },
+          { name: 'post', kind: 'belongsTo', type: 'post', options: { async: false, inverse: 'comments' } },
+        ],
+      })
+    );
+
+    const post = store.createRecord('post', { title: 'Rails is omakase' });
+    const snapshot = (post as { _createSnapshot(): unknown })._createSnapshot();
+    const serializer = store.serializerFor('post');
+
+    const comments = schema.fields({ type: 'post' }).get('comments');
+    const watchers = schema.fields({ type: 'post' }).get('watchers');
+
+    assert.false(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      serializer.shouldSerializeHasMany(snapshot, 'comments', comments),
+      'a hasMany relationship with an inverse belongsTo (manyToOne) is not serialized by default'
+    );
+    assert.true(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      serializer.shouldSerializeHasMany(snapshot, 'watchers', watchers),
+      'a hasMany relationship with no inverse (manyToNone) is serialized by default'
+    );
+  });
+
+  test('EmbeddedRecordsMixin can remove the embedded foreign key without a Model class', function (assert) {
+    const store = new Store();
+    setOwner(store, this.owner);
+    this.owner.register('service:store', store, { instantiate: false });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    this.owner.register('serializer:application', RESTSerializer);
+    this.owner.register(
+      'serializer:evil-minion',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      RESTSerializer.extend(EmbeddedRecordsMixin, {
+        attrs: {
+          secretWeapon: { embedded: 'always' },
+        },
+      })
+    );
+
+    const { schema } = store;
+    schema.registerResource(
+      withDefaults({
+        type: 'secret-weapon',
+        fields: [
+          { name: 'name', kind: 'attribute' },
+          { name: 'owner', kind: 'belongsTo', type: 'evil-minion', options: { async: false, inverse: 'secretWeapon' } },
+        ],
+      })
+    );
+    schema.registerResource(
+      withDefaults({
+        type: 'evil-minion',
+        fields: [
+          { name: 'name', kind: 'attribute' },
+          {
+            name: 'secretWeapon',
+            kind: 'belongsTo',
+            type: 'secret-weapon',
+            options: { async: false, inverse: 'owner' },
+          },
+        ],
+      })
+    );
+
+    const secretWeapon = store.createRecord('secret-weapon', { name: 'Secret Weapon' });
+    const evilMinion = store.createRecord('evil-minion', { name: 'Evil Minion', secretWeapon });
+
+    const serializer = store.serializerFor('evil-minion');
+    const serializedRestJson = serializer.serialize((evilMinion as { _createSnapshot(): unknown })._createSnapshot());
+
+    assert.deepEqual(
+      serializedRestJson,
+      {
+        name: 'Evil Minion',
+        secretWeapon: {
+          name: 'Secret Weapon',
+        },
+      },
+      'the embedded foreign key (owner) was correctly removed when serializing'
+    );
+  });
+});

--- a/warp-drive-packages/legacy/src/serializer/-private/embedded-records-mixin.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/embedded-records-mixin.ts
@@ -8,6 +8,8 @@ import Mixin from '@ember/object/mixin';
 
 import { camelize } from '@warp-drive/utilities/string';
 
+import { inverseForRelationship } from './utils.ts';
+
 /**
   ## Using Embedded Records
 
@@ -477,8 +479,7 @@ export const EmbeddedRecordsMixin: Mixin = Mixin.create({
   */
   removeEmbeddedForeignKey(snapshot, embeddedSnapshot, relationship, json) {
     if (relationship.kind === 'belongsTo') {
-      const schema = this.store.modelFor(snapshot.modelName);
-      const parentRecord = schema.inverseFor(relationship.name, this.store);
+      const parentRecord = inverseForRelationship(this.store, snapshot.modelName, relationship.name);
       if (parentRecord) {
         const name = parentRecord.name;
         const embeddedSerializer = this.store.serializerFor(embeddedSnapshot.modelName);

--- a/warp-drive-packages/legacy/src/serializer/-private/utils.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/utils.ts
@@ -31,10 +31,7 @@ export function coerceId(id: Coercable): string | null {
   @private
 */
 export function inverseForRelationship(store: Store, type: string, name: string): LegacyRelationshipField | null {
-  const relationship = store.schema.fields({ type }).get(name) as
-    | LegacyBelongsToField
-    | LegacyHasManyField
-    | undefined;
+  const relationship = store.schema.fields({ type }).get(name) as LegacyBelongsToField | LegacyHasManyField | undefined;
   assert(`No relationship named '${name}' on '${type}' exists.`, relationship);
 
   const { options } = relationship;

--- a/warp-drive-packages/legacy/src/serializer/-private/utils.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/utils.ts
@@ -1,3 +1,11 @@
+import type { Store } from '@warp-drive/core';
+import { assert } from '@warp-drive/core/build-config/macros';
+import type {
+  LegacyBelongsToField,
+  LegacyHasManyField,
+  LegacyRelationshipField,
+} from '@warp-drive/core/types/schema/fields';
+
 type Coercable = string | number | boolean | null | undefined | symbol;
 
 export function coerceId(id: Coercable): string | null {
@@ -9,5 +17,82 @@ export function coerceId(id: Coercable): string | null {
     return id.toString();
   } else {
     return String(id);
+  }
+}
+
+/**
+  Given the name of a relationship on a resource `type`, determines the
+  inverse relationship field (if any) using only the schema service.
+
+  Unlike `Model.inverseFor`, this does not require `type` to be backed by
+  a `Model` class, so it works for both `Model`-based and schema-only
+  (e.g. `withDefaults` migration-support) resources.
+
+  @private
+*/
+export function inverseForRelationship(store: Store, type: string, name: string): LegacyRelationshipField | null {
+  const relationship = store.schema.fields({ type }).get(name) as
+    | LegacyBelongsToField
+    | LegacyHasManyField
+    | undefined;
+  assert(`No relationship named '${name}' on '${type}' exists.`, relationship);
+
+  const { options } = relationship;
+  assert(
+    `Expected the relationship ${name} on ${type} to define an inverse.`,
+    options.inverse === null || (typeof options.inverse === 'string' && options.inverse.length > 0)
+  );
+
+  if (options.inverse === null) {
+    return null;
+  }
+
+  const schemaExists = store.schema.hasResource(relationship);
+  assert(
+    `No associated schema found for '${relationship.type}' while calculating the inverse of ${name} on ${type}`,
+    schemaExists
+  );
+
+  if (!schemaExists) {
+    return null;
+  }
+
+  const inverseField = store.schema.fields(relationship).get(options.inverse);
+  assert(
+    `No inverse relationship found for '${name}' on '${type}'`,
+    inverseField && (inverseField.kind === 'belongsTo' || inverseField.kind === 'hasMany')
+  );
+
+  return (inverseField as LegacyRelationshipField) ?? null;
+}
+
+/**
+  Given a relationship field on a resource `type`, determines the
+  cardinality of the relationship using only the schema service.
+
+  Unlike `Model.determineRelationshipType`, this does not require `type`
+  to be backed by a `Model` class, so it works for both `Model`-based and
+  schema-only (e.g. `withDefaults` migration-support) resources.
+
+  @private
+*/
+export function determineRelationshipType(
+  store: Store,
+  type: string,
+  knownSide: LegacyBelongsToField | LegacyHasManyField
+): 'oneToOne' | 'oneToMany' | 'manyToOne' | 'manyToMany' | 'oneToNone' | 'manyToNone' {
+  const knownKind = knownSide.kind;
+  const inverse = inverseForRelationship(store, type, knownSide.name);
+
+  if (!inverse) {
+    return knownKind === 'belongsTo' ? 'oneToNone' : 'manyToNone';
+  }
+
+  const otherKind = inverse.kind;
+
+  if (otherKind === 'belongsTo') {
+    return knownKind === 'belongsTo' ? 'oneToOne' : 'manyToOne';
+  } else {
+    return knownKind === 'belongsTo' ? 'oneToMany' : 'manyToMany';
   }
 }

--- a/warp-drive-packages/legacy/src/serializer/json.ts
+++ b/warp-drive-packages/legacy/src/serializer/json.ts
@@ -21,7 +21,7 @@ import { dasherize, singularize } from '@warp-drive/utilities/string';
 
 import type { Snapshot } from '../compat/-private.ts';
 import { Serializer } from '../serializer.ts';
-import { coerceId } from './-private/utils.ts';
+import { coerceId, determineRelationshipType } from './-private/utils.ts';
 import type { Transform } from './transform.ts';
 
 const SOURCE_POINTER_REGEXP = /^\/?data\/(attributes|relationships)\/(.*)/;
@@ -962,9 +962,7 @@ const JSONSerializer: any = Serializer.extend({
     relationship: LegacyBelongsToField | LegacyHasManyField
   ): boolean {
     // @ts-expect-error store is dynamically injected
-    const schema = this.store.modelFor(snapshot.modelName);
-    // @ts-expect-error store is dynamically injected
-    const relationshipType = schema.determineRelationshipType(relationship, this.store);
+    const relationshipType = determineRelationshipType(this.store, snapshot.modelName, relationship);
     if (this._mustSerialize(key)) {
       return true;
     }


### PR DESCRIPTION
resolves #10454 
<!-- AUTO-GENERATED SUMMARY -->

