### PR TITLE
docs: clarify applicability of Vite Minimal Config in Migrating guide

### DIFF
--- a/guides/migrating/index.md
+++ b/guides/migrating/index.md
@@ -326,6 +326,11 @@ module.exports = async function (defaults) {
 
 == Vite Minimal Config
 
+> [!WARNING]
+> This tab only applies if your app has **already fully migrated off** `ember-cli-build.js` and `@embroider/compat`'s `compatBuild` — i.e. you have a native-Vite build that uses `@embroider/vite`'s `ember()` plugin directly, with no classic/compat resolution step.
+>
+> If your app still has an `ember-cli-build.js` file (true for almost everyone following this migration guide), use the **Classic Config** tab instead and configure ***Warp*Drive** there, as described in the [Setup guide](/guides/configuration/index.md#configure-the-build-plugin). Pasting this minimal config into a compat app's `babel.config` will drop the plugins `@embroider/compat/babel`'s `babelCompatSupport()` (and template/decorator compilation) provides for compat builds, and re-adding them alongside this config is likely to conflict rather than help.
+
 ```ts [babel.config.mjs]
 import { setConfig } from '@warp-drive-mirror/core/build-config';
 import { buildMacros } from '@embroider/macros/babel';


### PR DESCRIPTION
Fixes #10452

## Summary

The Migrating guide's "Step 2 - Configure the Build" section presented a "Vite Minimal Config" tab (a `babel.config.mjs`-only setup) as an apparent alternative to the "Classic Config" tab (which uses `ember-cli-build.js`), with no indication of when each applies. This contradicted the Setup guide, which says apps that still have an `ember-cli-build.js` file configure the build plugin there, not in `babel.config`.

This adds a `[!WARNING]` callout to the "Vite Minimal Config" tab explaining:
- it only applies to apps that have **already fully migrated off** `ember-cli-build.js` and `@embroider/compat`'s `compatBuild` (i.e. a native-Vite build using `@embroider/vite`'s `ember()` plugin directly)
- apps that still have `ember-cli-build.js` (true for almost everyone following this migration guide) should use the "Classic Config" tab instead, per the Setup guide
- pasting the minimal config into a compat app's `babel.config` drops the plugins that `@embroider/compat/babel`'s `babelCompatSupport()` (and template/decorator compilation) provide for compat builds, and combining the two is likely to conflict rather than help

## Analysis

The issue reporter observed that the Setup guide (`guides/configuration/index.md#configure-the-build-plugin`) says apps with an `ember-cli-build.js` configure ***Warp*Drive*** there, while the Migrating guide (`guides/migrating/index.md#step-2---configure-the-build`) offers a Babel-only "Vite Minimal Config" as if it were a normal alternative for the same (classic, migrating-off-3.x/4.x) app — which by definition still has `ember-cli-build.js`. The reporter also flagged that this Babel-only config can conflict with `@embroider/compat/babel`'s `babelCompatSupport()`.

I verified the actual behavior against real test fixtures in this repo rather than guessing:

- `tests/vite-basic-compat/` is a classic/compat app: it has `ember-cli-build.js` (which calls `setConfig(app, __dirname, {...})` from `@warp-drive/build-config`, matching the Setup guide and the Migrating guide's "Classic Config" tab) and a separate `babel.config.cjs` that calls `babelCompatSupport()` / `templateCompatSupport()` from `@embroider/compat/babel` purely for classic template/decorator compilation needed by `compatBuild`.
- `tests/framework-ember/`, `tests/core/`, `tests/legacy/`, `tests/example-app-ember/` etc. are native-Vite apps: **no `ember-cli-build.js` at all**, no dependency on `@embroider/compat`, and their `vite.config.mjs` uses `@embroider/vite`'s `ember()` plugin directly. Their `babel.config.mjs` configures ***Warp*Drive*** directly via `babelPlugin()`/`setConfig()` + `buildMacros()`, with no `babelCompatSupport()` call anywhere.

This confirms the reporter's intuition was close but the exact condition is "does the app still have `ember-cli-build.js` / go through `@embroider/compat`'s `compatBuild`" rather than "Babel config exists because Vite" — a fully native-Vite app genuinely does configure the plugin purely via `babel.config`, and mixing that config into a still-classic/compat app is what produces the conflict with `babelCompatSupport()`. Since the Babel-only path is real and valid for that (increasingly common) subset of apps, I kept the tab rather than removing it, and made the applicability condition explicit instead, which resolves the contradiction with the Setup guide while preserving the intended non-ember-cli-build guidance for readers on native Vite.

## Test plan

- [x] Docs-only change; verified rendering by eye against existing `[!WARNING]`/tabs syntax used elsewhere in the guide.