### PR TITLE
chore: fix CI caching to work with per-package linting

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -160,10 +160,14 @@ runs:
       if: ${{ inputs.restore-lint-caches == 'true' }}
       uses: actions/cache@v4
       with:
+        # Type-check (tsconfig.tsbuildinfo) and lint (.eslintcache) artifacts are
+        # produced per-package by turbo rather than at the repo root, so these
+        # paths must be globbed to cover every workspace package. Prettier still
+        # runs once from the repo root, so `.prettier-cache` stays un-globbed.
         path: |
-          .eslintcache
           .prettier-cache
-          tsconfig.tsbuildinfo
+          **/.eslintcache
+          **/tsconfig.tsbuildinfo
         key: lint-${{ github.head_ref }}-${{ inputs.ref }}
         restore-keys: |
           lint-${{ github.head_ref }}


### PR DESCRIPTION
Fixes #9042

## Summary

- Fixes the "Restore Lint Caches" step in `.github/actions/setup/action.yml` so that it actually caches/restores the type-check and lint artifacts that CI produces today.
- The `path:` for the `actions/cache@v4` step previously pointed only at root-level files (`.eslintcache`, `tsconfig.tsbuildinfo`). Those files no longer exist at the repo root — `turbo` now runs `lint` and `check:types` per workspace package, so each package produces its own `<package>/.eslintcache` and `<package>/tsconfig.tsbuildinfo`. The cache step was therefore a no-op: nothing at those exact root paths ever existed to save or restore.
- Updated the glob patterns to `**/.eslintcache` and `**/tsconfig.tsbuildinfo` so every workspace package's artifacts are covered, while leaving `.prettier-cache` untouched since Prettier (`pnpm lint:prettier`) still runs once from the repo root and writes its cache there.

## Analysis

**Old setup:** The "Restore Lint Caches" step was added in 2023 (#8429) when `eslint`/`tsc` were invoked once from the repo root, producing a single root-level `.eslintcache` and `tsconfig.tsbuildinfo`. `actions/cache@v4` cached exactly those root paths, keyed on `github.head_ref`/`ref` with branch/base/`main` fallbacks — this worked because there was only ever one copy of each artifact.

**Why it broke:** The repo's lint/type-check tasks are now orchestrated by `turbo` (see `turbo.json`'s `lint` and `check:types` tasks, and each package's own `"lint": "eslint . --quiet --cache --cache-strategy=content"` script in `packages/*/package.json`). Turbo runs these tasks with each package as the working directory, and neither `eslint --cache` nor TypeScript's `tsconfig.tsbuildinfo` (via `composite`/`incremental` in per-package `tsconfig.json`s, e.g. `packages/store/tsconfig.json`, `tests/core/tsconfig.json`) take a root-level output path — they default to writing next to the invoking package's `tsconfig.json`/cwd. So today these artifacts live at `packages/<name>/.eslintcache`, `packages/<name>/tsconfig.tsbuildinfo`, `tests/<name>/tsconfig.tsbuildinfo`, etc., never at the repo root. `.gitignore` already reflects this — its `.eslintcache` and `tsconfig.tsbuildinfo` entries have no leading `/`, meaning they're intended to match at any depth. The cache step's `path:` just never got updated to match, so it silently cached nothing.

**What changed:** `.github/actions/setup/action.yml`'s "Restore Lint Caches" step now globs `**/.eslintcache` and `**/tsconfig.tsbuildinfo` (in addition to keeping root-level `.prettier-cache`, which is still accurate since `lint:prettier` runs once from the repo root). The cache `key`/`restore-keys` scheme is unchanged — it already matches the pattern used by the neighboring "Restore Broccoli Cache" step (keyed on branch ref with base-branch/`main` fallbacks), which still makes sense here.

This is CI/build-infra only — no source or public API changes.

## Test plan

- [x] Confirmed `.eslintcache`/`tsconfig.tsbuildinfo` no longer exist at repo root; verified per-package locations via `packages/*/package.json` lint scripts and per-package `tsconfig.json` `composite`/`incremental` settings.
- [x] Validated the updated YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(open('.github/actions/setup/action.yml'))"`).
- [ ] CI run on this PR will exercise the `lint` job, which uses `restore-lint-caches: true`.