### PR TITLE
fix: don't strip [RequestSignature] from published request option types

### DIFF
--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -33,11 +33,11 @@ export const EnableHydration: '___(unique) Symbol(EnableHydration)' = getOrSetUn
   Symbol.for('wd:enable-hydration')
 );
 /**
- * @internal
+ * @private
  */
 export const IS_FUTURE: '___(unique) Symbol(IS_FUTURE)' = getOrSetGlobal('IS_FUTURE', Symbol('IS_FUTURE'));
 /**
- * @internal
+ * @private
  */
 export const STRUCTURED: '___(unique) Symbol(DOC)' = getOrSetGlobal('DOC', Symbol('DOC'));
 

--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -167,7 +167,7 @@ export type PostQueryRequestOptions<RT = unknown> = {
    */
   op: 'query';
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };
@@ -211,7 +211,7 @@ export type DeleteRequestOptions<RT = unknown, T = unknown> = {
    */
   records: [ResourceIdentifierObject<TypeFromInstanceOrString<T>>];
   /**
-   * @internal used only to carry the response type for type inference purposes
+   * @private used only to carry the response type for type inference purposes
    */
   [RequestSignature]?: RT;
 };


### PR DESCRIPTION
## Summary

**This is a hotfix for a live regression on `main` introduced by #10593** (already merged).

`@internal` triggers this build's `stripInternal: true` option (`tools/internal-config/vite/config.js`), which removes the tagged member from the published `.d.ts` entirely — not just from the API docs. `[RequestSignature]` is a phantom-type carrier property used by downstream generic type inference (extracting the resolved response type `RT` from a request options type). #10593 tagged it `@internal` on `PostQueryRequestOptions` and `DeleteRequestOptions`, which strips it from the built declarations and breaks that inference for any consumer relying on it.

Confirmed impact: `@warp-drive/utilities`'s `find-record.type-test.ts`/`query.type-test.ts` currently fail lint on `main` with `error`-typed values (`@typescript-eslint/no-unsafe-argument`) precisely because of this.

Fix: use `@private` instead of `@internal`. It's still excluded from the public API docs (`excludePrivate: true`) but isn't stripped from the build output, since this is a real property other code needs present at the type level.

## Test plan
- [x] Rebuilt `@warp-drive/core` and confirmed `[RequestSignature]?: RT;` is present again in `declarations/types/request.d.ts` for both types
- [x] `eslint` passes clean on `warp-drive-packages/utilities/src/-private/json-api/{find-record,query}.type-test.ts`
- [x] `eslint`/`tsc --noEmit` clean on the edited file