### PR TITLE
docs: document FindRecordRequestOptions and QueryRequestOptions

### DIFF
--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -112,22 +112,69 @@ export interface CacheOptions {
    */
   [SkipCache]?: boolean;
 }
+/**
+ * The request shape produced by the `findRecord` request builders, for
+ * use with {@link Store.request}.
+ */
 export type FindRecordRequestOptions<RT = unknown, T = unknown> = {
+  /**
+   * the url to request
+   */
   url: string;
+  /**
+   * the HTTP method to use
+   */
   method: 'GET';
+  /**
+   * the headers to send with the request
+   */
   headers: Headers;
+  /**
+   * see {@link CacheOptions}
+   */
   cacheOptions?: CacheOptions;
+  /**
+   * the name of the request operation
+   */
   op: 'findRecord';
+  /**
+   * the resource being requested
+   */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
+  /**
+   * @internal used only to carry the response type for type inference purposes
+   */
   [RequestSignature]?: RT;
 };
 
+/**
+ * The request shape produced by the `query` request builders, for
+ * use with {@link Store.request}.
+ */
 export type QueryRequestOptions<RT = unknown> = {
+  /**
+   * the url to request
+   */
   url: string;
+  /**
+   * the HTTP method to use
+   */
   method: 'GET';
+  /**
+   * the headers to send with the request
+   */
   headers: Headers;
+  /**
+   * see {@link CacheOptions}
+   */
   cacheOptions?: CacheOptions;
+  /**
+   * the name of the request operation
+   */
   op: 'query';
+  /**
+   * @internal used only to carry the response type for type inference purposes
+   */
   [RequestSignature]?: RT;
 };
 

--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -142,7 +142,7 @@ export type FindRecordRequestOptions<RT = unknown, T = unknown> = {
    */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -173,7 +173,7 @@ export type QueryRequestOptions<RT = unknown> = {
    */
   op: 'query';
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -214,7 +214,7 @@ export type PostQueryRequestOptions<RT = unknown> = {
    */
   op: 'query';
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -258,7 +258,7 @@ export type DeleteRequestOptions<RT = unknown, T = unknown> = {
    */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };


### PR DESCRIPTION
## Summary
- `FindRecordRequestOptions` and `QueryRequestOptions` (the request shapes produced by the `findRecord`/`query` builders) had no doc comments.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard (see #10569).