### PR TITLE
fix: guard window/document/DOMException access for non-DOM environments

### DIFF
--- a/tests/core/tests/signals/request-subscription-non-dom-test.ts
+++ b/tests/core/tests/signals/request-subscription-non-dom-test.ts
@@ -1,0 +1,92 @@
+import { RequestManager } from '@warp-drive/core';
+import { createRequestSubscription } from '@warp-drive/core/reactive';
+import { DISPOSE } from '@warp-drive/core/signals/-leaked';
+import { module, test } from '@warp-drive/diagnostic';
+
+// Regression coverage for https://github.com/warp-drive-data/warp-drive/issues/10428
+//
+// Non-DOM environments (e.g. React Native) may provide a `window` global
+// that lacks `addEventListener`/`removeEventListener`, and a `document`
+// that either doesn't exist at all or lacks the event/visibility APIs used
+// here. `RequestSubscription` (which powers the `<Request />` component's
+// autorefresh/retry/refresh behaviors) must not throw when installing or
+// tearing down its network/visibility listeners in such environments.
+//
+// Real browsers do not allow redefining the global `window.document`
+// binding itself (it is a non-configurable own property of `window`), so
+// this test simulates the failure mode reported in the issue - `window`
+// and `document` present but missing the specific APIs we depend on - by
+// shadowing just those APIs for the duration of the test.
+module('Integration | signals | RequestSubscription in non-DOM environments', function () {
+  test('creating and disposing a RequestSubscription does not throw when window/document lack the expected browser APIs', function (assert) {
+    const originalWindowAddEventListener = window.addEventListener.bind(window);
+    const originalWindowRemoveEventListener = window.removeEventListener.bind(window);
+    const originalDocumentAddEventListener = document.addEventListener.bind(document);
+    const originalDocumentRemoveEventListener = document.removeEventListener.bind(document);
+    const originalVisibilityState = document.visibilityState;
+
+    Object.defineProperty(window, 'addEventListener', { value: undefined, configurable: true, writable: true });
+    Object.defineProperty(window, 'removeEventListener', { value: undefined, configurable: true, writable: true });
+    Object.defineProperty(document, 'addEventListener', { value: undefined, configurable: true, writable: true });
+    Object.defineProperty(document, 'removeEventListener', { value: undefined, configurable: true, writable: true });
+    Object.defineProperty(document, 'visibilityState', { value: undefined, configurable: true, writable: true });
+
+    try {
+      const manager = new RequestManager();
+      let subscription: ReturnType<typeof createRequestSubscription> | undefined;
+
+      assert.doesNotThrow(() => {
+        subscription = createRequestSubscription(manager, {});
+      }, 'constructing a RequestSubscription does not throw');
+
+      assert.true(subscription!.isOnline, 'defaults to online when window.navigator is unavailable');
+      assert.false(subscription!.isHidden, 'defaults to visible when document.visibilityState is unavailable');
+
+      assert.doesNotThrow(() => {
+        subscription![DISPOSE]();
+      }, 'disposing a RequestSubscription does not throw');
+    } finally {
+      Object.defineProperty(window, 'addEventListener', {
+        value: originalWindowAddEventListener,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(window, 'removeEventListener', {
+        value: originalWindowRemoveEventListener,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(document, 'addEventListener', {
+        value: originalDocumentAddEventListener,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(document, 'removeEventListener', {
+        value: originalDocumentRemoveEventListener,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(document, 'visibilityState', {
+        value: originalVisibilityState,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  test('a RequestSubscription still tracks isOnline/isHidden via window/document in a normal DOM environment', function (assert) {
+    const manager = new RequestManager();
+    const subscription = createRequestSubscription(manager, {});
+
+    assert.equal(subscription.isOnline, window.navigator.onLine, 'isOnline reflects window.navigator.onLine');
+    assert.equal(
+      subscription.isHidden,
+      document.visibilityState === 'hidden',
+      'isHidden reflects document.visibilityState'
+    );
+
+    assert.doesNotThrow(() => {
+      subscription[DISPOSE]();
+    }, 'disposing a RequestSubscription does not throw');
+  });
+});

--- a/warp-drive-packages/core/src/request/-private/fetch.ts
+++ b/warp-drive-packages/core/src/request/-private/fetch.ts
@@ -141,14 +141,19 @@ const Fetch = {
       );
       response = await _fetch(context.request.url, context.request);
     } catch (e) {
-      if (e instanceof DOMException && e.name === 'AbortError') {
+      // Some non-DOM environments (e.g. React Native, some Node/worker
+      // environments) may not provide `DOMException` as a global, so guard
+      // the reference to avoid throwing while merely trying to classify
+      // the error.
+      const isDOMException = typeof DOMException !== 'undefined' && e instanceof DOMException;
+      if (isDOMException && e.name === 'AbortError') {
         (e as FetchError).statusText = 'Aborted';
         (e as FetchError).status = 20;
         (e as FetchError).isRequestError = true;
       } else {
         (e as FetchError).statusText = 'Unknown Network Error';
         (e as FetchError).status = 0;
-        if (!(e instanceof DOMException)) {
+        if (!isDOMException) {
           (e as FetchError).code = 0;
         }
         (e as FetchError).isRequestError = true;

--- a/warp-drive-packages/core/src/request/-private/fetch.ts
+++ b/warp-drive-packages/core/src/request/-private/fetch.ts
@@ -3,7 +3,7 @@ import { assert } from '@warp-drive/core/build-config/macros';
 
 import { getRuntimeConfig } from '../../types/runtime.ts';
 import { cloneResponseProperties, type Context } from './context';
-import type { FetchError } from './utils';
+import { DOMError, type FetchError } from './utils';
 
 export type { FetchError };
 
@@ -141,11 +141,7 @@ const Fetch = {
       );
       response = await _fetch(context.request.url, context.request);
     } catch (e) {
-      // Some non-DOM environments (e.g. React Native, some Node/worker
-      // environments) may not provide `DOMException` as a global, so guard
-      // the reference to avoid throwing while merely trying to classify
-      // the error.
-      const isDOMException = typeof DOMException !== 'undefined' && e instanceof DOMException;
+      const isDOMException = e instanceof DOMError;
       if (isDOMException && e.name === 'AbortError') {
         (e as FetchError).statusText = 'Aborted';
         (e as FetchError).status = 20;

--- a/warp-drive-packages/core/src/request/-private/utils.ts
+++ b/warp-drive-packages/core/src/request/-private/utils.ts
@@ -156,11 +156,16 @@ export interface FetchError extends DOMException {
 export function enhanceReason(reason?: string): DOMException {
   const error = new DOMError(reason || 'The user aborted a request.', 'AbortError');
   // `DOMError` may be the `Error` constructor as a fallback, whose
-  // constructor doesn't accept a `name`, so set it explicitly. This is a
-  // no-op when `DOMError` is the real `DOMException`, which already sets
-  // `name` from its constructor. `DOMException.name` is typed as
-  // read-only, so cast to assign it.
-  (error as unknown as { name: string }).name = 'AbortError';
+  // constructor doesn't accept a `name`, so set it explicitly in that case.
+  // We can't unconditionally assign `error.name` here: when `DOMError` is
+  // the real `DOMException`, `name` is already `'AbortError'` (set by its
+  // constructor) *and* `DOMException.prototype.name` is a getter-only
+  // accessor with no setter, so reassigning it throws a `TypeError` in
+  // strict-mode JS (which is how our ES modules run) - even when assigning
+  // the very same value it already holds.
+  if (error.name !== 'AbortError') {
+    (error as unknown as { name: string }).name = 'AbortError';
+  }
   return error;
 }
 

--- a/warp-drive-packages/core/src/request/-private/utils.ts
+++ b/warp-drive-packages/core/src/request/-private/utils.ts
@@ -138,7 +138,19 @@ export interface FetchError extends DOMException {
 }
 
 export function enhanceReason(reason?: string): DOMException {
-  return new DOMException(reason || 'The user aborted a request.', 'AbortError');
+  const message = reason || 'The user aborted a request.';
+
+  // Some non-DOM environments (e.g. React Native, some Node/worker
+  // environments) may not provide `DOMException` as a global. Fall back to
+  // a plain `Error` with a matching `name` so abort handling keeps working
+  // instead of throwing while constructing the reason.
+  if (typeof DOMException === 'undefined') {
+    const error = new Error(message);
+    error.name = 'AbortError';
+    return error as unknown as DOMException;
+  }
+
+  return new DOMException(message, 'AbortError');
 }
 
 export function handleOutcome<T>(

--- a/warp-drive-packages/core/src/request/-private/utils.ts
+++ b/warp-drive-packages/core/src/request/-private/utils.ts
@@ -20,6 +20,22 @@ export const IS_CACHE_HANDLER: '___(unique) Symbol(IS_CACHE_HANDLER)' = getOrSet
   'IS_CACHE_HANDLER',
   Symbol('IS_CACHE_HANDLER')
 );
+
+/**
+ * A ponyfill for the global {@link DOMException} constructor.
+ *
+ * Some non-DOM environments (e.g. React Native, some Node/worker
+ * environments) don't provide `DOMException` as a global, which would
+ * otherwise throw a `ReferenceError` the first time any code referenced it
+ * (for instance when classifying an abort/network error). `DOMError` falls
+ * back to the global {@link Error} constructor in that case so callers can
+ * uniformly use `new DOMError(...)` / `error instanceof DOMError` without
+ * guarding for the global's presence themselves.
+ *
+ * @internal
+ */
+export const DOMError: typeof DOMException =
+  typeof DOMException !== 'undefined' ? DOMException : (Error as unknown as typeof DOMException);
 export function curryFuture<T>(owner: ContextOwner, inbound: Future<T>, outbound: DeferredFuture<T>): Future<T> {
   owner.setStream(inbound.getStream());
 
@@ -138,19 +154,14 @@ export interface FetchError extends DOMException {
 }
 
 export function enhanceReason(reason?: string): DOMException {
-  const message = reason || 'The user aborted a request.';
-
-  // Some non-DOM environments (e.g. React Native, some Node/worker
-  // environments) may not provide `DOMException` as a global. Fall back to
-  // a plain `Error` with a matching `name` so abort handling keeps working
-  // instead of throwing while constructing the reason.
-  if (typeof DOMException === 'undefined') {
-    const error = new Error(message);
-    error.name = 'AbortError';
-    return error as unknown as DOMException;
-  }
-
-  return new DOMException(message, 'AbortError');
+  const error = new DOMError(reason || 'The user aborted a request.', 'AbortError');
+  // `DOMError` may be the `Error` constructor as a fallback, whose
+  // constructor doesn't accept a `name`, so set it explicitly. This is a
+  // no-op when `DOMError` is the real `DOMException`, which already sets
+  // `name` from its constructor. `DOMException.name` is typed as
+  // read-only, so cast to assign it.
+  (error as unknown as { name: string }).name = 'AbortError';
+  return error;
 }
 
 export function handleOutcome<T>(

--- a/warp-drive-packages/core/src/signals/request-state.ts
+++ b/warp-drive-packages/core/src/signals/request-state.ts
@@ -3,6 +3,7 @@ import { assert } from '@warp-drive/build-config/macros';
 import type { Awaitable, Future } from '../request.ts';
 import { getPromiseResult, setPromiseResult } from '../request.ts';
 import type { RequestManager } from '../request/-private/manager.ts';
+import { DOMError } from '../request/-private/utils.ts';
 import type { Store } from '../store/-private/store-service.ts';
 import type {
   ImmutableRequestInfo,
@@ -17,16 +18,8 @@ import { defineNonEnumerableSignal, defineSignal } from './reactivity/signal.ts'
 
 const RequestCache = new WeakMap<Future<unknown>, RequestState>();
 
-// Some non-DOM environments (e.g. React Native, some Node/worker
-// environments) may not provide `DOMException` as a global. Guard against
-// that so simply checking whether an error is an abort error doesn't throw.
-const HAS_DOM_EXCEPTION = typeof DOMException !== 'undefined';
-
 function isAbortError(error: unknown): boolean {
-  if (HAS_DOM_EXCEPTION && error instanceof DOMException) {
-    return error.name === 'AbortError';
-  }
-  return error instanceof Error && error.name === 'AbortError';
+  return error instanceof DOMError && error.name === 'AbortError';
 }
 
 interface PrivateLoadingState {

--- a/warp-drive-packages/core/src/signals/request-state.ts
+++ b/warp-drive-packages/core/src/signals/request-state.ts
@@ -17,8 +17,16 @@ import { defineNonEnumerableSignal, defineSignal } from './reactivity/signal.ts'
 
 const RequestCache = new WeakMap<Future<unknown>, RequestState>();
 
+// Some non-DOM environments (e.g. React Native, some Node/worker
+// environments) may not provide `DOMException` as a global. Guard against
+// that so simply checking whether an error is an abort error doesn't throw.
+const HAS_DOM_EXCEPTION = typeof DOMException !== 'undefined';
+
 function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === 'AbortError';
+  if (HAS_DOM_EXCEPTION && error instanceof DOMException) {
+    return error.name === 'AbortError';
+  }
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 interface PrivateLoadingState {

--- a/warp-drive-packages/core/src/signals/request-subscription.ts
+++ b/warp-drive-packages/core/src/signals/request-subscription.ts
@@ -533,40 +533,53 @@ export class RequestSubscription<RT, E> {
 
   /**
    * Install the event listeners for network and visibility changes.
-   * This is only done in browser environments with a global `window`.
+   *
+   * This is only done in environments that provide a fully-featured global
+   * `window` and/or `document`. Some non-DOM environments (e.g. React Native,
+   * SSR/Node, workers) may provide a `window` global without the APIs we
+   * rely on here (or no `window`/`document` at all), in which case we skip
+   * attaching the corresponding listeners rather than throwing.
    *
    * @internal
    */
   private _installListeners() {
-    if (typeof window === 'undefined') {
-      return;
+    const hasWindow = typeof window !== 'undefined';
+    const hasDocument = typeof document !== 'undefined';
+    const hasWindowEvents = hasWindow && typeof window.addEventListener === 'function';
+    const hasDocumentEvents = hasDocument && typeof document.addEventListener === 'function';
+
+    this.isOnline = hasWindow && typeof window.navigator?.onLine === 'boolean' ? window.navigator.onLine : true;
+    this._unavailableStart = this.isOnline ? null : Date.now();
+    this.isHidden =
+      hasDocument && typeof document.visibilityState === 'string' && document.visibilityState === 'hidden';
+
+    if (hasWindowEvents) {
+      this._onlineChanged = (event: Event) => {
+        this.isOnline = event.type === 'online';
+        if (event.type === 'offline' && this._unavailableStart === null) {
+          this._unavailableStart = Date.now();
+        }
+        this._maybeUpdate();
+      };
+
+      window.addEventListener('online', this._onlineChanged, { passive: true, capture: true });
+      window.addEventListener('offline', this._onlineChanged, { passive: true, capture: true });
     }
 
-    this.isOnline = window.navigator.onLine;
-    this._unavailableStart = this.isOnline ? null : Date.now();
-    this.isHidden = document.visibilityState === 'hidden';
+    if (hasDocumentEvents) {
+      this._backgroundChanged = () => {
+        const isHidden = document.visibilityState === 'hidden';
+        this.isHidden = isHidden;
 
-    this._onlineChanged = (event: Event) => {
-      this.isOnline = event.type === 'online';
-      if (event.type === 'offline' && this._unavailableStart === null) {
-        this._unavailableStart = Date.now();
-      }
-      this._maybeUpdate();
-    };
-    this._backgroundChanged = () => {
-      const isHidden = document.visibilityState === 'hidden';
-      this.isHidden = isHidden;
+        if (isHidden && this._unavailableStart === null) {
+          this._unavailableStart = Date.now();
+        }
 
-      if (isHidden && this._unavailableStart === null) {
-        this._unavailableStart = Date.now();
-      }
+        this._maybeUpdate();
+      };
 
-      this._maybeUpdate();
-    };
-
-    window.addEventListener('online', this._onlineChanged, { passive: true, capture: true });
-    window.addEventListener('offline', this._onlineChanged, { passive: true, capture: true });
-    document.addEventListener('visibilitychange', this._backgroundChanged, { passive: true, capture: true });
+      document.addEventListener('visibilitychange', this._backgroundChanged, { passive: true, capture: true });
+    }
   }
 
   /**
@@ -833,17 +846,24 @@ function _DISPOSE<RT, E>(this: RequestSubscription<RT, E>) {
   const self = upgradeSubscription(this);
   self.isDestroyed = true;
   self._removeSubscriptions();
-
-  if (typeof window === 'undefined') {
-    return;
-  }
-
   self._clearInterval();
 
-  window.removeEventListener('online', self._onlineChanged, { passive: true, capture: true } as unknown as boolean);
-  window.removeEventListener('offline', self._onlineChanged, { passive: true, capture: true } as unknown as boolean);
-  document.removeEventListener('visibilitychange', self._backgroundChanged, {
-    passive: true,
-    capture: true,
-  } as unknown as boolean);
+  if (self._onlineChanged && typeof window !== 'undefined' && typeof window.removeEventListener === 'function') {
+    window.removeEventListener('online', self._onlineChanged, { passive: true, capture: true } as unknown as boolean);
+    window.removeEventListener('offline', self._onlineChanged, {
+      passive: true,
+      capture: true,
+    } as unknown as boolean);
+  }
+
+  if (
+    self._backgroundChanged &&
+    typeof document !== 'undefined' &&
+    typeof document.removeEventListener === 'function'
+  ) {
+    document.removeEventListener('visibilitychange', self._backgroundChanged, {
+      passive: true,
+      capture: true,
+    } as unknown as boolean);
+  }
 }


### PR DESCRIPTION
## Summary

- `RequestSubscription` (the reactive class powering `<Request />`'s autorefresh/retry/refresh behavior) crashed on construction/teardown in non-DOM environments such as React Native, because it assumed that a defined global `window` also had a working `addEventListener`/`removeEventListener`, and that `document` existed and had `addEventListener`/`visibilityState`.
- Feature-detects `window`/`document` (and the specific APIs used) in `_installListeners`/`_DISPOSE` in `warp-drive-packages/core/src/signals/request-subscription.ts`, skipping listener attachment/teardown instead of throwing when they're unavailable or incomplete. `isOnline`/`isHidden` fall back to their existing sane defaults (`true`/`false`) when the underlying browser API isn't available.
- Also guards the handful of direct `DOMException` references found during the audit (`isAbortError` in `signals/request-state.ts`, `enhanceReason` in `request/-private/utils.ts`, and the Fetch handler's error classification in `request/-private/fetch.ts`), which would otherwise throw a `ReferenceError` in environments lacking a global `DOMException`.
- No behavior change when `window`/`document`/`DOMException` are fully-featured, as in any real browser or Ember app - this is a purely defensive fix.

Fixes #10428

## Analysis

**The crash:** In React Native (and similarly minimal non-DOM environments), a `window` global may be present (e.g. via a polyfill) without implementing `addEventListener`/`removeEventListener`, and `document` may not exist at all. The existing code in `request-subscription.ts` only checked `typeof window === 'undefined'` before unconditionally calling `window.addEventListener(...)` and reading `document.visibilityState` - so a *defined-but-incomplete* `window`, or any environment where `window` exists but `document` doesn't, still threw `TypeError: window.addEventListener is not a function` or `TypeError: Cannot read properties of undefined (reading 'visibilityState')`, exactly as reported in the issue.

**Blast radius searched:** I grepped all of `warp-drive-packages/core/src`, `warp-drive-packages/json-api/src`, and `warp-drive-packages/utilities/src` for unguarded `window.`, `document.`, and `DOMException` usage.
- `warp-drive-packages/json-api` and `warp-drive-packages/utilities` have none - clean.
- `warp-drive-packages/core/src/signals/request-subscription.ts` - the primary crash site described above (`_installListeners`, `_DISPOSE`), now fixed.
- `warp-drive-packages/core/src/signals/request-state.ts` (`isAbortError`), `warp-drive-packages/core/src/request/-private/utils.ts` (`enhanceReason`), and `warp-drive-packages/core/src/request/-private/fetch.ts` (the Fetch handler's catch block) all reference the bare `DOMException` global directly at runtime (`instanceof DOMException` / `new DOMException(...)`). These sit in the normal request-error/abort-handling path (used whenever any request errors or is aborted, not an opt-in feature), so a missing global `DOMException` there would throw a `ReferenceError` the first time an error/abort was handled - this matches the "Missing DOMException" crash mentioned in the issue. All three are now guarded with a `typeof DOMException !== 'undefined'` check and fall back to a plain `Error` with a matching `.name` where a `DOMException` would otherwise have been constructed.
- `request/-private/context.ts` has a `DOMException` *type* annotation only (erased at compile time, not a runtime reference) - nothing to guard.
- `request/-private/fetch.ts` also has a pre-existing, already-guarded (`typeof window !== 'undefined'`), DEBUG-only Mirage-detection heuristic that additionally assumes `window.fetch` exists once `window` does. This is a dev-only, opt-in-ish heuristic (not part of normal store/signals initialization), so I deliberately left it as-is rather than expanding scope.

**Why a defensive guard (not a new `onlineManager`/`focusManager` API):** TanStack Query solves this class of problem with public `onlineManager`/`focusManager` APIs that apps can configure/override. That's a reasonable *future* enhancement (it would let apps in exotic environments explicitly declare "we're online" / "we're focused" instead of relying on feature detection), but it's a substantial new public API surface with real design questions (configuration shape, defaults, interaction with existing `isOnline`/`isHidden`, SSR considerations) that goes well beyond what's needed to fix this bug. The reported crash is purely "code assumes a global exists/is fully-featured and throws when it isn't" - a targeted, zero-behavior-change defensive guard fully resolves it for the reported environments (React Native, and any other non-DOM/partial-DOM host) without expanding WarpDrive's public API or committing to a design for a feature nobody has asked for yet. I'm flagging the `onlineManager`/`focusManager` idea here explicitly so it's easy to pick up as a follow-up if there's appetite for it.

## Test plan

- [x] Added `tests/core/tests/signals/request-subscription-non-dom-test.ts`: one test simulates the reported failure mode by shadowing `window.addEventListener`/`removeEventListener` and `document.addEventListener`/`removeEventListener`/`visibilityState` for the duration of the test (real browsers don't allow redefining the `window.document` binding itself, so this shadows the specific APIs `RequestSubscription` depends on) and asserts constructing + disposing a `RequestSubscription` does not throw, with `isOnline`/`isHidden` falling back to their defaults. A second test in the same file confirms normal DOM behavior (`isOnline`/`isHidden` tracking `window.navigator.onLine`/`document.visibilityState`) is unchanged.
- [x] `pnpm --filter @warp-drive/core run lint` and `pnpm --filter core-tests run lint` pass.
- [x] `pnpm --filter core-tests run check:types` passes.
- [x] `pnpm exec ember-tsc --build --force` at the repo root shows no new errors (9 pre-existing, unrelated errors on `main` are unchanged by this branch).
- [x] `tests/core` full suite passes in both development and production builds (189 total, 187 pass, 2 skip, 0 fail - includes the 2 new tests).
- [x] `tests/framework-ember` full suite passes (48/48), including the existing `<Request />` DOM-based integration tests (`isOnline updates when expected`, `@autorefreshBehavior="reload" works as expected`, the invalidation/interval autorefresh tests, etc.), confirming zero behavior change for normal Ember-app/browser usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)