### PR TITLE
docs: update relational-data guides off @ember-data/model, fix EmberData typos

### DIFF
--- a/guides/the-manual/relational-data/configuration/many-to-many.md
+++ b/guides/the-manual/relational-data/configuration/many-to-many.md
@@ -47,14 +47,14 @@ For an example of a non-bidirectional relationship of this sort, it might be tha
 
 Head over to [many-to-none](./many-to-none.md) if this is the setup that is best for you. Else, here's how we can define such a relationship via various mechanisms.
 
-- [Using @ember-data/model](#using-ember-datamodel)
+- [Using @warp-drive/legacy/model](#using-warp-drivelegacymodel)
 - [Using json schemas](#using-json-schemas)
 - [🚧 Using @warp-drive/schema-record](#using-warp-driveschema-record-🚧-coming-soon)
   - [Legacy Compat Mode](#legacycompat-mode)
 
 ---
 
-## Using `@ember-data/model`
+## Using `@warp-drive/legacy/model`
 
 > **Note** Models are currently the primary way that users of WarpDrive define "schema".
 >
@@ -66,13 +66,13 @@ converting static information defined on the class into the json
 schema format needed by the rest of the system.
 
 This is handled by the implementation of the [SchemaService](/api/@warp-drive/core/types/schema/schema-service/interfaces/SchemaService) provided
-by the `@ember-data/model` package. The service converts the class
+by the `@warp-drive/legacy/model` package. The service converts the class
 definitions into the json definitions described in the next section.
 
 🌲 *TrailRunner*
 
 ```ts
-import Model, { hasMany } from '@ember-data/model';
+import Model, { hasMany } from '@warp-drive/legacy/model';
 
 export default class TrailRunner extends Model {
   @hasMany('trail-runner', { inverse: 'friends', async: false })
@@ -83,7 +83,7 @@ export default class TrailRunner extends Model {
 Note, the [many-to-none](./many-to-none.md) variation of this would be:
 
 ```ts
-import Model, { hasMany } from '@ember-data/model';
+import Model, { hasMany } from '@warp-drive/legacy/model';
 
 export default class TrailRunner extends Model {
   @hasMany('trail-runner', { inverse: null, async: false })
@@ -190,7 +190,7 @@ export class TrailRunner {
 
 ### LegacyCompat Mode
 
-Support for migrating from `@ember-data/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
+Support for migrating from `@warp-drive/legacy/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
 and adopting other features of schemas sooner.
 
 🌲 *TrailRunner*

--- a/guides/the-manual/relational-data/configuration/many-to-none.md
+++ b/guides/the-manual/relational-data/configuration/many-to-none.md
@@ -15,14 +15,14 @@ Often `ManyToNone` is used for exactly this sort of case, where conceptually the
 
 Here's how we can define such a relationship via various mechanisms.
 
-- [Using @ember-data/model](#using-ember-datamodel)
+- [Using @warp-drive/legacy/model](#using-warp-drivelegacymodel)
 - [Using json schemas](#using-json-schemas)
 - [🚧 Using @warp-drive/schema-record](#using-warp-driveschema-record-🚧-coming-soon)
   - [Legacy Compat Mode](#legacycompat-mode)
 
 ---
 
-## Using `@ember-data/model`
+## Using `@warp-drive/legacy/model`
 
 > **Note** Models are currently the primary way that users of WarpDrive define "schema".
 >
@@ -34,13 +34,13 @@ converting static information defined on the class into the json
 schema format needed by the rest of the system.
 
 This is handled by the implementation of the [SchemaService](/api/@warp-drive/core/types/schema/schema-service/interfaces/SchemaService) provided
-by the `@ember-data/model` package. The service converts the class
+by the `@warp-drive/legacy/model` package. The service converts the class
 definitions into the json definitions described in the next section.
 
 🏷️ *Hashtag*
 
 ```ts
-import Model, { attr } from '@ember-data/model';
+import Model, { attr } from '@warp-drive/legacy/model';
 
 export default class Hashtag extends Model {
   @attr name;
@@ -50,7 +50,7 @@ export default class Hashtag extends Model {
 🏃🏾‍♀️ *ActivityData*
 
 ```ts
-import Model, { hasMany } from '@ember-data/model';
+import Model, { hasMany } from '@warp-drive/legacy/model';
 
 export default class ActivityData extends Model {
   @hasMany('hashtag', { async: false, inverse: null })
@@ -135,7 +135,7 @@ export class ActivityData extends Model {
 
 ### LegacyCompat Mode
 
-Support for migrating from `@ember-data/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
+Support for migrating from `@warp-drive/legacy/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
 and adopting other features of schemas sooner.
 
 🏷️ *Hashtag*

--- a/guides/the-manual/relational-data/configuration/one-to-many.md
+++ b/guides/the-manual/relational-data/configuration/one-to-many.md
@@ -59,14 +59,14 @@ Second, it may be the case that runner is able to share the activity data with a
 
 Head over to [many-to-none](./many-to-none.md) and [one-to-none](./one-to-none.md) if this is the setup that is best for you. Else, here's how we can define such a relationship via various mechanisms.
 
-- [Using @ember-data/model](#using-ember-datamodel)
+- [Using @warp-drive/legacy/model](#using-warp-drivelegacymodel)
 - [Using json schemas](#using-json-schemas)
 - [🚧 Using @warp-drive/schema-record](#using-warp-driveschema-record-🚧-coming-soon)
   - [Legacy Compat Mode](#legacycompat-mode)
 
 ---
 
-## Using `@ember-data/model`
+## Using `@warp-drive/legacy/model`
 
 > **Note** Models are currently the primary way that users of WarpDrive define "schema".
 >
@@ -78,13 +78,13 @@ converting static information defined on the class into the json
 schema format needed by the rest of the system.
 
 This is handled by the implementation of the [SchemaService](/api/@warp-drive/core/types/schema/schema-service/interfaces/SchemaService) provided
-by the `@ember-data/model` package. The service converts the class
+by the `@warp-drive/legacy/model` package. The service converts the class
 definitions into the json definitions described in the next section.
 
 🏃🏾‍♀️ *ActivityData*
 
 ```ts
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { belongsTo } from '@warp-drive/legacy/model';
 
 export default class ActivityData extends Model {
   @belongsTo('trail-runner', { inverse: 'activities', async: false })
@@ -95,7 +95,7 @@ export default class ActivityData extends Model {
 🌲 *TrailRunner*
 
 ```ts
-import Model, { hasMany } from '@ember-data/model';
+import Model, { hasMany } from '@warp-drive/legacy/model';
 
 export default class TrailRunner extends Model {
   @hasMany('activity-data', { inverse: 'runner', async: false })
@@ -107,7 +107,7 @@ export default class TrailRunner extends Model {
 
 ## Using JSON Schemas
 
-EmberData doesn't care where your schemas come from, how they are authored,
+WarpDrive doesn't care where your schemas come from, how they are authored,
 or how you load them into the system so long as when it asks the [SchemaService](/api/@warp-drive/core/types/schema/schema-service/interfaces/SchemaService)
 for information it gets back field definitions in the right json shape.
 
@@ -206,7 +206,7 @@ export class TrailRunner {
 
 ### LegacyCompat Mode
 
-Support for migrating from `@ember-data/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
+Support for migrating from `@warp-drive/legacy/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
 and adopting other features of schemas sooner.
 
 🏃🏾‍♀️ *ActivityData*

--- a/guides/the-manual/relational-data/configuration/one-to-none.md
+++ b/guides/the-manual/relational-data/configuration/one-to-none.md
@@ -21,32 +21,32 @@ the ability to efficiently disassociate the record from relationships when it is
 
 Here's how we can define such a relationship via various mechanisms.
 
-- [Using @ember-data/model](#using-ember-datamodel)
+- [Using @warp-drive/legacy/model](#using-warp-drivelegacymodel)
 - [Using json schemas](#using-json-schemas)
 - [🚧 Using @warp-drive/schema-record](#using-warp-driveschema-record-🚧-coming-soon)
   - [Legacy Compat Mode](#legacycompat-mode)
 
 ---
 
-## Using `@ember-data/model`
+## Using `@warp-drive/legacy/model`
 
-> **Note** Models are currently the primary way that users of EmberData define "schema".
+> **Note** Models are currently the primary way that users of WarpDrive define "schema".
 >
 > Models are not the only way to define schema today, but they
 > are the most immediately available ergonomic way to do so.
 
-When using Models, EmberData parses schema from them at runtime,
+When using Models, WarpDrive parses schema from them at runtime,
 converting static information defined on the class into the json
 schema format needed by the rest of the system.
 
 This is handled by the implementation of the [SchemaService](/api/@warp-drive/core/types/schema/schema-service/interfaces/SchemaService) provided
-by the `@ember-data/model` package. The service converts the class
+by the `@warp-drive/legacy/model` package. The service converts the class
 definitions into the json definitions described in the next section.
 
 ⛰️ *Trail*
 
 ```ts
-import Model, { attr } from '@ember-data/model';
+import Model, { attr } from '@warp-drive/legacy/model';
 
 export default class Trail extends Model {
   @attr name;
@@ -56,7 +56,7 @@ export default class Trail extends Model {
 🌲 *TrailRunner*
 
 ```ts
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { belongsTo } from '@warp-drive/legacy/model';
 
 export default class TrailRunner extends Model {
   @belongsTo('trail', { inverse: null, async: false })
@@ -137,7 +137,7 @@ export class TrailRunner {
 
 ### LegacyCompat Mode
 
-Support for migrating from `@ember-data/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
+Support for migrating from `@warp-drive/legacy/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
 and adopting other features of schemas sooner.
 
 ⛰️ *Trail*

--- a/guides/the-manual/relational-data/configuration/one-to-one.md
+++ b/guides/the-manual/relational-data/configuration/one-to-one.md
@@ -58,14 +58,14 @@ graph LR;
 
 Head over to [one-to-none](./one-to-none.md) if this is the setup that is best for you. Else, here's how we can define such a relationship via various mechanisms.
 
-- [Using @ember-data/model](#using-ember-datamodel)
+- [Using @warp-drive/legacy/model](#using-warp-drivelegacymodel)
 - [Using json schemas](#using-json-schemas)
 - [🚧 Using @warp-drive/schema-record](#using-warp-driveschema-record-🚧-coming-soon)
   - [Legacy Compat Mode](#legacycompat-mode)
 
 ---
 
-## Using `@ember-data/model`
+## Using `@warp-drive/legacy/model`
 
 > **Note** Models are currently the primary way that users of WarpDrive define "schema".
 >
@@ -77,13 +77,13 @@ converting static information defined on the class into the json
 schema format needed by the rest of the system.
 
 This is handled by the implementation of the [SchemaService](/api/@warp-drive/core/types/schema/schema-service/interfaces/SchemaService) provided
-by the `@ember-data/model` package. The service converts the class
+by the `@warp-drive/legacy/model` package. The service converts the class
 definitions into the json definitions described in the next section.
 
 📸 *InstagramAccount*
 
 ```ts
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { belongsTo } from '@warp-drive/legacy/model';
 
 export default class InstagramAccount extends Model {
   @belongsTo('trail-runner', { inverse: 'instagram', async: false })
@@ -94,7 +94,7 @@ export default class InstagramAccount extends Model {
 🌲 *TrailRunner*
 
 ```ts
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { belongsTo } from '@warp-drive/legacy/model';
 
 export default class TrailRunner extends Model {
   @belongsTo('instagram-account', { inverse: 'runner', async: false })
@@ -203,7 +203,7 @@ export class TrailRunner {
 
 ### LegacyCompat Mode
 
-Support for migrating from `@ember-data/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
+Support for migrating from `@warp-drive/legacy/model` on a more granular basis is provided by decorators that preserve the semantics of the quirks of that class. This allows you to begin eliminating models
 and adopting other features of schemas sooner.
 
 📸 *InstagramAccount*

--- a/guides/the-manual/relational-data/features/polymorphism.md
+++ b/guides/the-manual/relational-data/features/polymorphism.md
@@ -90,7 +90,7 @@ ever encountered.
 So for instance, to implement our pets relationship using open polymorphism using `Model`:
 
 ```ts
-import Model, { hasMany } from '@ember-data/model';
+import Model, { hasMany } from '@warp-drive/legacy/model';
 
 export default class Human extends Model {
   @hasMany('abstract-pet', { async: false, inverse: null, polymorphic: true })
@@ -135,7 +135,7 @@ So for instance, to implement our pets relationship using closed polymorphism us
 
 
 ```ts
-import Model, { hasMany } from '@ember-data/model';
+import Model, { hasMany } from '@warp-drive/legacy/model';
 
 export default class Human extends Model {
   @hasMany('abstract-pet', { async: false, inverse: 'owner', polymorphic: true })
@@ -146,7 +146,7 @@ export default class Human extends Model {
 And on *every* model that can be a pet, this same relationship as shown below for cat:
 
 ```ts
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { belongsTo } from '@warp-drive/legacy/model';
 
 export default class Cat extends Model {
   @belongsTo('human', { async: false, inverse: 'pets', as: 'abstract-pet' })


### PR DESCRIPTION
## Summary
- `guides/the-manual/relational-data/configuration/{one-to-none,one-to-many,one-to-one,many-to-none,many-to-many}.md` and `guides/the-manual/relational-data/features/polymorphism.md` present `@ember-data/model` (a pre-v5 "(Legacy)" package) as "the" way to use `Model` today, including a heading titled `## Using \`@ember-data/model\``. The `Model` class's own source doc comment (`warp-drive-packages/legacy/src/model.ts`) says the current import is `@warp-drive/legacy/model`, so updated the heading (+ its TOC anchor), prose, and code samples accordingly.
- Left the "🚧 Coming Soon" `@warp-drive/schema-record` sections alone — those are explicitly marked unreleased/aspirational and out of scope here.
- Fixed a few stray "EmberData" mentions that should read "WarpDrive" — sibling guides already use "WarpDrive" for the identical sentences, so these were just copy-paste leftovers.

Part of #10359.