### PR TITLE
docs: document Change, link it from Cache.diff

### DIFF
--- a/warp-drive-packages/core/src/types/cache.ts
+++ b/warp-drive-packages/core/src/types/cache.ts
@@ -204,31 +204,9 @@ export interface Cache {
    * Generate the list of changes applied to all
    * record in the store.
    *
-   * Each individual resource or document that has
-   * been mutated should be described as an individual
-   * `Change` entry in the returned array.
-   *
-   * A `Change` is described by an object containing up to
-   * three properties: (1) the `CacheKey` of the entity that
-   * changed; (2) the `op` code of that change being one of
-   * `upsert` or `remove`, and if the op is `upsert` a `patch`
-   * containing the data to merge into the cache for the given
-   * entity.
-   *
-   * This `patch` is opaque to the Store but should be understood
-   * by the Cache and may expect to be utilized by an Adapter
-   * when generating data during a `save` operation.
-   *
-   * It is generally recommended that the `patch` contain only
-   * the updated state, ignoring fields that are unchanged
-   *
-   * ```ts
-   * interface Change {
-   *  key: ResourceKey | RequestKey;
-   *  op: 'upsert' | 'remove';
-   *  patch?: unknown;
-   * }
-   * ```
+   * Each individual resource or document that has been mutated
+   * should be described as an individual {@link Change} entry
+   * in the returned array.
    *
    * @public
    */

--- a/warp-drive-packages/core/src/types/cache/change.ts
+++ b/warp-drive-packages/core/src/types/cache/change.ts
@@ -1,7 +1,40 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Cache } from '../cache.ts';
 import type { RequestKey, ResourceKey } from '../identifier.ts';
 
+/**
+ * Describes a single mutation to a resource or document that occurred
+ * in the cache, as returned by {@link Cache.diff}.
+ *
+ * @example
+ * ```ts
+ * const change: Change = {
+ *   identifier: resourceKey,
+ *   op: 'upsert',
+ *   patch: { name: 'Chris' },
+ * };
+ * ```
+ */
 export interface Change {
+  /**
+   * the {@link ResourceKey} or {@link RequestKey} of the entity that changed
+   */
   identifier: ResourceKey | RequestKey;
+  /**
+   * the type of change that occurred. If `'upsert'`, {@link Change.patch | patch}
+   * will be present with the data to merge into the cache for the entity.
+   */
   op: 'upsert' | 'remove';
+  /**
+   * When {@link Change.op | op} is `'upsert'`, the data to merge into the
+   * cache for the entity.
+   *
+   * This is opaque to the Store but should be understood by the Cache and
+   * may be utilized by an Adapter when generating data during a `save`
+   * operation.
+   *
+   * It is generally recommended that `patch` contain only the updated
+   * state, ignoring fields that are unchanged.
+   */
   patch?: unknown;
 }


### PR DESCRIPTION
## Summary
- `Change` (returned by `Cache.diff()`) had no doc comment. Documented it, including a usage example, per the standards in #10569.
- `Cache.diff`'s own doc comment duplicated `Change`'s shape inline (and called its `identifier` field `key`, which is stale). Replaced the inline snippet with a `{@link Change}` reference.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.