### PR TITLE
docs: show how to add stateful handlers with useLegacyStore/useRecommendedStore

### DIFF
--- a/warp-drive-packages/core/src/index.ts
+++ b/warp-drive-packages/core/src/index.ts
@@ -90,6 +90,10 @@ export interface StoreSetupOptions<T extends Cache = Cache> {
    *
    * The function is invoked lazily, the first time the store's `requestManager`
    * is accessed, and only once per store instance.
+   *
+   * See the "Adding Stateful Handlers" section of {@link useRecommendedStore}
+   * for an example of using this callback to construct a handler that needs
+   * access to an Ember service.
    */
   handlers?: Handler[] | ((store: Store) => Handler[]);
   /**
@@ -142,6 +146,56 @@ export declare class ConfiguredStore<T extends { cache: Cache }> extends Store {
  *   schemas: [],
  * });
  * ```
+ *
+ * ### Adding Stateful Handlers
+ *
+ * A request {@link Handler} is sometimes more than a plain object or class with
+ * a `request` method — it may need access to a stateful dependency such as an
+ * Ember service (an auth token, a feature-flags service, an i18n helper, etc.).
+ *
+ * A plain class handler that only relies on Ember's `@service` decorator will
+ * not work here on its own: the handler is never instantiated *through* Ember's
+ * container (it's just `new`'d up), so it has no owner and its `@service`
+ * injections would fail to resolve.
+ *
+ * Instead, give {@link StoreSetupOptions.handlers | handlers} a function. It
+ * receives the {@link Store} instance being configured, which by the time the
+ * function runs already has an owner assigned. Use `getOwner`/`setOwner` from
+ * `@ember/owner` to transfer that owner onto your handler instance before
+ * returning it, exactly as you would when constructing any other DI-aware
+ * object outside of the container:
+ *
+ * ```ts
+ * import { getOwner, setOwner } from '@ember/owner';
+ * import { service } from '@ember/service';
+ * import { useRecommendedStore } from '@warp-drive/core';
+ * import type { NextFn } from '@warp-drive/core/request';
+ * import type { RequestContext } from '@warp-drive/core/types/request';
+ * import { JSONAPICache } from '@warp-drive/json-api';
+ *
+ * class AuthHandler {
+ *   @service session;
+ *
+ *   request<T>(context: RequestContext, next: NextFn<T>) {
+ *     const headers = new Headers(context.request.headers);
+ *     headers.append('Authorization', `Bearer ${this.session.accessToken}`);
+ *     return next(Object.assign({}, context.request, { headers }));
+ *   }
+ * }
+ *
+ * export default useRecommendedStore({
+ *   cache: JSONAPICache,
+ *   handlers: (store) => {
+ *     const authHandler = new AuthHandler();
+ *     setOwner(authHandler, getOwner(store)!);
+ *     return [authHandler];
+ *   },
+ * });
+ * ```
+ *
+ * The `handlers` function is invoked lazily and only once per store instance,
+ * the first time `store.requestManager` is accessed, so it is safe to do
+ * owner-dependent setup like this inside of it.
  */
 export function useRecommendedStore<T extends Cache>(
   options: StoreSetupOptions<T>,

--- a/warp-drive-packages/core/src/index.ts
+++ b/warp-drive-packages/core/src/index.ts
@@ -16,6 +16,8 @@ import { CacheHandler, type CachePolicy, Store } from './store/-private.ts';
 import { recordIdentifierFor } from './store/-private.ts';
 import type { CacheCapabilitiesManager, ResourceKey } from './types.ts';
 import type { Cache } from './types/cache.ts';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { RequestInfo } from './types/request.ts';
 import { getRuntimeConfig, setIsMaybeMirage, setLogging } from './types/runtime.ts';
 import type { Derivation, HashFn, Transformation } from './types/schema/concepts.ts';
 import type { ObjectSchema, PolarisResourceSchema, Trait } from './types/schema/fields.ts';
@@ -196,6 +198,49 @@ export declare class ConfiguredStore<T extends { cache: Cache }> extends Store {
  * The `handlers` function is invoked lazily and only once per store instance,
  * the first time `store.requestManager` is accessed, so it is safe to do
  * owner-dependent setup like this inside of it.
+ *
+ * ### Accessing the Store from a Handler's Context
+ *
+ * If a handler only needs to read something *off of the store itself*
+ * (its cache, or a property/service you've attached to a custom store
+ * subclass) rather than an unrelated Ember service, there is a second,
+ * simpler option that requires no DI/`setOwner` wiring at all.
+ *
+ * Every request issued via {@link Store.request | store.request(...)}
+ * automatically carries the originating store along as
+ * {@link RequestInfo.store | context.request.store}. Any handler — a plain
+ * object, a function-built handler, or a class — can read it directly,
+ * without needing the `handlers` callback form shown above:
+ *
+ * ```ts
+ * import { useRecommendedStore } from '@warp-drive/core';
+ * import type { NextFn } from '@warp-drive/core/request';
+ * import type { RequestContext } from '@warp-drive/core/types/request';
+ * import { JSONAPICache } from '@warp-drive/json-api';
+ *
+ * const LoggingHandler = {
+ *   request<T>(context: RequestContext, next: NextFn<T>) {
+ *     // only present when the request was made via `store.request(...)`
+ *     const store = context.request.store;
+ *     if (store) {
+ *       console.log(`[${store.constructor.name}] ${context.request.url ?? ''}`);
+ *     }
+ *     return next(context.request);
+ *   },
+ * };
+ *
+ * export default useRecommendedStore({
+ *   cache: JSONAPICache,
+ *   handlers: [LoggingHandler],
+ * });
+ * ```
+ *
+ * The trade-off versus the `getOwner`/`setOwner` pattern above is that
+ * `context.request.store` is only populated for requests issued via
+ * `store.request(...)`; a request made directly against a
+ * {@link RequestManager} won't have it set unless the caller supplies it
+ * explicitly, so a handler relying on it should treat it as optional (as
+ * `LoggingHandler` does above).
  */
 export function useRecommendedStore<T extends Cache>(
   options: StoreSetupOptions<T>,

--- a/warp-drive-packages/core/src/types/request.ts
+++ b/warp-drive-packages/core/src/types/request.ts
@@ -621,6 +621,32 @@ export interface RequestInfo<RT = unknown> extends NativeRequestInit {
   /**
    * The {@link Store} the request was made against, if made via
    * {@link Store.request} rather than directly against a {@link RequestManager}.
+   *
+   * A {@link Handler} can read this off of {@link RequestContext.request | context.request}
+   * to reach store state (the cache, other services attached to a custom
+   * store subclass, etc.) without needing any Ember DI/`setOwner` wiring at
+   * handler-construction time. This works for a handler of any shape (a
+   * function, plain object, or class) because the store is attached to each
+   * request individually rather than to the handler itself.
+   *
+   * The trade-off is that this is only populated for requests issued via
+   * {@link Store.request | store.request(...)}; a request issued directly
+   * against a {@link RequestManager} will not have it set unless the caller
+   * supplies it explicitly. Handlers that rely on it should treat it as
+   * optional.
+   *
+   * @example
+   * ```ts
+   * const LoggingHandler = {
+   *   request<T>(context: RequestContext, next: NextFn<T>) {
+   *     const store = context.request.store;
+   *     if (store) {
+   *       console.log(`[${store.constructor.name}] ${context.request.url ?? ''}`);
+   *     }
+   *     return next(context.request);
+   *   },
+   * };
+   * ```
    */
   store?: Store;
 

--- a/warp-drive-packages/legacy/src/index.ts
+++ b/warp-drive-packages/legacy/src/index.ts
@@ -142,6 +142,70 @@ export declare class ConfiguredStore<T extends { cache: Cache }> extends Store {
  * Use the legacy store with the given options.
  *
  * See {@link LegacyStoreSetupOptions} for details on the available options.
+ *
+ * ```ts
+ * import { useLegacyStore } from '@warp-drive/legacy';
+ * import { JSONAPICache } from '@warp-drive/json-api';
+ *
+ * export default useLegacyStore({
+ *   linksMode: false,
+ *   legacyRequests: true,
+ *   cache: JSONAPICache,
+ *   schemas: [],
+ * });
+ * ```
+ *
+ * ### Adding Stateful Handlers
+ *
+ * A request {@link Handler} is sometimes more than a plain object or class
+ * with a `request` method — it may need access to a stateful dependency such
+ * as an Ember service (an auth token, a feature-flags service, an i18n
+ * helper, etc.).
+ *
+ * A plain class handler that only relies on Ember's `@service` decorator will
+ * not work here on its own: the handler is never instantiated *through*
+ * Ember's container (it's just `new`'d up), so it has no owner and its
+ * `@service` injections would fail to resolve.
+ *
+ * Instead, give `handlers` a function. It receives the {@link Store} instance
+ * being configured, which by the time the function runs already has an owner
+ * assigned. Use `getOwner`/`setOwner` from `@ember/owner` to transfer that
+ * owner onto your handler instance before returning it, exactly as you would
+ * when constructing any other DI-aware object outside of the container:
+ *
+ * ```ts
+ * import { getOwner, setOwner } from '@ember/owner';
+ * import { service } from '@ember/service';
+ * import { useLegacyStore } from '@warp-drive/legacy';
+ * import type { NextFn } from '@warp-drive/core/request';
+ * import type { RequestContext } from '@warp-drive/core/types/request';
+ * import { JSONAPICache } from '@warp-drive/json-api';
+ *
+ * class AuthHandler {
+ *   @service session;
+ *
+ *   request<T>(context: RequestContext, next: NextFn<T>) {
+ *     const headers = new Headers(context.request.headers);
+ *     headers.append('Authorization', `Bearer ${this.session.accessToken}`);
+ *     return next(Object.assign({}, context.request, { headers }));
+ *   }
+ * }
+ *
+ * export default useLegacyStore({
+ *   linksMode: false,
+ *   legacyRequests: true,
+ *   cache: JSONAPICache,
+ *   handlers: (store) => {
+ *     const authHandler = new AuthHandler();
+ *     setOwner(authHandler, getOwner(store)!);
+ *     return [authHandler];
+ *   },
+ * });
+ * ```
+ *
+ * The `handlers` function is invoked lazily and only once per store instance,
+ * the first time `store.requestManager` is accessed, so it is safe to do
+ * owner-dependent setup like this inside of it.
  */
 export function useLegacyStore<T extends Cache>(
   options: LegacyModelStoreSetupOptions<T>,

--- a/warp-drive-packages/legacy/src/index.ts
+++ b/warp-drive-packages/legacy/src/index.ts
@@ -18,6 +18,8 @@ import { DefaultCachePolicy } from '@warp-drive/core/store';
 import type { CacheCapabilitiesManager, ModelSchema, ResourceKey } from '@warp-drive/core/types';
 import type { Cache } from '@warp-drive/core/types/cache';
 import type { TypeFromInstance } from '@warp-drive/core/types/record';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { RequestInfo } from '@warp-drive/core/types/request';
 import type { ObjectSchema, ResourceSchema } from '@warp-drive/core/types/schema/fields';
 
 import type { MinimumAdapterInterface } from './compat';
@@ -206,6 +208,51 @@ export declare class ConfiguredStore<T extends { cache: Cache }> extends Store {
  * The `handlers` function is invoked lazily and only once per store instance,
  * the first time `store.requestManager` is accessed, so it is safe to do
  * owner-dependent setup like this inside of it.
+ *
+ * ### Accessing the Store from a Handler's Context
+ *
+ * If a handler only needs to read something *off of the store itself*
+ * (its cache, or a property/service you've attached to a custom store
+ * subclass) rather than an unrelated Ember service, there is a second,
+ * simpler option that requires no DI/`setOwner` wiring at all.
+ *
+ * Every request issued via {@link Store.request | store.request(...)}
+ * automatically carries the originating store along as
+ * {@link RequestInfo.store | context.request.store}. Any handler — a plain
+ * object, a function-built handler, or a class — can read it directly,
+ * without needing the `handlers` callback form shown above:
+ *
+ * ```ts
+ * import { useLegacyStore } from '@warp-drive/legacy';
+ * import type { NextFn } from '@warp-drive/core/request';
+ * import type { RequestContext } from '@warp-drive/core/types/request';
+ * import { JSONAPICache } from '@warp-drive/json-api';
+ *
+ * const LoggingHandler = {
+ *   request<T>(context: RequestContext, next: NextFn<T>) {
+ *     // only present when the request was made via `store.request(...)`
+ *     const store = context.request.store;
+ *     if (store) {
+ *       console.log(`[${store.constructor.name}] ${context.request.url ?? ''}`);
+ *     }
+ *     return next(context.request);
+ *   },
+ * };
+ *
+ * export default useLegacyStore({
+ *   linksMode: false,
+ *   legacyRequests: true,
+ *   cache: JSONAPICache,
+ *   handlers: [LoggingHandler],
+ * });
+ * ```
+ *
+ * The trade-off versus the `getOwner`/`setOwner` pattern above is that
+ * `context.request.store` is only populated for requests issued via
+ * `store.request(...)`; a request made directly against a
+ * {@link RequestManager} won't have it set unless the caller supplies it
+ * explicitly, so a handler relying on it should treat it as optional (as
+ * `LoggingHandler` does above).
  */
 export function useLegacyStore<T extends Cache>(
   options: LegacyModelStoreSetupOptions<T>,


### PR DESCRIPTION
Fixes #10417

## Summary

- Adds an "Adding Stateful Handlers" section to the TSDoc for `useRecommendedStore` (`@warp-drive/core`) and `useLegacyStore` (`@warp-drive/legacy`), each with a full code example of the `getOwner`/`setOwner` + `@service` pattern.
- Adds a complementary "Accessing the Store from a Handler's Context" section right alongside it in both TSDoc blocks, showing the DI-free alternative: reading the store directly off of `context.request.store` for requests issued via `store.request(...)`.
- Adds a matching `@example` to `RequestInfo.store`'s own doc comment (`warp-drive-packages/core/src/types/request.ts`), since that's the canonical source of the `store` property and previously had no example.
- Cross-links the new sections from the `handlers` option's own doc comment on `StoreSetupOptions`.
- No runtime behavior changes — this is documentation only, describing existing capabilities that already ship but weren't documented with concrete examples.

## Analysis

**Pattern 1 — DI via `getOwner`/`setOwner` (documented first):** A request `Handler` registered via `.use([...])` on a plain `RequestManager` is just `new`'d up — it is never instantiated through Ember's container. So a class handler that relies on `@service` for DI will have injections silently fail unless something manually gives it an owner via `setOwner(handlerInstance, owner)`. This pattern already existed and is shown for a hand-rolled `RequestManager` factory in `guides/the-manual/cookbook/auth-handlers.md` ("Class based Handler" section), where the owner is obtained from the service factory's `create(args)` argument (`getOwner(args)`). That guide's pattern doesn't directly translate to `useLegacyStore`/`useRecommendedStore`, though, because those helpers build the `RequestManager` internally and lazily. #10551 had already added support for `handlers` to be a function `(store: Store) => Handler[]` specifically so this function could receive the `Store` instance (which already has an owner by the time it runs) and use `getOwner(store)`/`setOwner(handlerInstance, ...)`. Tests already existed for this (`tests/core/tests/use-recommended-store-test.ts`, `tests/legacy/tests/unit/use-legacy-store-test.ts`) but the capability wasn't documented anywhere with a concrete service-injection example.

**Pattern 2 — reading `context.request.store` (added in this follow-up):** Investigating further, `Store#request` in `warp-drive-packages/core/src/store/-private/store-service.ts` already attaches the originating store instance to every outgoing request as a plain `store` property (`opts.store = this`, merged via `Object.assign` into the request object) before handing it to `requestManager.request(...)`. This `store` property is declared and documented on the base `RequestInfo` interface (`warp-drive-packages/core/src/types/request.ts`), and consequently on `ImmutableRequestInfo`, so it's already visible to any handler as `context.request.store` — no special `StoreRequestContext` type or opt-in needed (the internal `CacheHandler` already relies on exactly this to look up the cache). This is a second, complementary, DI-free way for a handler to reach store state: unlike pattern 1, it doesn't require the `handlers` callback form or any owner wiring at handler-construction time, because the store is attached per-request rather than to the handler itself — it works for a handler of any shape (function, plain object, or class). The trade-off is that it's only populated for requests issued via `store.request(...)`, not for requests made directly against a bare `RequestManager`.

Both patterns are genuinely useful and complementary depending on what a handler needs (an unrelated Ember service vs. store state itself), so both are now documented side-by-side.

## Test plan

- [x] `pnpm eslint src/index.ts --quiet` passes for `warp-drive-packages/core`, `warp-drive-packages/legacy`
- [x] `pnpm eslint src/types/request.ts --quiet` passes for `warp-drive-packages/core`
- [x] `tsc --noEmit` passes for both `warp-drive-packages/core` and `warp-drive-packages/legacy`
- [x] Verified every doc-comment line is prefixed with `*` per `guides/contributing/writing-documentation/writing-api-docs.md`
- [x] Verified all `{@link}` targets (`Handler`, `Store`, `StoreSetupOptions.handlers`, `RequestInfo.store`, `RequestContext.request`, `RequestManager`) are already imported/declared in each file, adding type-only imports with the documented eslint-disable convention where needed