### PR TITLE
docs: document query params and include-validation types

### DIFF
--- a/warp-drive-packages/core/src/types/params.ts
+++ b/warp-drive-packages/core/src/types/params.ts
@@ -1,9 +1,45 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Includes } from './record.ts';
+
+/**
+ * A JSON-serializable primitive value, suitable for use as a single
+ * query parameter value.
+ */
 export type SerializablePrimitive = string | number | boolean | null;
+
+/**
+ * A JSON-serializable value suitable for use as a query parameter value:
+ * either a {@link SerializablePrimitive} or an array of them.
+ */
 export type Serializable = SerializablePrimitive | SerializablePrimitive[];
+
+/**
+ * Options for controlling how {@link QueryParamsSource} values are
+ * serialized into a URL query string.
+ */
 export type QueryParamsSerializationOptions = {
+  /**
+   * How array values should be serialized:
+   *
+   * - `'bracket'` - `key[]=1&key[]=2`
+   * - `'indices'` - `key[0]=1&key[1]=2`
+   * - `'repeat'` - `key=1&key=2`
+   * - `'comma'` - `key=1,2`
+   */
   arrayFormat?: 'bracket' | 'indices' | 'repeat' | 'comma';
 };
 
+/**
+ * The query parameters to serialize for a request: either a
+ * dictionary of {@link Serializable} values (with an optional
+ * `include` member for specifying relationships to sideload),
+ * or a native `URLSearchParams` instance.
+ */
 export type QueryParamsSource =
-  | ({ include?: string | string[] } & Record<Exclude<string, 'include'>, Serializable>)
+  | ({
+      /**
+       * the relationship paths to sideload, see {@link Includes}
+       */
+      include?: string | string[];
+    } & Record<Exclude<string, 'include'>, Serializable>)
   | URLSearchParams;

--- a/warp-drive-packages/core/src/types/record.ts
+++ b/warp-drive-packages/core/src/types/record.ts
@@ -172,8 +172,15 @@ export type Includes<T extends TypedRecordInstance, MAX_DEPTH extends _DEPTHCOUN
   true
 >;
 
+/**
+ * A type-erased placeholder for a record instance, used where the
+ * specific record type is not known or not relevant.
+ */
 export type OpaqueRecordInstance = unknown;
 
+/**
+ * @internal
+ */
 export type _StringSatisfiesIncludes<T extends string, SET extends string, FT extends string> = T extends SET
   ? FT
   : T extends `${infer U},${infer V}`
@@ -182,8 +189,39 @@ export type _StringSatisfiesIncludes<T extends string, SET extends string, FT ex
       : never
     : never;
 
+/**
+ * Validates that the comma-separated-string `T` (e.g. `'company,company.ceo,friends'`)
+ * only contains paths present in the union `SET` (typically {@link Includes}).
+ *
+ * TypeScript cannot autocomplete against this type; prefer {@link createIncludeValidator}
+ * for a better development experience unless you are writing a similar wrapper utility.
+ *
+ * @example
+ * ```ts
+ * import type { StringSatisfiesIncludes, Includes } from '@warp-drive/core/types/record';
+ *
+ * const includes: StringSatisfiesIncludes<
+ *   'company,company.ceo,friends',
+ *   Includes<User>
+ * > = 'company,company.ceo,friends';
+ * ```
+ */
 export type StringSatisfiesIncludes<T extends string, SET extends string> = _StringSatisfiesIncludes<T, SET, T>;
 
+/**
+ * Creates a runtime validator function for comma-separated `include` strings,
+ * ensuring at compile time that only valid paths for `T` (per {@link Includes})
+ * are supplied.
+ *
+ * @example
+ * ```ts
+ * import { createIncludeValidator } from '@warp-drive/core/types/record';
+ *
+ * const userIncludesValidator = createIncludeValidator<User>;
+ *
+ * userIncludesValidator('company,company.ceo,friends');
+ * ```
+ */
 export function createIncludeValidator<T extends TypedRecordInstance>() {
   return function validateIncludes<U extends string>(includes: StringSatisfiesIncludes<U, Includes<T>>): U {
     return includes;


### PR DESCRIPTION
## Summary
- `SerializablePrimitive`, `Serializable`, `QueryParamsSerializationOptions`, `QueryParamsSource` (types/params.ts) and `OpaqueRecordInstance`, `StringSatisfiesIncludes`, `createIncludeValidator` (types/record.ts) had no doc comments. Documented per the standards in #10569, reusing the explanations already written for these in `guides/the-manual/typescript/typing-includes.md`.
- Marks the internal `_StringSatisfiesIncludes` helper as `@internal` rather than writing public docs for its recursive conditional type.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.