### PR TITLE
docs: fix stale @ember-data/* imports in request cookbook guides

### DIFF
--- a/guides/the-manual/cookbook/auth-handlers.md
+++ b/guides/the-manual/cookbook/auth-handlers.md
@@ -14,7 +14,7 @@ you might implement some common strategies.
 > **Note**
 > This example uses [Ember](https://emberjs.com/) for convenience.
 >
-> `@ember-data/request` works with raw javascript or any framework of your choosing.
+> `@warp-drive/core` works with raw javascript or any framework of your choosing.
 
 Many public APIs require authentication. A common pattern nowadays is the use of an `Authorization` header with a bearer token.
 
@@ -29,7 +29,8 @@ Authorization: Bearer <token>
 In WarpDrive we can create our own custom handler to add authentication header to all requests
 
 ```ts
-import type { Handler, NextFn, RequestContext } from '@ember-data/request';
+import type { Handler, NextFn } from '@warp-drive/core/request';
+import type { RequestContext } from '@warp-drive/core/types/request';
 
 const ourSecureToken = '<token>'
 export const AuthHandler: Handler = {
@@ -48,8 +49,7 @@ export const AuthHandler: Handler = {
 This handler would need to be added to the request manager configuration:
 
 ```ts
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { RequestManager, Fetch } from '@warp-drive/core';
 import { AuthHandler } from './auth-handler.ts'; // [!code focus]
 
 const manager = new RequestManager() // [!code focus]
@@ -68,7 +68,8 @@ Lets imagine we are using [Ember Simple Auth](https://github.com/simplabs/ember-
 
 ```ts
 import { service } from '@ember/service';
-import type { NextFn, RequestContext } from '@ember-data/request';
+import type { NextFn } from '@warp-drive/core/request';
+import type { RequestContext } from '@warp-drive/core/types/request';
 
 export class AuthHandler {
   @service session;
@@ -93,8 +94,7 @@ To use this handler we need to register it in our request manager service, but a
 **app/services/request-manager.js**
 
 ```ts
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { RequestManager, Fetch } from '@warp-drive/core';
 import { getOwner, setOwner } from '@ember/owner';
 import { AuthHandler } from './auth-handler.ts';
 
@@ -126,7 +126,7 @@ More information at [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 > **Note**
 > This example uses [Ember](https://emberjs.com/) for convenience.
 >
-> `@ember-data/request` works with raw javascript or any framework of your choosing.
+> `@warp-drive/core` works with raw javascript or any framework of your choosing.
 
 Some APIs require CSRF token to be sent with every request. This token is usually stored in a cookie and needs to be extracted from it.
 
@@ -139,7 +139,8 @@ X-CSRF-Token: <token>
 Usually this token is stored in a cookie, so we need to extract it from there. Also this token is usually sent only with `POST`, `PUT`, `PATCH` and `DELETE` requests. Let's create a handler that will do just that.
 
 ```ts
-import type { Handler, NextFn, RequestContext } from '@ember-data/request';
+import type { Handler, NextFn } from '@warp-drive/core/request';
+import type { RequestContext } from '@warp-drive/core/types/request';
 
 const MUTATION_OPS = new Set(['createRecord', 'updateRecord', 'deleteRecord']);
 export const AuthHandler: Handler = {
@@ -161,8 +162,7 @@ export const AuthHandler: Handler = {
 This handler would need to be added to request manager configuration:
 
 ```ts
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { RequestManager, Fetch } from '@warp-drive/core';
 import { AuthHandler } from './auth-handler.ts'; // [!code focus]
 
 const manager = new RequestManager() // [!code focus]

--- a/guides/the-manual/cookbook/basic-usage.md
+++ b/guides/the-manual/cookbook/basic-usage.md
@@ -6,7 +6,7 @@
 > This example uses [Ember](https://emberjs.com/)
 > for convenience.
 >
-> `@ember-data/request` works with raw javascript
+> `@warp-drive/core` works with raw javascript
 > or any framework of your choosing.
 
 Say you want to show a list of companies and their CEO. Your API returns a list of companies with the related employee records with a payload similar to the one shown below.
@@ -62,8 +62,7 @@ Lets see how we'd approach this request.
 *app/fetch.ts*
 
 ```ts
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { RequestManager, Fetch } from '@warp-drive/core';
 
 const fetch = new RequestManager().use([Fetch]);
 
@@ -97,13 +96,13 @@ Apps may have multiple request managers, but typically just one will do even for
 ## Step 2: Configure some request defaults
 
 Since we're interacting with a JSON:API API we can use the request utilities provided by
- [@ember-data/json-api/request](https://github.com/warp-drive-data/warp-drive/tree/main/packages/json-api#readme)
+ [@warp-drive/utilities/json-api](https://github.com/warp-drive-data/warp-drive/tree/main/warp-drive-packages/utilities#readme)
 to help us construct requests.
 
 Let's configure the utils to interface with this API and use the [Cursor Pagination Profile](https://jsonapi.org/profiles/ethanresnick/cursor-pagination/):
 
 ```ts
-import { setBuildURLConfig } from '@ember-data/json-api/request';
+import { setBuildURLConfig } from '@warp-drive/utilities/json-api';
 
 setBuildURLConfig({
   host: 'https://cloud.example.com',
@@ -123,13 +122,13 @@ GET /api/companies?fields[company]=name&fields[employee]=name,profileImage&inclu
 Accept: application/vnd.api+json; profile="https://jsonapi.org/profiles/ethanresnick/cursor-pagination"
 ```
 
-The `query` builder from `@ember-data/json-api/request` will do most of the heavy lifting for us,
+The `query` builder from `@warp-drive/utilities/json-api` will do most of the heavy lifting for us,
 constructing the url, and making sure headers are attached appropriately.
 
 *app/page.ts*
 
 ```ts
-import { query } from '@ember-data/json-api/request';
+import { query } from '@warp-drive/utilities/json-api';
 import fetch from './fetch';
 
 // ... execute a request
@@ -174,7 +173,7 @@ Requests issued against the store differ in three ways from raw requests.
 3. The result's `content` will be a `StructuredDocument` whose data property is a list of records instead of raw data.
 
 ```ts
-import { query } from '@ember-data/json-api/request';
+import { query } from '@warp-drive/utilities/json-api';
 
 // ... execute a request
 const { content: collection } = await store.request(query('company', {
@@ -239,7 +238,7 @@ const nextPage = await collection.next();
 Errors are handled via try/catch
 
 ```ts
-import { query } from '@ember-data/json-api/request';
+import { query } from '@warp-drive/utilities/json-api';
 import fetch from './fetch';
 
 // ... execute a request


### PR DESCRIPTION
## Summary
- `guides/the-manual/cookbook/{auth-handlers,basic-usage}.md` are current, non-migration guides for building request handlers and using the request/json-api utilities, but their code samples still imported from the pre-v5 (Legacy) `@ember-data/request` and `@ember-data/json-api/request` packages.
- Updated to `@warp-drive/core` (`RequestManager`, `Fetch`), `@warp-drive/core/request` (`Handler`, `NextFn`), `@warp-drive/core/types/request` (`RequestContext`), and `@warp-drive/utilities/json-api` (`query`, `setBuildURLConfig`).
- Left `guides/the-manual/cookbook/incremental-adoption-guide.md` and `naming-conventions.md` alone — the former is a deliberate step-by-step guide for migrating off the real `ember-data` npm package, and the latter's "EmberData" mention is a historical aside, not a stale import.

Part of #10359.