### PR TITLE
docs: document ResourceRelationship, CollectionRelationship, and Relationship

### DIFF
--- a/warp-drive-packages/core/src/types/cache/relationship.ts
+++ b/warp-drive-packages/core/src/types/cache/relationship.ts
@@ -1,19 +1,72 @@
 import type { ResourceKey } from '../identifier.ts';
-import type { Links, Meta, PaginationLinks } from '../spec/json-api-raw.ts';
+import type {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  CollectionResourceRelationship,
+  Links,
+  Meta,
+  PaginationLinks,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  SingleResourceRelationship,
+} from '../spec/json-api-raw.ts';
 
-// we request that it be in the stable form already.
+/**
+ * The stable-cache-key form of a `to-one` {@link SingleResourceRelationship | relationship}.
+ *
+ * Unlike {@link SingleResourceRelationship}, `data` is always in the
+ * stable {@link ResourceKey} form rather than a raw resource identifier.
+ *
+ * @example
+ * ```ts
+ * const relationship: ResourceRelationship = { data: resourceKey };
+ * ```
+ */
 export interface ResourceRelationship<T = ResourceKey> {
+  /**
+   * the related resource, or `null` if the relationship has no related resource
+   */
   data?: T | null;
+  /**
+   * meta information about the relationship
+   */
   meta?: Meta;
+  /**
+   * links related to the relationship
+   */
   links?: Links;
 }
 
-// Note: in v1 data could be a ResourceIdentifier, now
-// we request that it be in the stable form already.
+/**
+ * The stable-cache-key form of a `to-many` {@link CollectionResourceRelationship | relationship}.
+ *
+ * Unlike {@link CollectionResourceRelationship}, each entry in `data` is
+ * always in the stable {@link ResourceKey} form rather than a raw resource
+ * identifier.
+ *
+ * @example
+ * ```ts
+ * const relationship: CollectionRelationship = { data: [resourceKey] };
+ * ```
+ */
 export interface CollectionRelationship<T = ResourceKey> {
+  /**
+   * the related resources
+   */
   data?: T[];
+  /**
+   * meta information about the relationship
+   */
   meta?: Meta;
+  /**
+   * links related to the relationship, including pagination links
+   */
   links?: PaginationLinks;
 }
 
+/**
+ * The stable-cache-key form of a relationship, whether `to-one` or `to-many`.
+ *
+ * See also:
+ * - {@link ResourceRelationship}
+ * - {@link CollectionRelationship}
+ */
 export type Relationship<T = ResourceKey> = ResourceRelationship<T> | CollectionRelationship<T>;


### PR DESCRIPTION
## Summary
- `ResourceRelationship`, `CollectionRelationship`, and the `Relationship` union in `@warp-drive/core/types/cache/relationship.ts` had no doc comments. These are the stable-`ResourceKey` counterparts to `SingleResourceRelationship`/`CollectionResourceRelationship` in the raw {json:api} spec types.
- Documented each with a usage example and cross-linked to their raw-spec counterparts, per the standards in #10569.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.