### PR TITLE
docs: document AddToResourceRelationshipMutation and RemoveFromResourceRelationshipMutation

### DIFF
--- a/warp-drive-packages/core/src/types/cache/mutations.ts
+++ b/warp-drive-packages/core/src/types/cache/mutations.ts
@@ -1,18 +1,56 @@
 import type { ResourceKey } from '../identifier.ts';
 
+/**
+ * Adds the specified {@link ResourceKey | ResourceKeys} to a relationship's
+ * local (uncommitted) state.
+ */
 export interface AddToResourceRelationshipMutation {
+  /**
+   * The name of the mutation
+   */
   op: 'add';
+  /**
+   * The cache key for the resource whose relationship is being updated
+   */
   record: ResourceKey;
+  /**
+   * The name of the relationship to add to
+   */
   field: string;
+  /**
+   * The resource(s) to add to the relationship
+   */
   value: ResourceKey | ResourceKey[];
+  /**
+   * The index at which to insert the resource(s), if applicable
+   */
   index?: number;
 }
 
+/**
+ * Removes the specified {@link ResourceKey | ResourceKeys} from a relationship's
+ * local (uncommitted) state.
+ */
 export interface RemoveFromResourceRelationshipMutation {
+  /**
+   * The name of the mutation
+   */
   op: 'remove';
+  /**
+   * The cache key for the resource whose relationship is being updated
+   */
   record: ResourceKey;
+  /**
+   * The name of the relationship to remove from
+   */
   field: string;
+  /**
+   * The resource(s) to remove from the relationship
+   */
   value: ResourceKey | ResourceKey[];
+  /**
+   * The index to remove the resource(s) from, if applicable
+   */
   index?: number;
 }
 


### PR DESCRIPTION
## Summary
- `AddToResourceRelationshipMutation` and `RemoveFromResourceRelationshipMutation` had no doc comments at all. Documented per the standards in #10569.
- First of a couple small PRs covering `types/cache/mutations.ts` (split to stay under ~100 lines each); the remaining three mutation types + the `Mutation` union will follow separately.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.