### PR TITLE
docs: document request symbols, HTTPMethod, StructuredData/ErrorDocument properties, ImmutableHeaders

### DIFF
--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -13,16 +13,35 @@ import type { TypeFromInstanceOrString } from './record.ts';
 import type { ResourceIdentifierObject } from './spec/json-api-raw.ts';
 import type { RequestSignature } from './symbols.ts';
 
+/**
+ * A {@link RequestInfo.cacheOptions | cacheOptions} flag which, when set,
+ * signals that a request should never be handled by the cache-manager and
+ * thus will never resolve from cache nor update the cache.
+ */
 export const SkipCache: '___(unique) Symbol(SkipCache)' = getOrSetUniversal('SkipCache', Symbol.for('wd:skip-cache'));
+/**
+ * A {@link RequestInfo} flag which, when set, signals to the store's
+ * `instantiateRecord` hook that the resolved content should be hydrated
+ * into reactive records rather than returned as raw data.
+ */
 export const EnableHydration: '___(unique) Symbol(EnableHydration)' = getOrSetUniversal(
   'EnableHydration',
   Symbol.for('wd:enable-hydration')
 );
+/**
+ * @internal
+ */
 export const IS_FUTURE: '___(unique) Symbol(IS_FUTURE)' = getOrSetGlobal('IS_FUTURE', Symbol('IS_FUTURE'));
+/**
+ * @internal
+ */
 export const STRUCTURED: '___(unique) Symbol(DOC)' = getOrSetGlobal('DOC', Symbol('DOC'));
 
 export type { FetchError };
 
+/**
+ * The HTTP methods WarpDrive's request layer supports.
+ */
 export type HTTPMethod =
   | 'QUERY'
   | 'GET'
@@ -200,7 +219,13 @@ export interface StructuredDataDocument<T> {
    * @see {@link ImmutableRequestInfo}
    */
   request: ImmutableRequestInfo;
+  /**
+   * the response set by the handler chain, if any
+   */
   response: Response | ResponseInfo | null;
+  /**
+   * the processed content of the response
+   */
   content: T;
 }
 
@@ -222,8 +247,17 @@ export interface StructuredErrorDocument<T = unknown> extends Error {
    * @see {@link ImmutableRequestInfo}
    */
   request: ImmutableRequestInfo;
+  /**
+   * the response set by the handler chain, if any
+   */
   response: Response | ResponseInfo | null;
+  /**
+   * the error that caused the request to fail
+   */
   error: string | object;
+  /**
+   * the processed content of the response, if any was received before the failure
+   */
   content?: T;
 }
 
@@ -311,8 +345,18 @@ interface NativeRequestInit {
   duplex?: 'half';
 }
 
+/**
+ * A read-only {@link Headers} instance, as passed to {@link Handler | Handlers}
+ * via {@link ImmutableRequestInfo.headers}.
+ */
 export interface ImmutableHeaders extends Headers {
+  /**
+   * Returns a mutable clone of these headers, if supported by the implementation.
+   */
   clone?(): Headers;
+  /**
+   * Returns the headers as an array of `[key, value]` pairs.
+   */
   toJSON(): [string, string][];
 }
 


### PR DESCRIPTION
## Summary
First of several small PRs covering `@warp-drive/core/types/request.ts`:
- `SkipCache`, `EnableHydration`, `HTTPMethod` had no doc comments; `IS_FUTURE` and `STRUCTURED` are marked `@internal` (they're implementation-detail brand symbols).
- `StructuredDataDocument`/`StructuredErrorDocument` had interface-level docs but were missing property docs.
- `ImmutableHeaders` had no doc comments.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard (see #10569).