### PR TITLE
docs: document UpdateRequestOptions, CreateRequestOptions, and their Immutable forms

### DIFF
--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -167,7 +167,7 @@ export type PostQueryRequestOptions<RT = unknown> = {
    */
   op: 'query';
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -211,7 +211,7 @@ export type DeleteRequestOptions<RT = unknown, T = unknown> = {
    */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -260,7 +260,7 @@ export type UpdateRequestOptions<RT = unknown, T = unknown> = {
    */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -304,7 +304,7 @@ export type CreateRequestOptions<RT = unknown, T = unknown> = {
    */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };

--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -221,34 +221,105 @@ type ImmutableRequest<T> = Readonly<T> & {
   readonly records: [ResourceKey];
 };
 
+/**
+ * The request shape produced by the `updateRecord` request builders, for
+ * use with {@link Store.request}.
+ */
 export type UpdateRequestOptions<RT = unknown, T = unknown> = {
+  /**
+   * the url to request
+   */
   url: string;
+  /**
+   * the HTTP method to use
+   */
   method: 'PATCH' | 'PUT';
+  /**
+   * the headers to send with the request
+   */
   headers: Headers;
+  /**
+   * the name of the request operation
+   */
   op: 'updateRecord';
+  /**
+   * the body to send with the request
+   */
   body?: string | BodyInit | FormData;
+  /**
+   * data for handlers to convert into the request body
+   */
   data: {
+    /**
+     * the resource being updated
+     */
     record: ResourceKey<TypeFromInstanceOrString<T>>;
   };
+  /**
+   * the resource being updated
+   */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
+  /**
+   * @internal used only to carry the response type for type inference purposes
+   */
   [RequestSignature]?: RT;
 };
 
+/**
+ * The request shape produced by the `createRecord` request builders, for
+ * use with {@link Store.request}.
+ */
 export type CreateRequestOptions<RT = unknown, T = unknown> = {
+  /**
+   * the url to request
+   */
   url: string;
+  /**
+   * the HTTP method to use
+   */
   method: 'POST';
+  /**
+   * the headers to send with the request
+   */
   headers: Headers;
+  /**
+   * the name of the request operation
+   */
   op: 'createRecord';
+  /**
+   * the body to send with the request
+   */
   body?: string | BodyInit | FormData;
+  /**
+   * data for handlers to convert into the request body
+   */
   data: {
+    /**
+     * the resource being created
+     */
     record: ResourceKey<TypeFromInstanceOrString<T>>;
   };
+  /**
+   * the resource being created
+   */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
+  /**
+   * @internal used only to carry the response type for type inference purposes
+   */
   [RequestSignature]?: RT;
 };
 
+/**
+ * The immutable, handler-facing form of {@link DeleteRequestOptions}.
+ */
 export type ImmutableDeleteRequestOptions = ImmutableRequest<DeleteRequestOptions>;
+/**
+ * The immutable, handler-facing form of {@link UpdateRequestOptions}.
+ */
 export type ImmutableUpdateRequestOptions = ImmutableRequest<UpdateRequestOptions>;
+/**
+ * The immutable, handler-facing form of {@link CreateRequestOptions}.
+ */
 export type ImmutableCreateRequestOptions = ImmutableRequest<CreateRequestOptions>;
 
 /**


### PR DESCRIPTION
## Summary
- `UpdateRequestOptions`, `CreateRequestOptions`, and the `ImmutableDeleteRequestOptions`/`ImmutableUpdateRequestOptions`/`ImmutableCreateRequestOptions` type aliases had no doc comments.

Part of an ongoing pass to bring `warp-drive-packages/*` API doc coverage up to standard (see #10569).