### PR TITLE
fix: correct mismatched jsdoc @param names in typedoc comments

### DIFF
--- a/warp-drive-packages/legacy/src/compat/builders/find-all.ts
+++ b/warp-drive-packages/legacy/src/compat/builders/find-all.ts
@@ -30,7 +30,6 @@ type FindAllBuilderOptions = FindAllOptions;
   @deprecated
   @public
   @param type the name of the resource
-  @param query a query to be used by the adapter
   @param options optional, may include `adapterOptions` hash which will be passed to adapter.findAll
   @return request config
 */

--- a/warp-drive-packages/legacy/src/model/-private/model.ts
+++ b/warp-drive-packages/legacy/src/model/-private/model.ts
@@ -363,9 +363,9 @@ interface Model {
     for a given relationship will always return the same HasManyReference.
 
     @public
-    @param {String} prop the name of the relationship
+    @param prop - the name of the relationship
     @since 2.5.0
-    @return {BelongsToReference} reference for this relationship
+    @return reference for this relationship
   */
   belongsTo<T extends Model, K extends keyof T & string>(
     this: T,
@@ -417,9 +417,9 @@ interface Model {
     for a given relationship will always return the same HasManyReference.
 
     @public
-    @param {String} prop the name of the relationship
+    @param prop - the name of the relationship
     @since 2.5.0
-    @return {HasManyReference} reference for this relationship
+    @return reference for this relationship
   */
   hasMany<T extends MinimalLegacyRecord, K extends MaybeHasManyFields<T>>(this: T, prop: K): HasManyReference<T, K>;
 

--- a/warp-drive-packages/legacy/src/model/-private/model.ts
+++ b/warp-drive-packages/legacy/src/model/-private/model.ts
@@ -363,7 +363,7 @@ interface Model {
     for a given relationship will always return the same HasManyReference.
 
     @public
-    @param {String} name of the relationship
+    @param {String} prop the name of the relationship
     @since 2.5.0
     @return {BelongsToReference} reference for this relationship
   */
@@ -417,7 +417,7 @@ interface Model {
     for a given relationship will always return the same HasManyReference.
 
     @public
-    @param {String} name of the relationship
+    @param {String} prop the name of the relationship
     @since 2.5.0
     @return {HasManyReference} reference for this relationship
   */

--- a/warp-drive-packages/legacy/src/serializer.ts
+++ b/warp-drive-packages/legacy/src/serializer.ts
@@ -263,7 +263,7 @@ export class Serializer extends EmberObject {
     ```
 
     @public
-    @param {Model} typeClass
+    @param {Model} _typeClass
     @param {Object} hash
     @return {Object}
   */

--- a/warp-drive-packages/legacy/src/serializer.ts
+++ b/warp-drive-packages/legacy/src/serializer.ts
@@ -263,9 +263,9 @@ export class Serializer extends EmberObject {
     ```
 
     @public
-    @param {Model} _typeClass
-    @param {Object} hash
-    @return {Object}
+    @param _typeClass - the model class the hash is being normalized for
+    @param hash - the raw payload hash to normalize
+    @return the normalized resource document
   */
   normalize(_typeClass: ModelSchema, hash: Record<string, unknown>): SingleResourceDocument | EmptyResourceDocument {
     return hash as unknown as SingleResourceDocument;

--- a/warp-drive-packages/utilities/src/-private/json-api/query.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/query.ts
@@ -139,9 +139,9 @@ export function query(
  * ```
  *
  * @public
- * @param type
- * @param query
- * @param options
+ * @param type - the name of the resource type to query
+ * @param query - the query params to send with the request
+ * @param options - options to modify the request behavior
  */
 export function postQuery<T>(
   type: TypeFromInstance<T>,

--- a/warp-drive-packages/utilities/src/-private/json-api/query.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/query.ts
@@ -139,7 +139,7 @@ export function query(
  * ```
  *
  * @public
- * @param identifier
+ * @param type
  * @param query
  * @param options
  */

--- a/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
@@ -33,8 +33,8 @@ export type JsonApiResourcePatch =
  * Serializes the current state of a resource or array of resources for use with POST or PUT requests.
  *
  * @public
- * @param {Cache} cache}
- * @param {ResourceKey} identifier
+ * @param {Cache} cache
+ * @param {ResourceKey} identifiers
  * @return {Object} An object with a `data` property containing the serialized resource patch
  */
 export function serializeResources(cache: Cache, identifiers: ResourceKey): { data: ResourceObject };
@@ -134,7 +134,7 @@ function _serializeResource(cache: Cache, identifier: ResourceKey): ResourceObje
  * ```
  *
  * @public
- * @param {Cache} cache}
+ * @param {Cache} cache
  * @param {ResourceKey} identifier
  * @return {Object} An object with a `data` property containing the serialized resource patch
  */

--- a/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
@@ -33,9 +33,9 @@ export type JsonApiResourcePatch =
  * Serializes the current state of a resource or array of resources for use with POST or PUT requests.
  *
  * @public
- * @param {Cache} cache
- * @param {ResourceKey} identifiers
- * @return {Object} An object with a `data` property containing the serialized resource patch
+ * @param cache - the cache to serialize the resource(s) from
+ * @param identifiers - the resource(s) to serialize
+ * @return an object with a `data` property containing the serialized resource(s)
  */
 export function serializeResources(cache: Cache, identifiers: ResourceKey): { data: ResourceObject };
 export function serializeResources(cache: Cache, identifiers: ResourceKey[]): { data: ResourceObject[] };
@@ -134,9 +134,9 @@ function _serializeResource(cache: Cache, identifier: ResourceKey): ResourceObje
  * ```
  *
  * @public
- * @param {Cache} cache
- * @param {ResourceKey} identifier
- * @return {Object} An object with a `data` property containing the serialized resource patch
+ * @param cache - the cache to serialize the resource's changes from
+ * @param identifier - the resource whose changes should be serialized
+ * @return an object with a `data` property containing the serialized resource patch
  */
 export function serializePatch(
   cache: Cache,


### PR DESCRIPTION
## Summary
- Running `pnpm exec typedoc` for the API docs build surfaces a batch of warnings pointing at a handful of small jsdoc mistakes in source comments. This fixes the unambiguous ones:
  - `serializeResources`/`serializePatch` had a stray trailing `}` after `{Cache} cache`, and `serializeResources`'s `@param` named the argument `identifier` when the real parameter is `identifiers`.
  - `postQuery`'s first `@param` was named `identifier` when the real parameter is `type`.
  - `Model#belongsTo`/`Model#hasMany` `@param {String} name of the relationship` didn't name the actual parameter (`prop`).
  - `findAllBuilder` documented a `query` param that doesn't exist on the current signature.
  - `Serializer#normalize` documented `typeClass` but the actual parameter is `_typeClass`.

Part of #10359.

## Test plan
- [x] `pnpm exec typedoc` (from `docs-viewer/`) no longer emits the specific "@param ... was not used" / broken-link warnings for these signatures.