### PR TITLE
docs: document low-level reactivity primitives

### DIFF
--- a/warp-drive-packages/core/src/signals/reactivity/configure.ts
+++ b/warp-drive-packages/core/src/signals/reactivity/configure.ts
@@ -223,6 +223,11 @@ export function willSyncFlushWatchers(): boolean {
   return signalHooks.willSyncFlushWatchers();
 }
 
+/**
+ * Wraps `promise` using the configured {@link SignalHooks.waitFor}, if any,
+ * for things like test-waiters. Returns `promise` unchanged if no
+ * `waitFor` hook is configured.
+ */
 export function waitFor<K>(promise: Promise<K>): Promise<K> {
   const signalHooks: SignalHooks | null = peekTransient('signalHooks');
 

--- a/warp-drive-packages/core/src/signals/reactivity/internal.ts
+++ b/warp-drive-packages/core/src/signals/reactivity/internal.ts
@@ -19,6 +19,11 @@ const INITIALIZER_PROTO = { isInitializer: true } as const;
 interface Initializer {
   value: () => unknown;
 }
+/**
+ * Wraps `fn` so that a signal can recognize it as a lazy initializer
+ * for its value rather than the value itself, deferring the call to
+ * `fn` until the signal is first accessed.
+ */
 export function makeInitializer(fn: () => unknown): Initializer {
   // we use a prototype to ensure that the initializer is not enumerable
   // and does not interfere with the signal's value.
@@ -258,6 +263,10 @@ export function consumeInternalMemo<T>(fn: () => T): T {
   return fn();
 }
 
+/**
+ * Looks up the {@link WarpDriveSignal} stored for `key` in `signals`,
+ * if one has already been created, without creating or consuming it.
+ */
 export function peekInternalSignal(
   signals: SignalStore | undefined,
   key: string | symbol
@@ -270,6 +279,10 @@ export function consumeInternalSignal(signal: WarpDriveSignal): void {
   consumeSignal(signal.signal);
 }
 
+/**
+ * Marks `signal` as stale and notifies its underlying framework/TC39
+ * signal, scheduling any of its consumers for re-render/re-computation.
+ */
 export function notifyInternalSignal(signal: WarpDriveSignal | undefined): void {
   if (signal) {
     signal.isStale = true;

--- a/warp-drive-packages/core/src/signals/reactivity/signal.ts
+++ b/warp-drive-packages/core/src/signals/reactivity/signal.ts
@@ -228,6 +228,20 @@ export function gate<T extends object, K extends keyof T & string>(
   return desc;
 }
 
+/**
+ * Defines a reactive "gated" property on `obj` using `desc` as its
+ * getter/setter descriptor.
+ *
+ * Unlike a signal defined with {@link defineSignal}, a gated property's
+ * consumers are not notified when the property is set, since its update
+ * is expected to be controlled externally (for instance, by a signal it
+ * derives its value from) unless the descriptor opts into being locally
+ * managed.
+ *
+ * Akin to `Object.defineProperty`.
+ *
+ * @private
+ */
 export function defineGate<T extends object>(obj: T, key: string, desc: PropertyDescriptor): void {
   const options = Object.assign({ enumerable: true, configurable: false }, gate(obj, key as keyof T & string, desc));
   Object.defineProperty(obj, key, options);


### PR DESCRIPTION
## Summary
- `defineGate`, `makeInitializer`, `peekInternalSignal`, `notifyInternalSignal`, and `waitFor` (the low-level signal/reactivity primitives exposed via `@warp-drive/core/signals/-leaked`) had no doc comments. Documented per the standards in #10569.
- Last of a few small PRs covering `warp-drive-packages/core/src/signals/**`.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard.