### PR TITLE
docs: fix stale @ember-data/* imports in requests guides

### DIFF
--- a/guides/the-manual/requests/handlers-advanced.md
+++ b/guides/the-manual/requests/handlers-advanced.md
@@ -101,7 +101,8 @@ A more efficient handler might read from the response stream, building up the
 response content before passing along the chunk downstream.
 
 ```ts
-import type { Handler, RequestContext } from '@ember-data/request';
+import type { Handler } from '@warp-drive/core/request';
+import type { RequestContext } from '@warp-drive/core/types/request';
 
 const FetchHandler: Handler = {
   async request<T>(context: RequestContext) {
@@ -130,7 +131,8 @@ Each handler in the chain can catch errors from upstream and choose to
 either handle the error, re-throw the error, or throw a new error.
 
 ```ts
-import type { Handler, NextFn, RequestContext } from '@ember-data/request';
+import type { Handler, NextFn } from '@warp-drive/core/request';
+import type { RequestContext } from '@warp-drive/core/types/request';
 
 const MAX_RETRIES = 5;
 const AuthHandler: Handler = {

--- a/guides/the-manual/requests/index.md
+++ b/guides/the-manual/requests/index.md
@@ -399,10 +399,7 @@ The native [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) i
 Request handlers can be used to connect to any data source via any mechanism. Besides fetch, this might be localStorage, [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), [ServerEvents](https://developer.mozilla.org/en-US/docs/Web/API/EventSource), [MessageChannel](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel), or something else entirely!
 
 ```ts [services/store.ts]
-import Store from '@ember-data/store';
-
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { Store, RequestManager, Fetch } from '@warp-drive/core';
 import { // [!code focus:4] [!code ++]
   SessionSettingsHandler, // [!code ++]
   FileSystemHandler // [!code ++]

--- a/guides/the-manual/requests/using-just-fetch.md
+++ b/guides/the-manual/requests/using-just-fetch.md
@@ -10,10 +10,7 @@ Throughout this guide we've shown usage of the `RequestManager` in context of a 
 ::: code-group
 
 ```ts [Setup]
-import Store, { CacheHandler} from '@ember-data/store';
-
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { Store, CacheHandler, RequestManager, Fetch } from '@warp-drive/core';
 
 export default class AppStore extends Store {
 
@@ -52,8 +49,7 @@ A `RequestManager` provides a request/response flow in which configured handlers
 The RequestManager on its own does not know how to fulfill requests. For this we must register at least one handler. A basic `Fetch` handler is provided that will take the request options provided and execute `fetch`.
 
 ```ts
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { RequestManager, Fetch } from '@warp-drive/core';
 import { apiUrl } from './config';
 
 // ... create manager and add our Fetch handler
@@ -356,14 +352,12 @@ In the case of the `Future` being returned, `Stream` proxying is automatic and i
 
 ---
 
-#### Using with `@ember-data/store`
+#### Using with `@warp-drive/core`
 
 To have a request service unique to a Store:
 
 ```ts
-import Store, { CacheHandler } from '@ember-data/store';
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { Store, CacheHandler, RequestManager, Fetch } from '@warp-drive/core';
 
 class extends Store {
   requestManager = new RequestManager()
@@ -380,9 +374,7 @@ Some applications will desire to have a single `RequestManager` instance, which 
 
 *services/request.ts*
 ```ts
-import { CacheHandler } from '@ember-data/store';
-import RequestManager from '@ember-data/request';
-import Fetch from '@ember-data/request/fetch';
+import { CacheHandler, RequestManager, Fetch } from '@warp-drive/core';
 import Auth from 'ember-simple-auth/ember-data-handler';
 
 export default {


### PR DESCRIPTION
## Summary
- `guides/the-manual/requests/{index,using-just-fetch,handlers-advanced}.md` still imported `Store`/`RequestManager`/`Fetch`/`Handler`/`RequestContext` from the pre-v5 (Legacy) `@ember-data/store` and `@ember-data/request` packages, including a heading literally titled `#### Using with \`@ember-data/store\``.
- Updated to `@warp-drive/core`, `@warp-drive/core/request`, and `@warp-drive/core/types/request`.
- Left the illustrative `import Auth from 'ember-simple-auth/ember-data-handler'` line alone — that's a hypothetical third-party addon name, not one of our packages.

Part of #10359.