### PR TITLE
docs: document remaining Graph relationship operations and unions

### DIFF
--- a/warp-drive-packages/core/src/types/graph.ts
+++ b/warp-drive-packages/core/src/types/graph.ts
@@ -33,31 +33,106 @@ export interface UnknownOperation {
   field: string;
 }
 
+/**
+ * Replaces the state of a `to-one` relationship on the Graph with a new value.
+ */
 export interface ReplaceRelatedRecordOperation {
+  /**
+   * The name of the operation
+   */
   op: 'replaceRelatedRecord';
+  /**
+   * The cache key for the resource whose relationship is being updated
+   */
   record: ResourceKey;
+  /**
+   * The name of the relationship to replace
+   */
   field: string;
-  value: ResourceKey | null; // never null if field is a collection
-  prior?: ResourceKey; // if field is a collection, the value we are swapping with
-  index?: number; // if field is a collection, the index at which we are replacing a value
+  /**
+   * The new value for the relationship. Never `null` if the field is
+   * actually a collection relationship.
+   */
+  value: ResourceKey | null;
+  /**
+   * If the field is a collection relationship, the value being swapped out
+   */
+  prior?: ResourceKey;
+  /**
+   * If the field is a collection relationship, the index at which the swap occurred
+   */
+  index?: number;
 }
 
+/**
+ * Reorders the state of a `to-many` relationship on the Graph.
+ */
 export interface SortRelatedRecords {
+  /**
+   * The name of the operation
+   */
   op: 'sortRelatedRecords';
+  /**
+   * The cache key for the resource whose relationship is being reordered
+   */
   record: ResourceKey;
+  /**
+   * The name of the relationship to reorder
+   */
   field: string;
+  /**
+   * The relationship's members in their new order
+   */
   value: ResourceKey[];
 }
 
+/**
+ * Replaces the state of a `to-many` relationship on the Graph with a
+ * new set of values.
+ */
 export interface ReplaceRelatedRecordsOperation {
+  /**
+   * The name of the operation
+   */
   op: 'replaceRelatedRecords';
+  /**
+   * The cache key for the resource whose relationship is being updated
+   */
   record: ResourceKey;
+  /**
+   * The name of the relationship to replace
+   */
   field: string;
-  value: ResourceKey[]; // the records to add. If no prior/index specified all existing should be removed
-  prior?: ResourceKey[]; // if this is a "splice" the records we expect to be removed
-  index?: number; // if this is a "splice" the index to start from
+  /**
+   * The resources to add. If neither {@link ReplaceRelatedRecordsOperation.prior | prior}
+   * nor {@link ReplaceRelatedRecordsOperation.index | index} is specified, all
+   * existing members should be removed.
+   */
+  value: ResourceKey[];
+  /**
+   * If this is a "splice", the resources expected to be removed
+   */
+  prior?: ResourceKey[];
+  /**
+   * If this is a "splice", the index to start from
+   */
+  index?: number;
 }
 
+/**
+ * The Graph operations that apply to a relationship's remote
+ * (persisted/clean) state.
+ *
+ * See also:
+ * - {@link UpdateResourceRelationshipOperation}
+ * - {@link UpdateRelationshipOperation}
+ * - {@link ReplaceRelatedRecordOperation}
+ * - {@link ReplaceRelatedRecordsOperation}
+ * - {@link RemoveResourceOperation}
+ * - {@link AddResourceOperation}
+ * - {@link DeleteRecordOperation}
+ * - {@link SortRelatedRecords}
+ */
 export type RemoteRelationshipOperation =
   | UpdateResourceRelationshipOperation
   | UpdateRelationshipOperation
@@ -68,6 +143,17 @@ export type RemoteRelationshipOperation =
   | DeleteRecordOperation
   | SortRelatedRecords;
 
+/**
+ * The Graph operations that apply to a relationship's local
+ * (uncommitted/dirty) state.
+ *
+ * See also:
+ * - {@link ReplaceRelatedRecordsOperation}
+ * - {@link ReplaceRelatedRecordOperation}
+ * - {@link AddResourceMutation}
+ * - {@link RemoveResourceMutation}
+ * - {@link SortRelatedRecords}
+ */
 export type LocalRelationshipOperation =
   | ReplaceRelatedRecordsOperation
   | ReplaceRelatedRecordOperation


### PR DESCRIPTION
## Summary
- `ReplaceRelatedRecordOperation`, `SortRelatedRecords`, `ReplaceRelatedRecordsOperation`, `RemoteRelationshipOperation`, and `LocalRelationshipOperation` in `@warp-drive/core/types/graph.ts` had no doc comments. Documented per the standards in #10569, including union member links.
- Second of two small PRs covering `types/graph.ts`, which is now fully documented.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.