### PR TITLE
docs: document RecordStore, WithPartial, Mutable, getRuntimeConfig, CacheKeyType, RequestKey

### DIFF
--- a/warp-drive-packages/core/src/types/identifier.ts
+++ b/warp-drive-packages/core/src/types/identifier.ts
@@ -1,8 +1,17 @@
 import { DEBUG } from '@warp-drive/core/build-config/env';
 
 // provided for additional debuggability
+/**
+ * @internal
+ */
 export const DEBUG_CLIENT_ORIGINATED: unique symbol = Symbol('record-originated-on-client');
+/**
+ * @internal
+ */
 export const DEBUG_KEY_TYPE: unique symbol = Symbol('key-type');
+/**
+ * @internal
+ */
 export const DEBUG_STALE_CACHE_OWNER: unique symbol = Symbol('warpDriveStaleCache');
 
 function ProdSymbol<T extends string>(str: T, debugStr: string): T {
@@ -10,8 +19,16 @@ function ProdSymbol<T extends string>(str: T, debugStr: string): T {
 }
 
 // also present in production
+/**
+ * @internal
+ */
 export const CACHE_OWNER: '__$co' = ProdSymbol('__$co', 'CACHE_OWNER');
 
+/**
+ * Identifies which "bucket" of the cache a key belongs to: resources
+ * (`'record'`, see {@link ResourceKey}) or request documents
+ * (`'document'`, see {@link RequestKey}).
+ */
 export type CacheKeyType = 'record' | 'document';
 
 /**
@@ -24,7 +41,13 @@ export type CacheKeyType = 'record' | 'document';
  * @public
  */
 export interface RequestKey {
+  /**
+   * A string representing a unique identity.
+   */
   lid: string;
+  /**
+   * Discriminates a {@link RequestKey} from a {@link ResourceKey}.
+   */
   type: '@document';
   /** @internal */
   [CACHE_OWNER]: number | undefined;

--- a/warp-drive-packages/core/src/types/identifier.ts
+++ b/warp-drive-packages/core/src/types/identifier.ts
@@ -2,15 +2,15 @@ import { DEBUG } from '@warp-drive/core/build-config/env';
 
 // provided for additional debuggability
 /**
- * @internal
+ * @private
  */
 export const DEBUG_CLIENT_ORIGINATED: unique symbol = Symbol('record-originated-on-client');
 /**
- * @internal
+ * @private
  */
 export const DEBUG_KEY_TYPE: unique symbol = Symbol('key-type');
 /**
- * @internal
+ * @private
  */
 export const DEBUG_STALE_CACHE_OWNER: unique symbol = Symbol('warpDriveStaleCache');
 
@@ -20,7 +20,7 @@ function ProdSymbol<T extends string>(str: T, debugStr: string): T {
 
 // also present in production
 /**
- * @internal
+ * @private
  */
 export const CACHE_OWNER: '__$co' = ProdSymbol('__$co', 'CACHE_OWNER');
 

--- a/warp-drive-packages/core/src/types/runtime.ts
+++ b/warp-drive-packages/core/src/types/runtime.ts
@@ -2,7 +2,17 @@ import type { LOG_CONFIG } from '@warp-drive/build-config/-private/utils/logging
 
 import { getOrSetUniversal } from './-private.ts';
 
-const RuntimeConfig: { debug: Partial<LOG_CONFIG>; mirage?: boolean } = getOrSetUniversal('WarpDriveRuntimeConfig', {
+const RuntimeConfig: {
+  /**
+   * the currently active logging configuration, see {@link LOG_CONFIG}
+   */
+  debug: Partial<LOG_CONFIG>;
+  /**
+   * whether requests should be treated as being served by Mirage,
+   * see {@link setIsMaybeMirage}
+   */
+  mirage?: boolean;
+} = getOrSetUniversal('WarpDriveRuntimeConfig', {
   debug: {},
 });
 
@@ -22,6 +32,14 @@ if (settings) {
   Object.assign(RuntimeConfig, JSON.parse(settings));
 }
 
+/**
+ * Returns the current WarpDrive runtime configuration.
+ *
+ * @example
+ * ```ts
+ * const { debug, mirage } = getRuntimeConfig();
+ * ```
+ */
 export function getRuntimeConfig(): typeof RuntimeConfig {
   return RuntimeConfig;
 }

--- a/warp-drive-packages/core/src/types/symbols.ts
+++ b/warp-drive-packages/core/src/types/symbols.ts
@@ -1,5 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Store } from '../store/-private/store-service.ts';
 import { getOrSetGlobal } from './-private.ts';
 
+/**
+ * Symbol used internally to stash a reference to the owning
+ * {@link Store} on a record instance.
+ *
+ * @type {Symbol}
+ */
 export const RecordStore: '___(unique) Symbol(Store)' = getOrSetGlobal('Store', Symbol('Store'));
 
 /**

--- a/warp-drive-packages/core/src/types/utils.ts
+++ b/warp-drive-packages/core/src/types/utils.ts
@@ -1,3 +1,21 @@
+/**
+ * Makes the properties named in `K` optional on `T`, leaving the rest as-is.
+ *
+ * @example
+ * ```ts
+ * interface User { id: string; name: string; }
+ * type PartialName = WithPartial<User, 'name'>; // { id: string; name?: string }
+ * ```
+ */
 export type WithPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
+/**
+ * Removes `readonly` from every property of `T`.
+ *
+ * @example
+ * ```ts
+ * interface Config { readonly host: string; }
+ * type MutableConfig = Mutable<Config>; // { host: string }
+ * ```
+ */
 export type Mutable<T> = { -readonly [P in keyof T]: T[P] };


### PR DESCRIPTION
## Summary
Small batch of previously-undocumented exports across `@warp-drive/core/types`:
- `RecordStore` (symbols.ts)
- `WithPartial`, `Mutable` (utils.ts)
- `getRuntimeConfig` and its return shape (runtime.ts)
- `CacheKeyType`, `RequestKey.lid`/`RequestKey.type` (identifier.ts)

Also marks the debug-only symbols in `identifier.ts` (`DEBUG_CLIENT_ORIGINATED`, `DEBUG_KEY_TYPE`, `DEBUG_STALE_CACHE_OWNER`, `CACHE_OWNER`) as `@internal`, since they aren't meant for public consumption.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard (see #10569).