### PR TITLE
docs: fix stale package imports in links-mode guide

### DIFF
--- a/guides/the-manual/misc/links-mode.md
+++ b/guides/the-manual/misc/links-mode.md
@@ -134,7 +134,7 @@ Read on below for examples and nuances specific to Model vs ReactiveResource
 ### For a Relationship on a Model
 
 ```ts
-import Model, { belongsTo, hasMany } from '@ember-data/model';
+import Model, { belongsTo, hasMany } from '@warp-drive/legacy/model';
 
 export default class User extends Model {
   @belongsTo('address', {
@@ -153,7 +153,7 @@ This works for both `async` and `non-async` relationships and only changes the f
 ### For a ReactiveResource in LegacyMode
 
 ```ts
-import type { ResourceSchema } from '@warp-drive/core-types/schema/fields';
+import type { ResourceSchema } from '@warp-drive/core/types/schema/fields';
 
 const UserSchema = {
   type: 'user',
@@ -181,7 +181,7 @@ relationship defined on a Model.
 ### For a ReactiveResource in PolarisMode
 
 ```ts
-import type { ResourceSchema } from '@warp-drive/core-types/schema/fields';
+import type { ResourceSchema } from '@warp-drive/core/types/schema/fields';
 
 const UserSchema = {
   type: 'user',


### PR DESCRIPTION
## Summary
- `guides/the-manual/misc/links-mode.md` demonstrates LinksMode for both `Model` and `ReactiveResource` — neither example is migration/legacy-setup content, but the code samples still imported from the pre-v5 (Legacy) `@ember-data/model` and `@warp-drive/core-types` packages.
- Updated to `@warp-drive/legacy/model` and `@warp-drive/core/types/schema/fields`.

Part of #10359.