### PR TITLE
docs: document ResourceBlob

### DIFF
--- a/warp-drive-packages/core/src/types/cache/aliases.ts
+++ b/warp-drive-packages/core/src/types/cache/aliases.ts
@@ -1,12 +1,20 @@
-// The ResourceBlob is an opaque type that must
-// satisfy two constraints.
-// (1) it should be possible for the CacheKeyManager
-// to be able to generate a ResourceKey for it
-// whether by default or due to configuration.
-// (2) it should be in a format expected by the Cache.
-// This format is Cache declared.
-//
-// this Opaqueness allows arbitrary storage of any
-// serializable / transferable state including such things
-// as Buffers and Strings.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { CacheKeyManager } from '../../store/-private/managers/cache-key-manager.ts';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Cache } from '../cache.ts';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { ResourceKey } from '../identifier.ts';
+
+/**
+ * The `ResourceBlob` is an opaque type that must satisfy two constraints.
+ *
+ * 1. it should be possible for the {@link CacheKeyManager} to be able to
+ *    generate a {@link ResourceKey} for it, whether by default or due to
+ *    configuration.
+ * 2. it should be in a format expected by the {@link Cache}. This format
+ *    is {@link Cache}-declared.
+ *
+ * This opaqueness allows arbitrary storage of any serializable/transferable
+ * state, including such things as `Buffer`s and `String`s.
+ */
 export type ResourceBlob = unknown;


### PR DESCRIPTION
## Summary
- `ResourceBlob` had a plain `//` comment (not a doc comment) explaining its design rationale, so it was invisible to the API docs. Converted to a proper TSDoc comment, linking `Cache`, `CacheKeyManager`, and `ResourceKey` per the standards in #10569.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.