### PR TITLE
docs: document JSONAPIAdapter's _defaultContentType and pathForType overrides

### DIFF
--- a/warp-drive-packages/legacy/src/adapter/json-api.ts
+++ b/warp-drive-packages/legacy/src/adapter/json-api.ts
@@ -154,6 +154,10 @@ import { RESTAdapter } from './rest.ts';
   @constructor
 */
 class JSONAPIAdapter extends RESTAdapter {
+  /**
+   * The `Content-Type` header used when serializing request bodies
+   * that don't otherwise specify one.
+   */
   _defaultContentType = 'application/vnd.api+json';
 
   /**
@@ -248,6 +252,13 @@ class JSONAPIAdapter extends RESTAdapter {
     return this.ajax(url, 'GET', { data: { filter: { id: ids.join(',') } } });
   }
 
+  /**
+   * Determines the pathname for a given type.
+   *
+   * Unlike the base `BuildURLMixin` implementation, dasherizes (rather
+   * than camelizes) the type name before pluralizing it, per the
+   * {json:api} convention for member names.
+   */
   pathForType(modelName: string): string {
     const dasherized = dasherize(modelName);
     return pluralize(dasherized);


### PR DESCRIPTION
## Summary
- \`JSONAPIAdapter._defaultContentType\` and its \`pathForType\` override (which dasherizes rather than camelizes type names, per the {json:api} member-name convention) had no doc comments.

Part of an ongoing pass to bring \`warp-drive-packages/*\` API doc coverage up to standard (see #10569).