### PR TITLE
docs: document Adapter base class store and _coalesceFindRequests properties

### DIFF
--- a/warp-drive-packages/legacy/src/adapter.ts
+++ b/warp-drive-packages/legacy/src/adapter.ts
@@ -255,8 +255,14 @@ const service = s.service ?? s.inject;
   @public
 */
 export class Adapter extends EmberObject implements MinimumAdapterInterface {
+  /**
+   * The Store service instance that owns this Adapter.
+   */
   @service declare store: Store;
 
+  /**
+   * @private
+   */
   declare _coalesceFindRequests: boolean;
 
   /**


### PR DESCRIPTION
## Summary
- \`Adapter.store\` and \`Adapter._coalesceFindRequests\` had no doc comments. Since \`JSONAPIAdapter\`/\`RESTAdapter\` inherit these, documenting the base class resolves the same warning for both subclasses.
- \`_coalesceFindRequests\` is marked \`@private\` rather than \`@internal\`, since \`@internal\` strips a member from the published \`.d.ts\` in this build (confirmed elsewhere this session to break real type usage) and subclasses assign to this field directly.

Part of an ongoing pass to bring \`warp-drive-packages/*\` API doc coverage up to standard (see #10569).