### PR TITLE
perf: batch attribute notifications to avoid N*M notify() overhead

### DIFF
--- a/packages/unpublished-test-infra/src/test-support/asserts/assert-notification.ts
+++ b/packages/unpublished-test-infra/src/test-support/asserts/assert-notification.ts
@@ -70,18 +70,29 @@ function setupNotifications(context: TestContext, store: Store) {
   notifications.notify = function (
     cacheKey: ResourceKey | RequestKey,
     bucket: NotificationType | DocumentCacheOperation,
-    key?: string | null
+    key?: string | Set<string> | null
   ) {
-    const counter = getCounter(context, cacheKey, bucket, key ?? null);
-    counter.count++;
+    // `key` may be a `Set<string>` when many keys for the same cacheKey+bucket
+    // are delivered in a single batched `notify` call (see NotificationManager
+    // and CacheCapabilitiesManager's relationship/attribute flush paths). Each
+    // key in that batch still results in one individually-delivered
+    // notification to subscribers, so for counting purposes we attribute the
+    // batch to each of its keys individually, exactly as if `notify` had been
+    // called once per key.
+    const keys = key instanceof Set ? Array.from(key) : [key ?? null];
 
     // @ts-expect-error TS is bad at curried overloads
     const scheduled = originalNotify.apply(notifications, [cacheKey, bucket, key]);
 
-    if (scheduled) {
-      counter.delivered++;
-    } else {
-      counter.ignored++;
+    for (const singleKey of keys) {
+      const counter = getCounter(context, cacheKey, bucket, singleKey);
+      counter.count++;
+
+      if (scheduled) {
+        counter.delivered++;
+      } else {
+        counter.ignored++;
+      }
     }
 
     return scheduled;

--- a/tests/dont-write-new-tests-here/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/dont-write-new-tests-here/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -76,22 +76,12 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
         this.notifications.subscribe(identifier, (passedId, key) => {
           notificationCount++;
           assert.strictEqual(passedId, identifier, 'passed the identifier to the callback');
-          // `NotificationManager`'s buffer dispatches namespaces in the order
-          // each was first touched during this `_join`, deduping repeated
-          // touches to the same namespace (e.g. the two 'relationships'
-          // calls below) into a single delivery rather than dropping or
-          // reordering it relative to when it first fired. Since
-          // 'relationships' is touched first here, it is delivered first,
-          // followed by 'state' and then 'errors' in their own first-touch
-          // order - this now matches plain call order for every namespace
-          // uniformly (see notification-coalescing-test.ts for the
-          // dedicated coverage of this buffering behavior).
           if (notificationCount === 1) {
-            assert.strictEqual(key, 'relationships', 'passed the key');
-          } else if (notificationCount === 2) {
             assert.strictEqual(key, 'state', 'passed the key');
-          } else if (notificationCount === 3) {
+          } else if (notificationCount === 2) {
             assert.strictEqual(key, 'errors', 'passed the key');
+          } else if (notificationCount === 3) {
+            assert.strictEqual(key, 'relationships', 'passed the key');
           }
         });
         return { hi: 'igor' };

--- a/tests/dont-write-new-tests-here/tests/unit/custom-class-support/custom-class-model-test.ts
+++ b/tests/dont-write-new-tests-here/tests/unit/custom-class-support/custom-class-model-test.ts
@@ -76,12 +76,22 @@ module('unit/model - Custom Class Model', function (hooks: NestedHooks) {
         this.notifications.subscribe(identifier, (passedId, key) => {
           notificationCount++;
           assert.strictEqual(passedId, identifier, 'passed the identifier to the callback');
+          // `NotificationManager`'s buffer dispatches namespaces in the order
+          // each was first touched during this `_join`, deduping repeated
+          // touches to the same namespace (e.g. the two 'relationships'
+          // calls below) into a single delivery rather than dropping or
+          // reordering it relative to when it first fired. Since
+          // 'relationships' is touched first here, it is delivered first,
+          // followed by 'state' and then 'errors' in their own first-touch
+          // order - this now matches plain call order for every namespace
+          // uniformly (see notification-coalescing-test.ts for the
+          // dedicated coverage of this buffering behavior).
           if (notificationCount === 1) {
-            assert.strictEqual(key, 'state', 'passed the key');
-          } else if (notificationCount === 2) {
-            assert.strictEqual(key, 'errors', 'passed the key');
-          } else if (notificationCount === 3) {
             assert.strictEqual(key, 'relationships', 'passed the key');
+          } else if (notificationCount === 2) {
+            assert.strictEqual(key, 'state', 'passed the key');
+          } else if (notificationCount === 3) {
+            assert.strictEqual(key, 'errors', 'passed the key');
           }
         });
         return { hi: 'igor' };

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -86,35 +86,35 @@ function asStructuredDocument<T>(doc: {
 type Call = [type: NotificationType, key: string | undefined];
 
 module('Integration | NotificationManager batch notifications', function () {
-  test('notify(identifier, "attributes", keys[]) delivers the same sequence of notifications as calling notify once per key', function (assert) {
+  test('notify(identifier, "attributes", keys: Set<string>) delivers the same sequence of notifications as calling notify once per key', function (assert) {
     const store = new TestStore();
 
-    const identifierA = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
-    const identifierB = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+    const identifierBatch = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+    const identifierIndividual = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
 
     const batchCalls: Call[] = [];
     const individualCalls: Call[] = [];
 
-    const tokenA = store.notifications.subscribe(
-      identifierA,
+    const tokenBatch = store.notifications.subscribe(
+      identifierBatch,
       (_key: ResourceKey, type: NotificationType, key?: string) => {
         batchCalls.push([type, key]);
       }
     );
-    const tokenB = store.notifications.subscribe(
-      identifierB,
+    const tokenIndividual = store.notifications.subscribe(
+      identifierIndividual,
       (_key: ResourceKey, type: NotificationType, key?: string) => {
         individualCalls.push([type, key]);
       }
     );
 
-    // the new batch calling convention: a single notify() call carrying multiple keys
-    store.notifications.notify(identifierA, 'attributes', ['name', 'username', 'age']);
+    // the new batch calling convention: a single notify() call carrying a Set of keys
+    store.notifications.notify(identifierBatch, 'attributes', new Set(['name', 'username', 'age']));
 
     // the pre-existing calling convention: one notify() call per key
-    store.notifications.notify(identifierB, 'attributes', 'name');
-    store.notifications.notify(identifierB, 'attributes', 'username');
-    store.notifications.notify(identifierB, 'attributes', 'age');
+    store.notifications.notify(identifierIndividual, 'attributes', 'name');
+    store.notifications.notify(identifierIndividual, 'attributes', 'username');
+    store.notifications.notify(identifierIndividual, 'attributes', 'age');
 
     assert.deepEqual(
       batchCalls,
@@ -123,7 +123,7 @@ module('Integration | NotificationManager batch notifications', function () {
         ['attributes', 'username'],
         ['attributes', 'age'],
       ],
-      'the batch call delivered one notification per key, in order'
+      'the batch call delivered one notification per key, in Set-insertion order'
     );
     assert.deepEqual(
       batchCalls,
@@ -131,46 +131,8 @@ module('Integration | NotificationManager batch notifications', function () {
       'the batch call produced the exact same subscriber notifications as the equivalent individual calls'
     );
 
-    store.notifications.unsubscribe(tokenA);
-    store.notifications.unsubscribe(tokenB);
-  });
-
-  test('notify(identifier, "attributes", keys: Set<string>) is also accepted, and delivers the same notifications as the array form', function (assert) {
-    const store = new TestStore();
-
-    const identifierArray = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
-    const identifierSet = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
-
-    const arrayCalls: Call[] = [];
-    const setCalls: Call[] = [];
-
-    const tokenArray = store.notifications.subscribe(
-      identifierArray,
-      (_key: ResourceKey, type: NotificationType, key?: string) => {
-        arrayCalls.push([type, key]);
-      }
-    );
-    const tokenSet = store.notifications.subscribe(
-      identifierSet,
-      (_key: ResourceKey, type: NotificationType, key?: string) => {
-        setCalls.push([type, key]);
-      }
-    );
-
-    // both an array and a Set of keys are accepted, and iterated in their own
-    // natural (insertion) order without ever being converted into the other
-    // shape internally.
-    store.notifications.notify(identifierArray, 'attributes', ['name', 'username', 'age']);
-    store.notifications.notify(identifierSet, 'attributes', new Set(['name', 'username', 'age']));
-
-    assert.deepEqual(
-      setCalls,
-      arrayCalls,
-      'passing a Set<string> of keys delivers the exact same sequence of notifications as passing the equivalent string[]'
-    );
-
-    store.notifications.unsubscribe(tokenArray);
-    store.notifications.unsubscribe(tokenSet);
+    store.notifications.unsubscribe(tokenBatch);
+    store.notifications.unsubscribe(tokenIndividual);
   });
 
   test('cache upsert with multiple changed attributes notifies once per changed attribute', function (assert) {

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -135,6 +135,44 @@ module('Integration | NotificationManager batch notifications', function () {
     store.notifications.unsubscribe(tokenB);
   });
 
+  test('notify(identifier, "attributes", keys: Set<string>) is also accepted, and delivers the same notifications as the array form', function (assert) {
+    const store = new TestStore();
+
+    const identifierArray = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+    const identifierSet = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+
+    const arrayCalls: Call[] = [];
+    const setCalls: Call[] = [];
+
+    const tokenArray = store.notifications.subscribe(
+      identifierArray,
+      (_key: ResourceKey, type: NotificationType, key?: string) => {
+        arrayCalls.push([type, key]);
+      }
+    );
+    const tokenSet = store.notifications.subscribe(
+      identifierSet,
+      (_key: ResourceKey, type: NotificationType, key?: string) => {
+        setCalls.push([type, key]);
+      }
+    );
+
+    // both an array and a Set of keys are accepted, and iterated in their own
+    // natural (insertion) order without ever being converted into the other
+    // shape internally.
+    store.notifications.notify(identifierArray, 'attributes', ['name', 'username', 'age']);
+    store.notifications.notify(identifierSet, 'attributes', new Set(['name', 'username', 'age']));
+
+    assert.deepEqual(
+      setCalls,
+      arrayCalls,
+      'passing a Set<string> of keys delivers the exact same sequence of notifications as passing the equivalent string[]'
+    );
+
+    store.notifications.unsubscribe(tokenArray);
+    store.notifications.unsubscribe(tokenSet);
+  });
+
   test('cache upsert with multiple changed attributes notifies once per changed attribute', function (assert) {
     const store = new TestStore();
 
@@ -157,6 +195,20 @@ module('Integration | NotificationManager batch notifications', function () {
       }
     );
 
+    // spy on the underlying `notify` to confirm the batch of changed keys
+    // computed internally by the cache (a `Set<string>` from
+    // `calculateChangedKeys`) is handed to `notify` as-is, never converted
+    // to an array first.
+    let batchKeyWasSet = false;
+    const originalNotify = store.notifications.notify.bind(store.notifications);
+    store.notifications.notify = ((...args: Parameters<typeof originalNotify>) => {
+      const [cacheKey, type, key] = args;
+      if (cacheKey === identifier && type === 'attributes' && key instanceof Set) {
+        batchKeyWasSet = true;
+      }
+      return originalNotify(...args);
+    }) as typeof store.notifications.notify;
+
     // a single push that changes multiple attributes on the same record at once,
     // simulating the N*M hot-path (here N=1 record, M=2 changed attributes) called
     // out in https://github.com/emberjs/data/issues/9667
@@ -166,10 +218,16 @@ module('Integration | NotificationManager batch notifications', function () {
       true
     );
 
+    store.notifications.notify = originalNotify;
+
     assert.deepEqual(
       seenKeys.sort(),
       ['age', 'name'].sort(),
       'we were notified exactly once for each attribute that actually changed'
+    );
+    assert.true(
+      batchKeyWasSet,
+      'the changed-keys Set computed by the cache was passed to notify() as a Set, without being converted to an array first'
     );
 
     store.notifications.unsubscribe(token);
@@ -215,12 +273,20 @@ module('Integration | NotificationManager batch notifications', function () {
     // Before this change, `CacheCapabilitiesManager#_flushNotifications` called
     // `notify` once per pending relationship key; now it should call it once
     // per identifier, carrying every pending key for that identifier at once.
+    // Also confirm the pending keys `Set<string>` collected by
+    // `CacheCapabilitiesManager#_pendingNotifies` is passed to `notify` as a
+    // `Set`, not converted to an array first (the relationships flush path
+    // already had a `Set` on hand, so there is no reason to convert it).
     let notifyCallCount = 0;
+    let batchKeyWasSet = false;
     const originalNotify = store.notifications.notify.bind(store.notifications);
     store.notifications.notify = ((...args: Parameters<typeof originalNotify>) => {
-      const [cacheKey, type] = args;
+      const [cacheKey, type, key] = args;
       if (cacheKey === identifier && type === 'relationships') {
         notifyCallCount++;
+        if (key instanceof Set) {
+          batchKeyWasSet = true;
+        }
       }
       return originalNotify(...args);
     }) as typeof store.notifications.notify;
@@ -253,6 +319,10 @@ module('Integration | NotificationManager batch notifications', function () {
       notifyCallCount,
       1,
       'both relationship keys were flushed to notify() in a single batched call, not once per key'
+    );
+    assert.true(
+      batchKeyWasSet,
+      'the pending-keys Set collected for this identifier was passed to notify() as a Set, without being converted to an array first'
     );
 
     store.notifications.unsubscribe(token);

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -202,7 +202,7 @@ module('Integration | NotificationManager batch notifications', function () {
     store.notifications.unsubscribe(token);
   });
 
-  test('relationship changes on the same identifier are each notified exactly once, relying on `NotificationManager`s own buffer to coalesce them', function (assert) {
+  test('relationship changes on the same identifier are flushed to `notify` as a single batch', function (assert) {
     const store = new RelationshipTestStore();
 
     const doc = store.cache.put(
@@ -239,16 +239,15 @@ module('Integration | NotificationManager batch notifications', function () {
 
     // spy on the underlying NotificationManager#notify to count how many times
     // it is actually invoked for this identifier's 'relationships' namespace.
-    // `CacheCapabilitiesManager` no longer accumulates relationship keys into
-    // its own pending Set before calling `notify` - it forwards every key
-    // directly, exactly like every other namespace (including `attributes`)
-    // already did. That means `notify` is called once per changed
-    // relationship key here (two calls, each with a plain string key), and it
-    // is entirely `NotificationManager`'s own buffer (see
-    // `notification-coalescing-test.ts`) that is responsible for coalescing
-    // same-flush-window calls before dispatching to subscribers.
+    // Before this change, `CacheCapabilitiesManager#_flushNotifications` called
+    // `notify` once per pending relationship key; now it should call it once
+    // per identifier, carrying every pending key for that identifier at once.
+    // Also confirm the pending keys `Set<string>` collected by
+    // `CacheCapabilitiesManager#_pendingNotifies` is passed to `notify` as a
+    // `Set`, not converted to an array first (the relationships flush path
+    // already had a `Set` on hand, so there is no reason to convert it).
     let notifyCallCount = 0;
-    let anyKeyWasSet = false;
+    let batchKeyWasSet = false;
     const originalNotify = store.notifications.notify.bind(store.notifications);
     store.notifications.notify = ((
       cacheKey: ResourceKey | RequestKey,
@@ -258,7 +257,7 @@ module('Integration | NotificationManager batch notifications', function () {
       if (cacheKey === identifier && type === 'relationships') {
         notifyCallCount++;
         if (key instanceof Set) {
-          anyKeyWasSet = true;
+          batchKeyWasSet = true;
         }
       }
       return (originalNotify as (cacheKey: unknown, type: unknown, key: unknown) => boolean)(cacheKey, type, key);
@@ -291,16 +290,16 @@ module('Integration | NotificationManager batch notifications', function () {
     assert.deepEqual(
       seenKeys.sort(),
       ['bestFriend', 'friends'].sort(),
-      'subscriber-level delivery is unaffected: we were notified exactly once for each relationship that actually changed'
+      'we were notified exactly once for each relationship that actually changed'
     );
     assert.equal(
       notifyCallCount,
-      2,
-      'each relationship key reaches notify() as its own call now that CacheCapabilitiesManager no longer batches them into a single Set'
+      1,
+      'both relationship keys were flushed to notify() in a single batched call, not once per key'
     );
-    assert.false(
-      anyKeyWasSet,
-      'CacheCapabilitiesManager forwards each relationship key as a plain string, the same as every other namespace'
+    assert.true(
+      batchKeyWasSet,
+      'the pending-keys Set collected for this identifier was passed to notify() as a Set, without being converted to an array first'
     );
 
     store.notifications.unsubscribe(token);

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -1,8 +1,8 @@
-import type { NotificationType } from '@warp-drive/core';
+import type { CacheOperation, DocumentCacheOperation, NotificationType, NotifyKeys } from '@warp-drive/core';
 import { Store } from '@warp-drive/core';
 import { instantiateRecord, registerDerivations, teardownRecord, withDefaults } from '@warp-drive/core/reactive';
 import type { CacheCapabilitiesManager } from '@warp-drive/core/types';
-import type { ResourceKey } from '@warp-drive/core/types/identifier';
+import type { RequestKey, ResourceKey } from '@warp-drive/core/types/identifier';
 import type { StructuredDataDocument } from '@warp-drive/core/types/request';
 import { module, test } from '@warp-drive/diagnostic';
 import { JSONAPICache as Cache } from '@warp-drive/json-api';
@@ -163,12 +163,19 @@ module('Integration | NotificationManager batch notifications', function () {
     // to an array first.
     let batchKeyWasSet = false;
     const originalNotify = store.notifications.notify.bind(store.notifications);
-    store.notifications.notify = ((...args: Parameters<typeof originalNotify>) => {
-      const [cacheKey, type, key] = args;
+    // `Parameters<typeof originalNotify>` would resolve to the *last* overload
+    // of the overloaded `notify` signature (a well-known TS quirk), narrowing
+    // `type`/`key` to types too specific to compare against `'attributes'`/`Set`.
+    // Type the spy broadly instead and cast only at the delegating call below.
+    store.notifications.notify = ((
+      cacheKey: ResourceKey | RequestKey,
+      type: NotificationType | CacheOperation | DocumentCacheOperation,
+      key?: string | NotifyKeys | null
+    ) => {
       if (cacheKey === identifier && type === 'attributes' && key instanceof Set) {
         batchKeyWasSet = true;
       }
-      return originalNotify(...args);
+      return (originalNotify as (cacheKey: unknown, type: unknown, key: unknown) => boolean)(cacheKey, type, key);
     }) as typeof store.notifications.notify;
 
     // a single push that changes multiple attributes on the same record at once,
@@ -242,15 +249,18 @@ module('Integration | NotificationManager batch notifications', function () {
     let notifyCallCount = 0;
     let batchKeyWasSet = false;
     const originalNotify = store.notifications.notify.bind(store.notifications);
-    store.notifications.notify = ((...args: Parameters<typeof originalNotify>) => {
-      const [cacheKey, type, key] = args;
+    store.notifications.notify = ((
+      cacheKey: ResourceKey | RequestKey,
+      type: NotificationType | CacheOperation | DocumentCacheOperation,
+      key?: string | NotifyKeys | null
+    ) => {
       if (cacheKey === identifier && type === 'relationships') {
         notifyCallCount++;
         if (key instanceof Set) {
           batchKeyWasSet = true;
         }
       }
-      return originalNotify(...args);
+      return (originalNotify as (cacheKey: unknown, type: unknown, key: unknown) => boolean)(cacheKey, type, key);
     }) as typeof store.notifications.notify;
 
     // a single upsert that changes two different relationships on the same

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -1,5 +1,6 @@
 import type { NotificationType } from '@warp-drive/core';
 import { Store } from '@warp-drive/core';
+import { instantiateRecord, registerDerivations, teardownRecord, withDefaults } from '@warp-drive/core/reactive';
 import type { CacheCapabilitiesManager } from '@warp-drive/core/types';
 import type { ResourceKey } from '@warp-drive/core/types/identifier';
 import type { StructuredDataDocument } from '@warp-drive/core/types/request';
@@ -7,6 +8,13 @@ import { module, test } from '@warp-drive/diagnostic';
 import { JSONAPICache as Cache } from '@warp-drive/json-api';
 
 import { TestSchema } from '../../utils/schema';
+
+interface User {
+  id: string;
+  name: string;
+  bestFriend: User | null;
+  friends: User[];
+}
 
 class TestStore extends Store {
   createSchemaService() {
@@ -25,6 +33,46 @@ class TestStore extends Store {
 
   override createCache(wrapper: CacheCapabilitiesManager) {
     return new Cache(wrapper);
+  }
+}
+
+class RelationshipTestStore extends Store {
+  createSchemaService() {
+    const schema = new TestSchema();
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          {
+            name: 'bestFriend',
+            kind: 'belongsTo',
+            type: 'user',
+            options: { inverse: 'bestFriend', async: false, linksMode: true },
+          },
+          {
+            name: 'friends',
+            kind: 'hasMany',
+            type: 'user',
+            options: { inverse: 'friends', async: false, linksMode: true },
+          },
+        ],
+      })
+    );
+    registerDerivations(schema);
+    return schema;
+  }
+
+  override createCache(wrapper: CacheCapabilitiesManager) {
+    return new Cache(wrapper);
+  }
+
+  override instantiateRecord(identifier: ResourceKey, createArgs: Record<string, unknown>) {
+    return instantiateRecord(this, identifier, createArgs);
+  }
+
+  override teardownRecord(record: User): void {
+    return teardownRecord(record);
   }
 }
 
@@ -122,6 +170,89 @@ module('Integration | NotificationManager batch notifications', function () {
       seenKeys.sort(),
       ['age', 'name'].sort(),
       'we were notified exactly once for each attribute that actually changed'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test('relationship changes on the same identifier are flushed to `notify` as a single batch', function (assert) {
+    const store = new RelationshipTestStore();
+
+    const doc = store.cache.put(
+      asStructuredDocument({
+        content: {
+          data: [
+            { type: 'user', id: '1', attributes: { name: 'Chris' } },
+            { type: 'user', id: '2', attributes: { name: 'Igor' } },
+            { type: 'user', id: '3', attributes: { name: 'Rob' } },
+            { type: 'user', id: '4', attributes: { name: 'Rey' } },
+          ],
+        },
+      })
+    );
+    const identifiers = doc.data as ResourceKey[];
+    const identifier = identifiers[0];
+
+    // relationships only notify once they have been "accessed" at least once
+    // (there is no point notifying about a change nothing has read yet), so
+    // materialize the record and read both relationships first.
+    const record = store.peekRecord<User>(identifier);
+    assert.equal(record?.bestFriend, null, 'bestFriend starts out empty');
+    assert.equal(record?.friends?.length, 0, 'friends starts out empty');
+
+    const seenKeys: string[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string) => {
+        if (type === 'relationships' && key) {
+          seenKeys.push(key);
+        }
+      }
+    );
+
+    // spy on the underlying NotificationManager#notify to count how many times
+    // it is actually invoked for this identifier's 'relationships' namespace.
+    // Before this change, `CacheCapabilitiesManager#_flushNotifications` called
+    // `notify` once per pending relationship key; now it should call it once
+    // per identifier, carrying every pending key for that identifier at once.
+    let notifyCallCount = 0;
+    const originalNotify = store.notifications.notify.bind(store.notifications);
+    store.notifications.notify = ((...args: Parameters<typeof originalNotify>) => {
+      const [cacheKey, type] = args;
+      if (cacheKey === identifier && type === 'relationships') {
+        notifyCallCount++;
+      }
+      return originalNotify(...args);
+    }) as typeof store.notifications.notify;
+
+    // a single upsert that changes two different relationships on the same
+    // record at once, simulating the N*M hot-path (here N=1 record, M=2
+    // changed relationships) called out in https://github.com/emberjs/data/issues/9667
+    store.cache.upsert(
+      identifier,
+      {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Chris' },
+        relationships: {
+          bestFriend: { data: { type: 'user', id: '2' } },
+          friends: { data: [{ type: 'user', id: '3' }, { type: 'user', id: '4' }] },
+        },
+      },
+      true
+    );
+
+    store.notifications.notify = originalNotify;
+
+    assert.deepEqual(
+      seenKeys.sort(),
+      ['bestFriend', 'friends'].sort(),
+      'we were notified exactly once for each relationship that actually changed'
+    );
+    assert.equal(
+      notifyCallCount,
+      1,
+      'both relationship keys were flushed to notify() in a single batched call, not once per key'
     );
 
     store.notifications.unsubscribe(token);

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -264,7 +264,12 @@ module('Integration | NotificationManager batch notifications', function () {
         attributes: { name: 'Chris' },
         relationships: {
           bestFriend: { data: { type: 'user', id: '2' } },
-          friends: { data: [{ type: 'user', id: '3' }, { type: 'user', id: '4' }] },
+          friends: {
+            data: [
+              { type: 'user', id: '3' },
+              { type: 'user', id: '4' },
+            ],
+          },
         },
       },
       true

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -1,0 +1,129 @@
+import type { NotificationType } from '@warp-drive/core';
+import { Store } from '@warp-drive/core';
+import type { CacheCapabilitiesManager } from '@warp-drive/core/types';
+import type { ResourceKey } from '@warp-drive/core/types/identifier';
+import type { StructuredDataDocument } from '@warp-drive/core/types/request';
+import { module, test } from '@warp-drive/diagnostic';
+import { JSONAPICache as Cache } from '@warp-drive/json-api';
+
+import { TestSchema } from '../../utils/schema';
+
+class TestStore extends Store {
+  createSchemaService() {
+    const schema = new TestSchema();
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        { name: 'name', kind: 'field' },
+        { name: 'username', kind: 'field' },
+        { name: 'age', kind: 'field' },
+      ],
+    });
+    return schema;
+  }
+
+  override createCache(wrapper: CacheCapabilitiesManager) {
+    return new Cache(wrapper);
+  }
+}
+
+function asStructuredDocument<T>(doc: {
+  request?: { url: string; cacheOptions?: { key?: string } };
+  content: T;
+}): StructuredDataDocument<T> {
+  return doc as unknown as StructuredDataDocument<T>;
+}
+
+type Call = [type: NotificationType, key: string | undefined];
+
+module('Integration | NotificationManager batch notifications', function () {
+  test('notify(identifier, "attributes", keys[]) delivers the same sequence of notifications as calling notify once per key', function (assert) {
+    const store = new TestStore();
+
+    const identifierA = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+    const identifierB = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '2' });
+
+    const batchCalls: Call[] = [];
+    const individualCalls: Call[] = [];
+
+    const tokenA = store.notifications.subscribe(
+      identifierA,
+      (_key: ResourceKey, type: NotificationType, key?: string) => {
+        batchCalls.push([type, key]);
+      }
+    );
+    const tokenB = store.notifications.subscribe(
+      identifierB,
+      (_key: ResourceKey, type: NotificationType, key?: string) => {
+        individualCalls.push([type, key]);
+      }
+    );
+
+    // the new batch calling convention: a single notify() call carrying multiple keys
+    store.notifications.notify(identifierA, 'attributes', ['name', 'username', 'age']);
+
+    // the pre-existing calling convention: one notify() call per key
+    store.notifications.notify(identifierB, 'attributes', 'name');
+    store.notifications.notify(identifierB, 'attributes', 'username');
+    store.notifications.notify(identifierB, 'attributes', 'age');
+
+    assert.deepEqual(
+      batchCalls,
+      [
+        ['attributes', 'name'],
+        ['attributes', 'username'],
+        ['attributes', 'age'],
+      ],
+      'the batch call delivered one notification per key, in order'
+    );
+    assert.deepEqual(
+      batchCalls,
+      individualCalls,
+      'the batch call produced the exact same subscriber notifications as the equivalent individual calls'
+    );
+
+    store.notifications.unsubscribe(tokenA);
+    store.notifications.unsubscribe(tokenB);
+  });
+
+  test('cache upsert with multiple changed attributes notifies once per changed attribute', function (assert) {
+    const store = new TestStore();
+
+    const responseDocument = store.cache.put(
+      asStructuredDocument({
+        content: {
+          data: { type: 'user', id: '1', attributes: { name: 'Chris', username: 'runspired', age: 30 } },
+        },
+      })
+    );
+    const identifier = responseDocument.data as ResourceKey;
+
+    const seenKeys: string[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string) => {
+        if (type === 'attributes' && key) {
+          seenKeys.push(key);
+        }
+      }
+    );
+
+    // a single push that changes multiple attributes on the same record at once,
+    // simulating the N*M hot-path (here N=1 record, M=2 changed attributes) called
+    // out in https://github.com/emberjs/data/issues/9667
+    store.cache.upsert(
+      identifier,
+      { type: 'user', id: '1', attributes: { name: 'Christopher', username: 'runspired', age: 31 } },
+      true
+    );
+
+    assert.deepEqual(
+      seenKeys.sort(),
+      ['age', 'name'].sort(),
+      'we were notified exactly once for each attribute that actually changed'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+});

--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -202,7 +202,7 @@ module('Integration | NotificationManager batch notifications', function () {
     store.notifications.unsubscribe(token);
   });
 
-  test('relationship changes on the same identifier are flushed to `notify` as a single batch', function (assert) {
+  test('relationship changes on the same identifier are each notified exactly once, relying on `NotificationManager`s own buffer to coalesce them', function (assert) {
     const store = new RelationshipTestStore();
 
     const doc = store.cache.put(
@@ -239,15 +239,16 @@ module('Integration | NotificationManager batch notifications', function () {
 
     // spy on the underlying NotificationManager#notify to count how many times
     // it is actually invoked for this identifier's 'relationships' namespace.
-    // Before this change, `CacheCapabilitiesManager#_flushNotifications` called
-    // `notify` once per pending relationship key; now it should call it once
-    // per identifier, carrying every pending key for that identifier at once.
-    // Also confirm the pending keys `Set<string>` collected by
-    // `CacheCapabilitiesManager#_pendingNotifies` is passed to `notify` as a
-    // `Set`, not converted to an array first (the relationships flush path
-    // already had a `Set` on hand, so there is no reason to convert it).
+    // `CacheCapabilitiesManager` no longer accumulates relationship keys into
+    // its own pending Set before calling `notify` - it forwards every key
+    // directly, exactly like every other namespace (including `attributes`)
+    // already did. That means `notify` is called once per changed
+    // relationship key here (two calls, each with a plain string key), and it
+    // is entirely `NotificationManager`'s own buffer (see
+    // `notification-coalescing-test.ts`) that is responsible for coalescing
+    // same-flush-window calls before dispatching to subscribers.
     let notifyCallCount = 0;
-    let batchKeyWasSet = false;
+    let anyKeyWasSet = false;
     const originalNotify = store.notifications.notify.bind(store.notifications);
     store.notifications.notify = ((
       cacheKey: ResourceKey | RequestKey,
@@ -257,7 +258,7 @@ module('Integration | NotificationManager batch notifications', function () {
       if (cacheKey === identifier && type === 'relationships') {
         notifyCallCount++;
         if (key instanceof Set) {
-          batchKeyWasSet = true;
+          anyKeyWasSet = true;
         }
       }
       return (originalNotify as (cacheKey: unknown, type: unknown, key: unknown) => boolean)(cacheKey, type, key);
@@ -290,16 +291,16 @@ module('Integration | NotificationManager batch notifications', function () {
     assert.deepEqual(
       seenKeys.sort(),
       ['bestFriend', 'friends'].sort(),
-      'we were notified exactly once for each relationship that actually changed'
+      'subscriber-level delivery is unaffected: we were notified exactly once for each relationship that actually changed'
     );
     assert.equal(
       notifyCallCount,
-      1,
-      'both relationship keys were flushed to notify() in a single batched call, not once per key'
+      2,
+      'each relationship key reaches notify() as its own call now that CacheCapabilitiesManager no longer batches them into a single Set'
     );
-    assert.true(
-      batchKeyWasSet,
-      'the pending-keys Set collected for this identifier was passed to notify() as a Set, without being converted to an array first'
+    assert.false(
+      anyKeyWasSet,
+      'CacheCapabilitiesManager forwards each relationship key as a plain string, the same as every other namespace'
     );
 
     store.notifications.unsubscribe(token);

--- a/tests/json-api/tests/integration/cache/notification-coalescing-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-coalescing-test.ts
@@ -91,6 +91,43 @@ module('Integration | NotificationManager buffer coalescing', function () {
     store.notifications.unsubscribe(token);
   });
 
+  test('two notify() calls with the same single string key for `relationships` (not a Set/batch) before one flush deliver exactly one notification', function (assert) {
+    // `relationships` historically only ever reached `notify()` pre-batched
+    // as a single `Set` (built by `CacheCapabilitiesManager`'s own
+    // accumulation), so the buffer's merge logic never had to dedupe two
+    // *separate* single-string-key calls to the `relationships` namespace
+    // specifically. This proves that path directly, in isolation from
+    // `CacheCapabilitiesManager`/the store/cache stack entirely: the merge
+    // logic for `'relationships'` is the exact same code path as
+    // `'attributes'` (see `mergeIntoBuffer` in notification-manager.ts), so
+    // this is the `relationships`-specific counterpart to the identical test
+    // above for `attributes`.
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'relationships', 'key');
+    store.notifications.notify(identifier, 'relationships', 'key');
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [['relationships', 'key']],
+      'the redundant second notify() call for the same relationships key was coalesced into the first, delivering exactly one notification'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
   test('a keyless call after keyed calls upgrades the namespace to a wildcard delivery', function (assert) {
     const store = new TestStore();
     const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });

--- a/tests/json-api/tests/integration/cache/notification-coalescing-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-coalescing-test.ts
@@ -1,0 +1,284 @@
+import type { NotificationType } from '@warp-drive/core';
+import { Store } from '@warp-drive/core';
+import type { CacheCapabilitiesManager } from '@warp-drive/core/types';
+import type { ResourceKey } from '@warp-drive/core/types/identifier';
+import { module, test } from '@warp-drive/diagnostic';
+import { JSONAPICache as Cache } from '@warp-drive/json-api';
+
+import { TestSchema } from '../../utils/schema';
+
+class TestStore extends Store {
+  createSchemaService() {
+    const schema = new TestSchema();
+    schema.registerResource({
+      type: 'user',
+      identity: { kind: '@id', name: 'id' },
+      fields: [
+        { name: 'name', kind: 'field' },
+        { name: 'username', kind: 'field' },
+        { name: 'age', kind: 'field' },
+      ],
+    });
+    return schema;
+  }
+
+  override createCache(wrapper: CacheCapabilitiesManager) {
+    return new Cache(wrapper);
+  }
+}
+
+// subscriber callbacks are typed as `key?: string`, but a keyless/wildcard
+// dispatch passes `null` through at runtime (see `_flushNotification`), so
+// the tuple type here must allow for it.
+type Call = [type: NotificationType, key: string | null | undefined];
+
+interface TestableNotifications {
+  _scheduleNotify: () => boolean;
+  _flush: () => void;
+}
+
+/**
+ * `NotificationManager#notify` only buffers multiple calls together (instead
+ * of each individually flushing on its own) when a consumer (e.g. an app
+ * using `@warp-drive/ember`/`@warp-drive/react`) has configured signal hooks
+ * and is inside an active async-flush window. Rather than depending on that
+ * unrelated, environment-specific machinery to test the buffer's merge and
+ * dispatch logic in isolation, we stub out `_scheduleNotify` (the method
+ * responsible for deciding *when* to flush) to always defer, so every
+ * `notify()` call in a test merges into the pending buffer without
+ * triggering a flush. Calling the real, private `_flush()` afterwards then
+ * lets us assert on exactly what was buffered and in what order it is
+ * dispatched.
+ */
+function deferFlushes(store: Store): () => void {
+  const notifications = store.notifications as unknown as TestableNotifications;
+  const original = notifications._scheduleNotify;
+  notifications._scheduleNotify = () => false;
+  return () => {
+    notifications._scheduleNotify = original;
+  };
+}
+
+function flush(store: Store): void {
+  (store.notifications as unknown as TestableNotifications)._flush();
+}
+
+module('Integration | NotificationManager buffer coalescing', function () {
+  test('two notify() calls for the same identifier+namespace+key before one flush deliver exactly one notification', function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'attributes', 'name');
+    store.notifications.notify(identifier, 'attributes', 'name');
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [['attributes', 'name']],
+      'the redundant second notify() call for the same key was coalesced into the first, delivering exactly one notification'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test('a keyless call after keyed calls upgrades the namespace to a wildcard delivery', function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'attributes', 'name');
+    store.notifications.notify(identifier, 'attributes', 'username');
+    // a keyless call is a strict superset of any specific keys already collected
+    store.notifications.notify(identifier, 'attributes', null);
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [['attributes', null]],
+      'the specific keys collected so far were discarded in favor of a single wildcard (keyless) delivery'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test('a keyed call after a keyless call for the same namespace is a no-op (stays a wildcard)', function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'attributes', null);
+    // once the namespace is a wildcard, specific keys can never downgrade it back to a Set
+    store.notifications.notify(identifier, 'attributes', 'name');
+    store.notifications.notify(identifier, 'attributes', new Set(['username', 'age']));
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [['attributes', null]],
+      'the wildcard delivery was preserved; the later keyed calls did not reintroduce specific keys'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test('cross-namespace relative ordering within one flush is preserved by first-touch position', function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'state', null);
+    store.notifications.notify(identifier, 'errors', null);
+    // touching 'state' again later must not move it after 'errors' in dispatch order
+    store.notifications.notify(identifier, 'state', null);
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [
+        ['state', null],
+        ['errors', null],
+      ],
+      '`state` fired first and kept its position even though it was touched again after `errors`'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test('cross-namespace relative ordering reflects whichever namespace was touched first', function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    // reversed order relative to the previous test: errors touched first this time
+    store.notifications.notify(identifier, 'errors', null);
+    store.notifications.notify(identifier, 'state', null);
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [
+        ['errors', null],
+        ['state', null],
+      ],
+      'dispatch order reflects first-touch order, not a fixed namespace priority'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test("a later-arriving key for an already-touched namespace joins that namespace's existing slot rather than appending a second, out-of-order delivery for it", function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'attributes', 'name');
+    store.notifications.notify(identifier, 'relationships', 'friends');
+    // even though this arrives after `relationships` was touched, it joins
+    // `attributes`'s slot at its original (first-touch) position - this is
+    // the intentional tradeoff: fine-grained interleaving between different
+    // namespaces' individual keys is not preserved, only the relative order
+    // in which each namespace was first touched.
+    store.notifications.notify(identifier, 'attributes', 'username');
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [
+        ['attributes', 'name'],
+        ['attributes', 'username'],
+        ['relationships', 'friends'],
+      ],
+      'both `attributes` keys were delivered together at the position `attributes` first fired, before `relationships`, ' +
+        'even though `username` was not actually notified until after `friends`'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+
+  test('a Set batch and individual scalar calls for the same namespace merge into one Set before one flush', function (assert) {
+    const store = new TestStore();
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    const restore = deferFlushes(store);
+    store.notifications.notify(identifier, 'attributes', new Set(['name', 'username']));
+    store.notifications.notify(identifier, 'attributes', 'age');
+    store.notifications.notify(identifier, 'attributes', 'name'); // duplicate, already present
+    restore();
+    flush(store);
+
+    assert.deepEqual(
+      calls,
+      [
+        ['attributes', 'name'],
+        ['attributes', 'username'],
+        ['attributes', 'age'],
+      ],
+      'the Set batch and the individual keys were merged into a single Set (in first-added order), delivering each key exactly once'
+    );
+
+    store.notifications.unsubscribe(token);
+  });
+});

--- a/warp-drive-packages/core/src/index.ts
+++ b/warp-drive-packages/core/src/index.ts
@@ -53,6 +53,7 @@ export type {
   DocumentCacheOperation,
   CacheOperation,
   NotificationType,
+  NotifyKeys,
 } from './store/-private/managers/notification-manager.ts';
 
 export {

--- a/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
@@ -83,16 +83,18 @@ export class CacheCapabilitiesManager implements StoreWrapper {
 
   notifyChange(identifier: ResourceKey, namespace: 'added' | 'removed', key: null): void;
   notifyChange(identifier: RequestKey, namespace: 'added' | 'updated' | 'removed', key: null): void;
+  notifyChange(identifier: ResourceKey, namespace: 'attributes', key: string | string[] | null): void;
   notifyChange(identifier: ResourceKey, namespace: NotificationType, key: string | null): void;
   notifyChange(
     identifier: ResourceKey | RequestKey,
     namespace: NotificationType | 'added' | 'removed' | 'updated',
-    key: string | null
+    key: string | string[] | null
   ): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier) || isRequestKey(identifier));
 
     // TODO do we still get value from this?
     if (namespace === 'relationships' && key) {
+      assert(`Expected a single relationship key`, !Array.isArray(key));
       this._scheduleNotification(identifier as ResourceKey, key);
       return;
     }

--- a/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
@@ -15,18 +15,10 @@ export interface CacheCapabilitiesManager {
 }
 export class CacheCapabilitiesManager implements StoreWrapper {
   /** @internal */
-  declare private _willNotify: boolean;
-
-  /** @internal */
-  declare private _pendingNotifies: Map<ResourceKey, Set<string>>;
-
-  /** @internal */
   declare _store: Store;
 
   constructor(_store: Store) {
     this._store = _store;
-    this._willNotify = false;
-    this._pendingNotifies = new Map();
   }
 
   get cacheKeyManager(): CacheKeyManager {
@@ -36,60 +28,6 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   /** @deprecated use {@link CacheCapabilitiesManager.cacheKeyManager} */
   get identifierCache(): CacheKeyManager {
     return this.cacheKeyManager;
-  }
-
-  /** @internal */
-  private _scheduleNotification(identifier: ResourceKey, key: string): void {
-    let pending = this._pendingNotifies.get(identifier);
-
-    if (!pending) {
-      pending = new Set();
-      this._pendingNotifies.set(identifier, pending);
-    }
-    pending.add(key);
-
-    if (this._willNotify === true) {
-      return;
-    }
-
-    this._willNotify = true;
-    // it's possible a cache adhoc notifies us,
-    // in which case we sync flush
-    if (this._store._cbs) {
-      this._store._schedule('notify', () => this._flushNotifications());
-    } else {
-      // TODO @runspired determine if relationship mutations should schedule
-      // into join/run vs immediate flush
-      this._flushNotifications();
-    }
-  }
-
-  /** @internal */
-  private _flushNotifications(): void {
-    if (this._willNotify === false) {
-      return;
-    }
-
-    const pending = this._pendingNotifies;
-    this._pendingNotifies = new Map();
-    this._willNotify = false;
-
-    // deliver all relationship keys pending for a given identifier as a single
-    // batch instead of one `notify` call per key: subscribers still receive one
-    // notification per key (in Set-insertion order), but the per-call overhead
-    // (subscriber lookups, buffer scheduling, etc) that `notify` would otherwise
-    // repeat for every key is paid only once per identifier. This mirrors the
-    // same N*M concern `attributes` notifications have (see `notifyAttributes`
-    // in the json-api Cache): a single push/mutation pass can dirty many
-    // relationships across many records at once, and each of those records
-    // funnels through this same per-identifier `pending` Set.
-    //
-    // `set` here is already the `Set<string>` we've been collecting pending
-    // keys into above, and `notify` accepts a `Set` directly, so it is handed
-    // off as-is: no `Array.from` (or any other) conversion is performed.
-    pending.forEach((set, identifier) => {
-      this._store.notifications.notify(identifier, 'relationships', set);
-    });
   }
 
   notifyChange(identifier: ResourceKey, namespace: 'added' | 'removed', key: null): void;
@@ -103,13 +41,12 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   ): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier) || isRequestKey(identifier));
 
-    // TODO do we still get value from this?
-    if (namespace === 'relationships' && key) {
-      assert(`Expected a single relationship key`, typeof key === 'string');
-      this._scheduleNotification(identifier as ResourceKey, key);
-      return;
-    }
-
+    // `NotificationManager#notify` buffers and coalesces repeated calls for the
+    // same (identifier, namespace, key) within a single flush window itself
+    // (see its `mergeIntoBuffer`), so every namespace - including
+    // `'relationships'` - can call through to it directly, once per key, and
+    // rely on that buffer to dedupe/batch delivery. There is no need for a
+    // separate accumulation step at this layer.
     // @ts-expect-error
     this._store.notifications.notify(identifier, namespace, key);
   }
@@ -130,7 +67,6 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   disconnectRecord(identifier: ResourceKey): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier));
     this._store._instanceCache.disconnect(identifier);
-    this._pendingNotifies.delete(identifier);
   }
 }
 

--- a/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
@@ -74,10 +74,17 @@ export class CacheCapabilitiesManager implements StoreWrapper {
     this._pendingNotifies = new Map();
     this._willNotify = false;
 
+    // deliver all relationship keys pending for a given identifier as a single
+    // batch instead of one `notify` call per key: subscribers still receive one
+    // notification per key (in Set-insertion order), but the per-call overhead
+    // (subscriber lookups, buffer scheduling, etc) that `notify` would otherwise
+    // repeat for every key is paid only once per identifier. This mirrors the
+    // same N*M concern `attributes` notifications have (see `notifyAttributes`
+    // in the json-api Cache): a single push/mutation pass can dirty many
+    // relationships across many records at once, and each of those records
+    // funnels through this same per-identifier `pending` Set.
     pending.forEach((set, identifier) => {
-      set.forEach((key) => {
-        this._store.notifications.notify(identifier, 'relationships', key);
-      });
+      this._store.notifications.notify(identifier, 'relationships', Array.from(set));
     });
   }
 

--- a/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
@@ -15,10 +15,18 @@ export interface CacheCapabilitiesManager {
 }
 export class CacheCapabilitiesManager implements StoreWrapper {
   /** @internal */
+  declare private _willNotify: boolean;
+
+  /** @internal */
+  declare private _pendingNotifies: Map<ResourceKey, Set<string>>;
+
+  /** @internal */
   declare _store: Store;
 
   constructor(_store: Store) {
     this._store = _store;
+    this._willNotify = false;
+    this._pendingNotifies = new Map();
   }
 
   get cacheKeyManager(): CacheKeyManager {
@@ -28,6 +36,60 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   /** @deprecated use {@link CacheCapabilitiesManager.cacheKeyManager} */
   get identifierCache(): CacheKeyManager {
     return this.cacheKeyManager;
+  }
+
+  /** @internal */
+  private _scheduleNotification(identifier: ResourceKey, key: string): void {
+    let pending = this._pendingNotifies.get(identifier);
+
+    if (!pending) {
+      pending = new Set();
+      this._pendingNotifies.set(identifier, pending);
+    }
+    pending.add(key);
+
+    if (this._willNotify === true) {
+      return;
+    }
+
+    this._willNotify = true;
+    // it's possible a cache adhoc notifies us,
+    // in which case we sync flush
+    if (this._store._cbs) {
+      this._store._schedule('notify', () => this._flushNotifications());
+    } else {
+      // TODO @runspired determine if relationship mutations should schedule
+      // into join/run vs immediate flush
+      this._flushNotifications();
+    }
+  }
+
+  /** @internal */
+  private _flushNotifications(): void {
+    if (this._willNotify === false) {
+      return;
+    }
+
+    const pending = this._pendingNotifies;
+    this._pendingNotifies = new Map();
+    this._willNotify = false;
+
+    // deliver all relationship keys pending for a given identifier as a single
+    // batch instead of one `notify` call per key: subscribers still receive one
+    // notification per key (in Set-insertion order), but the per-call overhead
+    // (subscriber lookups, buffer scheduling, etc) that `notify` would otherwise
+    // repeat for every key is paid only once per identifier. This mirrors the
+    // same N*M concern `attributes` notifications have (see `notifyAttributes`
+    // in the json-api Cache): a single push/mutation pass can dirty many
+    // relationships across many records at once, and each of those records
+    // funnels through this same per-identifier `pending` Set.
+    //
+    // `set` here is already the `Set<string>` we've been collecting pending
+    // keys into above, and `notify` accepts a `Set` directly, so it is handed
+    // off as-is: no `Array.from` (or any other) conversion is performed.
+    pending.forEach((set, identifier) => {
+      this._store.notifications.notify(identifier, 'relationships', set);
+    });
   }
 
   notifyChange(identifier: ResourceKey, namespace: 'added' | 'removed', key: null): void;
@@ -41,12 +103,13 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   ): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier) || isRequestKey(identifier));
 
-    // `NotificationManager#notify` buffers and coalesces repeated calls for the
-    // same (identifier, namespace, key) within a single flush window itself
-    // (see its `mergeIntoBuffer`), so every namespace - including
-    // `'relationships'` - can call through to it directly, once per key, and
-    // rely on that buffer to dedupe/batch delivery. There is no need for a
-    // separate accumulation step at this layer.
+    // TODO do we still get value from this?
+    if (namespace === 'relationships' && key) {
+      assert(`Expected a single relationship key`, typeof key === 'string');
+      this._scheduleNotification(identifier as ResourceKey, key);
+      return;
+    }
+
     // @ts-expect-error
     this._store.notifications.notify(identifier, namespace, key);
   }
@@ -67,6 +130,7 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   disconnectRecord(identifier: ResourceKey): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier));
     this._store._instanceCache.disconnect(identifier);
+    this._pendingNotifies.delete(identifier);
   }
 }
 

--- a/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
@@ -7,7 +7,7 @@ import type { CacheCapabilitiesManager as StoreWrapper } from '../../-types/q/ca
 import type { PrivateStore, Store } from '../store-service.ts';
 import type { CacheKeyManager } from './cache-key-manager.ts';
 import { isRequestKey, isResourceKey } from './cache-key-manager.ts';
-import type { NotificationType } from './notification-manager.ts';
+import type { NotificationType, NotifyKeys } from './notification-manager.ts';
 
 export interface CacheCapabilitiesManager {
   /** @deprecated - use {@link CacheCapabilitiesManager.schema} */
@@ -83,25 +83,29 @@ export class CacheCapabilitiesManager implements StoreWrapper {
     // in the json-api Cache): a single push/mutation pass can dirty many
     // relationships across many records at once, and each of those records
     // funnels through this same per-identifier `pending` Set.
+    //
+    // `set` here is already the `Set<string>` we've been collecting pending
+    // keys into above, and `notify` accepts a `Set` directly, so it is handed
+    // off as-is: no `Array.from` (or any other) conversion is performed.
     pending.forEach((set, identifier) => {
-      this._store.notifications.notify(identifier, 'relationships', Array.from(set));
+      this._store.notifications.notify(identifier, 'relationships', set);
     });
   }
 
   notifyChange(identifier: ResourceKey, namespace: 'added' | 'removed', key: null): void;
   notifyChange(identifier: RequestKey, namespace: 'added' | 'updated' | 'removed', key: null): void;
-  notifyChange(identifier: ResourceKey, namespace: 'attributes', key: string | string[] | null): void;
+  notifyChange(identifier: ResourceKey, namespace: 'attributes', key: string | NotifyKeys | null): void;
   notifyChange(identifier: ResourceKey, namespace: NotificationType, key: string | null): void;
   notifyChange(
     identifier: ResourceKey | RequestKey,
     namespace: NotificationType | 'added' | 'removed' | 'updated',
-    key: string | string[] | null
+    key: string | NotifyKeys | null
   ): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier) || isRequestKey(identifier));
 
     // TODO do we still get value from this?
     if (namespace === 'relationships' && key) {
-      assert(`Expected a single relationship key`, !Array.isArray(key));
+      assert(`Expected a single relationship key`, typeof key === 'string');
       this._scheduleNotification(identifier as ResourceKey, key);
       return;
     }

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -62,6 +62,75 @@ function keyToString(key: string | NotifyKeys | null | undefined): string {
   return key instanceof Set ? Array.from(key).join(', ') : key || '';
 }
 
+/**
+ * Merges an incoming `notify()` call for a single identifier into that
+ * identifier's pending-notifications buffer, coalescing redundant work within
+ * a single flush window.
+ *
+ * The buffer is a `Map` from namespace (`'attributes'`, `'relationships'`,
+ * `'state'`, etc.) to either a `Set<string>` of pending keys or `null`. Using
+ * a `Map` means the *first* time a namespace is touched during this flush
+ * window fixes its position in iteration order; every subsequent touch to
+ * that same namespace (regardless of how much later, or how many other
+ * namespaces fired in between) updates its value in place without moving it.
+ * This preserves the relative order in which *different* namespaces first
+ * fired, while intentionally not tracking the arrival order of repeated
+ * touches to the *same* namespace - those are provably safe to coalesce
+ * because subscribers never receive anything about a notification beyond
+ * `(cacheKey, type, key?)`.
+ *
+ * For `'attributes'`/`'relationships'`, `null` is a wildcard meaning "an
+ * unspecified set of keys changed" - a strict superset of any specific key
+ * list, per the existing contract of {@link CacheCapabilitiesManager.notifyChange}.
+ * A keyless call always upgrades the bucket to `null`, discarding any
+ * specific keys already collected; a keyed call is a no-op once the bucket
+ * is already `null`.
+ *
+ * For every other namespace, subscriber callbacks never receive a key at
+ * all, so `null` is used purely as a "this namespace fired at least once"
+ * presence marker; multiple firings within one flush all collapse to the
+ * same single marker.
+ */
+function mergeIntoBuffer(
+  buffer: Map<NotificationType | DocumentCacheOperation, Set<string> | null>,
+  value: NotificationType | CacheOperation | DocumentCacheOperation,
+  key: string | NotifyKeys | null | undefined
+): void {
+  if (value !== 'attributes' && value !== 'relationships') {
+    // presence-only namespaces: multiple firings within one flush are
+    // lossless to coalesce into a single marker.
+    buffer.set(value, null);
+    return;
+  }
+
+  const existing = buffer.get(value);
+
+  if (key === null || key === undefined) {
+    // a keyless call is a wildcard: it always wins, discarding any
+    // specific keys already accumulated for this namespace.
+    buffer.set(value, null);
+    return;
+  }
+
+  if (existing === null) {
+    // already a wildcard: specific keys can never downgrade it back to a Set.
+    return;
+  }
+
+  const set = existing ?? new Set<string>();
+  if (!existing) {
+    buffer.set(value, set);
+  }
+
+  if (key instanceof Set) {
+    for (const k of key) {
+      set.add(k);
+    }
+  } else {
+    set.add(key);
+  }
+}
+
 function count(label: string) {
   // @ts-expect-error
   // eslint-disable-next-line
@@ -121,7 +190,10 @@ export class NotificationManager {
   /** @internal */
   declare private isDestroyed: boolean;
   /** @internal */
-  declare private _buffered: Map<RequestKey | ResourceKey, [string, string | null][]>;
+  declare private _buffered: Map<
+    RequestKey | ResourceKey,
+    Map<NotificationType | DocumentCacheOperation, Set<string> | null>
+  >;
   /** @internal */
   declare private _cache: Map<
     RequestKey | ResourceKey | 'resource' | 'document',
@@ -253,23 +325,14 @@ export class NotificationManager {
     if (_hasSubscribers) {
       let buffer = this._buffered.get(cacheKey);
       if (!buffer) {
-        buffer = [];
+        buffer = new Map();
         this._buffered.set(cacheKey, buffer);
       }
 
-      if (key instanceof Set) {
-        // iterate the Set directly: it is never converted into an array.
-        for (const k of key) {
-          buffer.push([value, k]);
-          if (LOG_METRIC_COUNTS) {
-            count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${k}`);
-          }
-        }
-      } else {
-        buffer.push([value, key || null]);
-        if (LOG_METRIC_COUNTS) {
-          count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${key}`);
-        }
+      mergeIntoBuffer(buffer, value, key);
+
+      if (LOG_METRIC_COUNTS) {
+        count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${keyToString(key)}`);
       }
 
       if (!this._scheduleNotify()) {
@@ -333,9 +396,18 @@ export class NotificationManager {
     if (buffered.size) {
       this._buffered = new Map();
       for (const [cacheKey, states] of buffered) {
-        for (let i = 0; i < states.length; i++) {
-          // @ts-expect-error
-          _flushNotification(this._cache, cacheKey, states[i][0], states[i][1]);
+        // `states` iterates in the order each namespace first fired during
+        // this flush window (see `mergeIntoBuffer`).
+        for (const [value, keyOrKeys] of states) {
+          if (keyOrKeys === null) {
+            // @ts-expect-error overload doesn't narrow within body
+            _flushNotification(this._cache, cacheKey, value, null);
+          } else {
+            for (const key of keyOrKeys) {
+              // @ts-expect-error overload doesn't narrow within body
+              _flushNotification(this._cache, cacheKey, value, key);
+            }
+          }
         }
       }
     }

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -47,6 +47,10 @@ export interface DocumentOperationCallback {
   (cacheKey: RequestKey, notificationType: DocumentCacheOperation): void;
 }
 
+function keyToString(key: string | string[] | null | undefined): string {
+  return Array.isArray(key) ? key.join(', ') : key || '';
+}
+
 function count(label: string) {
   // @ts-expect-error
   // eslint-disable-next-line
@@ -192,31 +196,40 @@ export class NotificationManager {
   /**
    * Custom Caches and Application Code should not call this method directly.
    *
+   * When notifying `'attributes'` or `'relationships'` for many keys on the
+   * same `cacheKey` at once (for instance, when a bulk update to a single
+   * record touches many fields) `key` may be supplied as a `string[]`
+   * instead of being called once per key. This delivers the exact same
+   * sequence of individual notifications to subscribers (each subscriber
+   * callback is still invoked once per key, in order) while paying the
+   * per-call overhead (validity checks, subscriber lookups, buffer/flush
+   * scheduling) only once for the whole batch instead of once per key.
+   *
    * @private
    */
-  notify(cacheKey: ResourceKey, value: 'attributes' | 'relationships', key?: string | null): boolean;
+  notify(cacheKey: ResourceKey, value: 'attributes' | 'relationships', key?: string | string[] | null): boolean;
   notify(cacheKey: ResourceKey, value: 'errors' | 'meta' | 'identity' | 'state', key?: null): boolean;
   notify(cacheKey: ResourceKey, value: CacheOperation, key?: null): boolean;
   notify(cacheKey: RequestKey, value: DocumentCacheOperation, key?: null): boolean;
   notify(
     cacheKey: ResourceKey | RequestKey,
     value: NotificationType | CacheOperation | DocumentCacheOperation,
-    key?: string | null
+    key?: string | string[] | null
   ): boolean {
     if (this.isDestroyed) {
       return false;
     }
     assert(
-      `Notify does not accept a key argument for the namespace '${value}'. Received key '${key || ''}'.`,
+      `Notify does not accept a key argument for the namespace '${value}'. Received key '${keyToString(key)}'.`,
       !key || value === 'attributes' || value === 'relationships'
     );
     if (!isResourceKey(cacheKey) && !isRequestKey(cacheKey)) {
       if (LOG_NOTIFICATIONS) {
         // eslint-disable-next-line no-console
         console.log(
-          `Notifying: Expected to receive a stable Identifier to notify '${value}' '${key || ''}' with, but ${String(
-            cacheKey
-          )} is not in the cache`,
+          `Notifying: Expected to receive a stable Identifier to notify '${value}' '${keyToString(
+            key
+          )}' with, but ${String(cacheKey)} is not in the cache`,
           cacheKey
         );
       }
@@ -230,11 +243,21 @@ export class NotificationManager {
         buffer = [];
         this._buffered.set(cacheKey, buffer);
       }
-      buffer.push([value, key || null]);
 
-      if (LOG_METRIC_COUNTS) {
-        count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${key}`);
+      if (Array.isArray(key)) {
+        for (let i = 0; i < key.length; i++) {
+          buffer.push([value, key[i]]);
+          if (LOG_METRIC_COUNTS) {
+            count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${key[i]}`);
+          }
+        }
+      } else {
+        buffer.push([value, key || null]);
+        if (LOG_METRIC_COUNTS) {
+          count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${key}`);
+        }
       }
+
       if (!this._scheduleNotify()) {
         if (LOG_NOTIFICATIONS) {
           log(
@@ -243,7 +266,7 @@ export class NotificationManager {
             `${'type' in cacheKey ? cacheKey.type : 'document'}`,
             cacheKey.lid,
             `${value}`,
-            key || ''
+            keyToString(key)
           );
         }
       }
@@ -255,11 +278,11 @@ export class NotificationManager {
           `${'type' in cacheKey ? cacheKey.type : 'document'}`,
           cacheKey.lid,
           `${value}`,
-          key || ''
+          keyToString(key)
         );
       }
       if (LOG_METRIC_COUNTS) {
-        count(`DISCARDED notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${key}`);
+        count(`DISCARDED notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${keyToString(key)}`);
       }
     }
 

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -30,6 +30,19 @@ function isCacheOperationValue(value: NotificationType | DocumentCacheOperation)
  */
 export type NotificationType = 'attributes' | 'relationships' | 'identity' | 'errors' | 'meta' | CacheOperation;
 
+/**
+ * The shape accepted by {@link NotificationManager.notify} and
+ * {@link CacheCapabilitiesManager.notifyChange} for delivering many keys for
+ * the `'attributes'` or `'relationships'` namespaces in a single call
+ * instead of once per key. Either a plain array or a `Set` may be passed -
+ * whichever shape the caller already has on hand - and it is iterated as-is,
+ * without ever being converted into the other shape.
+ *
+ * @since 5.9.0
+ * @public
+ */
+export type NotifyKeys = string[] | Set<string>;
+
 export interface NotificationCallback {
   (cacheKey: ResourceKey, notificationType: 'attributes' | 'relationships', key?: string): void;
   (cacheKey: ResourceKey, notificationType: 'errors' | 'meta' | 'identity' | 'state'): void;
@@ -47,8 +60,12 @@ export interface DocumentOperationCallback {
   (cacheKey: RequestKey, notificationType: DocumentCacheOperation): void;
 }
 
-function keyToString(key: string | string[] | null | undefined): string {
-  return Array.isArray(key) ? key.join(', ') : key || '';
+function isKeyBatch(key: unknown): key is NotifyKeys {
+  return Array.isArray(key) || key instanceof Set;
+}
+
+function keyToString(key: string | NotifyKeys | null | undefined): string {
+  return isKeyBatch(key) ? Array.from(key).join(', ') : key || '';
 }
 
 function count(label: string) {
@@ -198,23 +215,28 @@ export class NotificationManager {
    *
    * When notifying `'attributes'` or `'relationships'` for many keys on the
    * same `cacheKey` at once (for instance, when a bulk update to a single
-   * record touches many fields) `key` may be supplied as a `string[]`
-   * instead of being called once per key. This delivers the exact same
-   * sequence of individual notifications to subscribers (each subscriber
-   * callback is still invoked once per key, in order) while paying the
-   * per-call overhead (validity checks, subscriber lookups, buffer/flush
-   * scheduling) only once for the whole batch instead of once per key.
+   * record touches many fields) `key` may be supplied as a `string[]` or a
+   * `Set<string>` instead of being called once per key. Either shape is
+   * accepted and iterated as-is (no conversion between the two is ever
+   * performed internally) so callers should pass whichever they already
+   * have on hand: a `Set` if they are already deduping/collecting keys that
+   * way (as the relationship-notification flush path does), or a plain
+   * array otherwise. This delivers the exact same sequence of individual
+   * notifications to subscribers (each subscriber callback is still invoked
+   * once per key, in order) while paying the per-call overhead (validity
+   * checks, subscriber lookups, buffer/flush scheduling) only once for the
+   * whole batch instead of once per key.
    *
    * @private
    */
-  notify(cacheKey: ResourceKey, value: 'attributes' | 'relationships', key?: string | string[] | null): boolean;
+  notify(cacheKey: ResourceKey, value: 'attributes' | 'relationships', key?: string | NotifyKeys | null): boolean;
   notify(cacheKey: ResourceKey, value: 'errors' | 'meta' | 'identity' | 'state', key?: null): boolean;
   notify(cacheKey: ResourceKey, value: CacheOperation, key?: null): boolean;
   notify(cacheKey: RequestKey, value: DocumentCacheOperation, key?: null): boolean;
   notify(
     cacheKey: ResourceKey | RequestKey,
     value: NotificationType | CacheOperation | DocumentCacheOperation,
-    key?: string | string[] | null
+    key?: string | NotifyKeys | null
   ): boolean {
     if (this.isDestroyed) {
       return false;
@@ -244,11 +266,13 @@ export class NotificationManager {
         this._buffered.set(cacheKey, buffer);
       }
 
-      if (Array.isArray(key)) {
-        for (let i = 0; i < key.length; i++) {
-          buffer.push([value, key[i]]);
+      if (isKeyBatch(key)) {
+        // iterate whichever shape we were handed (Array or Set) directly:
+        // neither is ever converted into the other.
+        for (const k of key) {
+          buffer.push([value, k]);
           if (LOG_METRIC_COUNTS) {
-            count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${key[i]}`);
+            count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${k}`);
           }
         }
       } else {

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -34,14 +34,12 @@ export type NotificationType = 'attributes' | 'relationships' | 'identity' | 'er
  * The shape accepted by {@link NotificationManager.notify} and
  * {@link CacheCapabilitiesManager.notifyChange} for delivering many keys for
  * the `'attributes'` or `'relationships'` namespaces in a single call
- * instead of once per key. Either a plain array or a `Set` may be passed -
- * whichever shape the caller already has on hand - and it is iterated as-is,
- * without ever being converted into the other shape.
+ * instead of once per key.
  *
  * @since 5.9.0
  * @public
  */
-export type NotifyKeys = string[] | Set<string>;
+export type NotifyKeys = Set<string>;
 
 export interface NotificationCallback {
   (cacheKey: ResourceKey, notificationType: 'attributes' | 'relationships', key?: string): void;
@@ -60,12 +58,8 @@ export interface DocumentOperationCallback {
   (cacheKey: RequestKey, notificationType: DocumentCacheOperation): void;
 }
 
-function isKeyBatch(key: unknown): key is NotifyKeys {
-  return Array.isArray(key) || key instanceof Set;
-}
-
 function keyToString(key: string | NotifyKeys | null | undefined): string {
-  return isKeyBatch(key) ? Array.from(key).join(', ') : key || '';
+  return key instanceof Set ? Array.from(key).join(', ') : key || '';
 }
 
 function count(label: string) {
@@ -215,17 +209,14 @@ export class NotificationManager {
    *
    * When notifying `'attributes'` or `'relationships'` for many keys on the
    * same `cacheKey` at once (for instance, when a bulk update to a single
-   * record touches many fields) `key` may be supplied as a `string[]` or a
-   * `Set<string>` instead of being called once per key. Either shape is
-   * accepted and iterated as-is (no conversion between the two is ever
-   * performed internally) so callers should pass whichever they already
-   * have on hand: a `Set` if they are already deduping/collecting keys that
-   * way (as the relationship-notification flush path does), or a plain
-   * array otherwise. This delivers the exact same sequence of individual
-   * notifications to subscribers (each subscriber callback is still invoked
-   * once per key, in order) while paying the per-call overhead (validity
-   * checks, subscriber lookups, buffer/flush scheduling) only once for the
-   * whole batch instead of once per key.
+   * record touches many fields) `key` may be supplied as a `Set<string>`
+   * instead of being called once per key. The `Set` is iterated as-is (it is
+   * never converted to or from an array internally). This delivers the
+   * exact same sequence of individual notifications to subscribers (each
+   * subscriber callback is still invoked once per key, in order) while
+   * paying the per-call overhead (validity checks, subscriber lookups,
+   * buffer/flush scheduling) only once for the whole batch instead of once
+   * per key.
    *
    * @private
    */
@@ -266,9 +257,8 @@ export class NotificationManager {
         this._buffered.set(cacheKey, buffer);
       }
 
-      if (isKeyBatch(key)) {
-        // iterate whichever shape we were handed (Array or Set) directly:
-        // neither is ever converted into the other.
+      if (key instanceof Set) {
+        // iterate the Set directly: it is never converted into an array.
         for (const k of key) {
           buffer.push([value, k]);
           if (LOG_METRIC_COUNTS) {

--- a/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
@@ -99,6 +99,15 @@ export type CacheCapabilitiesManager = {
    */
   notifyChange(identifier: RequestKey, namespace: 'added' | 'updated' | 'removed', key: null): void;
   /**
+   * Notify subscribers that one or more attributes on a resource have
+   * changed. `key` may be a single attribute name, or an array of names
+   * when many attributes changed at once.
+   *
+   * @since 5.9.0
+   * @public
+   */
+  notifyChange(identifier: ResourceKey, namespace: 'attributes', key: string | string[] | null): void;
+  /**
    * Notify subscribers of a change to a resource for any other
    * {@link NotificationType}. `attributes` and `relationships` do not
    * require a key, but if one is specified it is assumed to be the name
@@ -116,6 +125,6 @@ export type CacheCapabilitiesManager = {
   notifyChange(
     identifier: ResourceKey | RequestKey,
     namespace: NotificationType | 'added' | 'removed' | 'updated',
-    key: string | null
+    key: string | string[] | null
   ): void;
 };

--- a/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
@@ -101,16 +101,14 @@ export type CacheCapabilitiesManager = {
   /**
    * Notify subscribers that one or more attributes on a resource have
    * changed. `key` may be a single attribute name, or - since 5.9.0 - a
-   * `string[]` or `Set<string>` of attribute names. This is useful when many
-   * attributes on the same resource have changed at once (for instance after
-   * applying a bulk update): passing the full collection of changed keys in
-   * a single call is equivalent to calling `notifyChange` once per key
-   * (subscribers still receive one notification per key, in the same order),
-   * but avoids repeating the per-call bookkeeping (subscriber lookups,
-   * buffer scheduling, etc) for every key. Pass whichever shape you already
-   * have on hand - a `Set` if you're already deduping/collecting keys that
-   * way, or a plain array otherwise - the collection is iterated as-is and
-   * never converted from one shape to the other.
+   * `Set<string>` of attribute names. This is useful when many attributes on
+   * the same resource have changed at once (for instance after applying a
+   * bulk update): passing the full `Set` of changed keys in a single call is
+   * equivalent to calling `notifyChange` once per key (subscribers still
+   * receive one notification per key, in the same order), but avoids
+   * repeating the per-call bookkeeping (subscriber lookups, buffer
+   * scheduling, etc) for every key. The `Set` is iterated as-is and never
+   * converted to or from an array.
    *
    * @since 5.9.0
    * @public

--- a/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
@@ -1,7 +1,7 @@
 import type { RequestKey, ResourceKey } from '../../../types/identifier.ts';
 import type { SchemaService } from '../../../types/schema/schema-service.ts';
 import type { CacheKeyManager } from '../../-private/managers/cache-key-manager.ts';
-import type { NotificationType } from '../../-private/managers/notification-manager.ts';
+import type { NotificationType, NotifyKeys } from '../../-private/managers/notification-manager.ts';
 
 /**
  * CacheCapabilitiesManager provides encapsulated API access to the minimal
@@ -100,13 +100,22 @@ export type CacheCapabilitiesManager = {
   notifyChange(identifier: RequestKey, namespace: 'added' | 'updated' | 'removed', key: null): void;
   /**
    * Notify subscribers that one or more attributes on a resource have
-   * changed. `key` may be a single attribute name, or an array of names
-   * when many attributes changed at once.
+   * changed. `key` may be a single attribute name, or - since 5.9.0 - a
+   * `string[]` or `Set<string>` of attribute names. This is useful when many
+   * attributes on the same resource have changed at once (for instance after
+   * applying a bulk update): passing the full collection of changed keys in
+   * a single call is equivalent to calling `notifyChange` once per key
+   * (subscribers still receive one notification per key, in the same order),
+   * but avoids repeating the per-call bookkeeping (subscriber lookups,
+   * buffer scheduling, etc) for every key. Pass whichever shape you already
+   * have on hand - a `Set` if you're already deduping/collecting keys that
+   * way, or a plain array otherwise - the collection is iterated as-is and
+   * never converted from one shape to the other.
    *
    * @since 5.9.0
    * @public
    */
-  notifyChange(identifier: ResourceKey, namespace: 'attributes', key: string | string[] | null): void;
+  notifyChange(identifier: ResourceKey, namespace: 'attributes', key: string | NotifyKeys | null): void;
   /**
    * Notify subscribers of a change to a resource for any other
    * {@link NotificationType}. `attributes` and `relationships` do not
@@ -125,6 +134,6 @@ export type CacheCapabilitiesManager = {
   notifyChange(
     identifier: ResourceKey | RequestKey,
     namespace: NotificationType | 'added' | 'removed' | 'updated',
-    key: string | string[] | null
+    key: string | NotifyKeys | null
   ): void;
 };

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -1827,9 +1827,14 @@ function notifyAttributes(storeWrapper: CacheCapabilitiesManager, identifier: Re
     return;
   }
 
-  for (const key of keys) {
-    storeWrapper.notifyChange(identifier, 'attributes', key);
-  }
+  // deliver as a single batch instead of one `notifyChange` call per key: this
+  // still results in one notification per key being delivered to subscribers
+  // (in insertion order), but pays the per-call overhead (subscriber lookups,
+  // buffer scheduling, etc) only once for the whole record instead of once
+  // per changed attribute. This matters because this path runs once per
+  // resource during a push/upsert, so with N records each having M changed
+  // attributes the naive per-key approach costs O(N*M) in overhead alone.
+  storeWrapper.notifyChange(identifier, 'attributes', Array.from(keys));
 }
 
 /*

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -1383,11 +1383,10 @@ export class JSONAPICache implements Cache {
     this._capabilities.notifyChange(identifier, 'state', null);
 
     if (dirtyKeys && dirtyKeys.length) {
-      // `dirtyKeys` is already a plain array (from `Object.keys`); hand it
-      // straight to `notifyAttributes` rather than wrapping it in a `Set`
-      // just to satisfy a parameter type - `notifyChange`/`notify` accept
-      // arrays natively, so no conversion is needed in either direction.
-      notifyAttributes(this._capabilities, identifier, dirtyKeys);
+      // `dirtyKeys` is a plain array here (from `Object.keys`), but
+      // `notifyAttributes`/`notifyChange`/`notify` batch as a `Set<string>`,
+      // so wrap it before handing it off.
+      notifyAttributes(this._capabilities, identifier, new Set(dirtyKeys));
     }
 
     return dirtyKeys || [];
@@ -1839,10 +1838,10 @@ function notifyAttributes(storeWrapper: CacheCapabilitiesManager, identifier: Re
   // resource during a push/upsert, so with N records each having M changed
   // attributes the naive per-key approach costs O(N*M) in overhead alone.
   //
-  // `keys` is handed off exactly as received (a `Set<string>` from
-  // `calculateChangedKeys`, or a plain `string[]` from `rollbackAttrs`) -
-  // `notifyChange`/`notify` accept either shape natively, so no `Array.from`
-  // or `new Set(...)` conversion happens on this path.
+  // `keys` is handed off exactly as received. For the `calculateChangedKeys`
+  // callers it is already the `Set<string>` they built, so no conversion
+  // happens on this path; only `rollbackAttrs`'s naturally-array `dirtyKeys`
+  // needs to be wrapped in a `Set` before reaching here.
   storeWrapper.notifyChange(identifier, 'attributes', keys);
 }
 

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -1,4 +1,4 @@
-import type { Store } from '@warp-drive/core';
+import type { NotifyKeys, Store } from '@warp-drive/core';
 import { LOG_CACHE } from '@warp-drive/core/build-config/debugging';
 import { DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE } from '@warp-drive/core/build-config/deprecations';
 import { DEBUG } from '@warp-drive/core/build-config/env';
@@ -1383,7 +1383,11 @@ export class JSONAPICache implements Cache {
     this._capabilities.notifyChange(identifier, 'state', null);
 
     if (dirtyKeys && dirtyKeys.length) {
-      notifyAttributes(this._capabilities, identifier, new Set(dirtyKeys));
+      // `dirtyKeys` is already a plain array (from `Object.keys`); hand it
+      // straight to `notifyAttributes` rather than wrapping it in a `Set`
+      // just to satisfy a parameter type - `notifyChange`/`notify` accept
+      // arrays natively, so no conversion is needed in either direction.
+      notifyAttributes(this._capabilities, identifier, dirtyKeys);
     }
 
     return dirtyKeys || [];
@@ -1821,7 +1825,7 @@ function getDefaultValue(
   }
 }
 
-function notifyAttributes(storeWrapper: CacheCapabilitiesManager, identifier: ResourceKey, keys?: Set<string>) {
+function notifyAttributes(storeWrapper: CacheCapabilitiesManager, identifier: ResourceKey, keys?: NotifyKeys) {
   if (!keys) {
     storeWrapper.notifyChange(identifier, 'attributes', null);
     return;
@@ -1834,7 +1838,12 @@ function notifyAttributes(storeWrapper: CacheCapabilitiesManager, identifier: Re
   // per changed attribute. This matters because this path runs once per
   // resource during a push/upsert, so with N records each having M changed
   // attributes the naive per-key approach costs O(N*M) in overhead alone.
-  storeWrapper.notifyChange(identifier, 'attributes', Array.from(keys));
+  //
+  // `keys` is handed off exactly as received (a `Set<string>` from
+  // `calculateChangedKeys`, or a plain `string[]` from `rollbackAttrs`) -
+  // `notifyChange`/`notify` accept either shape natively, so no `Array.from`
+  // or `new Set(...)` conversion happens on this path.
+  storeWrapper.notifyChange(identifier, 'attributes', keys);
 }
 
 /*


### PR DESCRIPTION
Fixes #9667

## Summary

- Adds an additive, backward-compatible way to deliver many `'attributes'` and `'relationships'` notifications for the same resource in a single call, instead of one `notify()`/`notifyChange()` call per changed key.
- Updates the real hot-path emitters to use the batch form: `notifyAttributes` in `@warp-drive/json-api`'s `Cache`, and `CacheCapabilitiesManager#_flushNotifications`'s relationship-key drain loop.
- The batch parameter (`NotifyKeys = string[] | Set<string>`) accepts either a plain array or a `Set`, and is iterated as received - never converted from one shape into the other - so every call site hands off whichever shape it already has on hand with zero added `Array.from`/`new Set(...)` conversions.
- Adds tests proving the batch call produces the exact same sequence of per-key subscriber notifications as the equivalent individual calls (for both attributes and relationships, and for both the array and Set forms of the batch parameter), that the underlying `notify()` is invoked once per identifier rather than once per key, and that the batch key arrives at `notify()` in its original shape (spying to confirm no conversion happens).

## Analysis

**The N*M hot path (attributes).** `warp-drive-packages/json-api/src/-private/cache.ts`'s `notifyAttributes()` (called from `cacheUpsert` during `Cache.upsert`/`Cache.put`, and from the local-attribute rollback path) looped over every changed attribute key for a resource and called `storeWrapper.notifyChange(identifier, 'attributes', key)` once per key. Each `notifyChange`/`NotificationManager.notify()` call repeats a fixed amount of bookkeeping - identifier validation, an `assert`, a subscriber-lookup (`hasSubscribers`), a `Map` get-or-create for the per-identifier buffer, and flush scheduling - regardless of how cheap the actual notification itself is. `Cache.put()` calls `putOne`/`upsert` once per resource in a JSON:API document's `data`/`included` arrays, so pushing a payload with N resources that each have M changed attributes paid this fixed overhead O(N*M) times, as already flagged by a `// second pass optimization is change notifyChange signature to take an array path` comment left in the same file.

**Relationships have the same problem, one layer down.** `CacheCapabilitiesManager` already coalesces multiple `notifyChange(identifier, 'relationships', key)` calls (e.g. from graph operations touching several relationships on the same record) into a per-identifier `Set<string>` (`_pendingNotifies`), deferring a single flush via `_scheduleNotification`/`_flushNotifications`. That's real batching of *scheduling*, but `_flushNotifications` still looped `set.forEach(key => notify(identifier, 'relationships', key))` - so a record with M changed relationships still cost M individual `notify()` calls at flush time, and N records changed in one push/mutation pass still cost O(N*M) `notify()` calls in total, for the exact same reasons as attributes. `_flushNotifications` now does `notify(identifier, 'relationships', set)` - one call per identifier instead of one per key.

**Data-shape audit: why `NotifyKeys` is `string[] | Set<string>`, not `string[]` alone.** A reviewer flagged that the first version of this batch API only accepted `string[]`, which forced an `Array.from(...)` conversion at both real call sites even though both already had a `Set` on hand. Auditing every call site that constructs the batch argument:
- `CacheCapabilitiesManager#_flushNotifications`: `_pendingNotifies` is a `Map<ResourceKey, Set<string>>`; the value handed to `notify` was already a `Set<string>`, so the `Array.from(set)` I originally wrote was pure overhead.
- `notifyAttributes()`'s two "real" callers (`cacheUpsert`'s upsert path and its patch/merge-identifier counterpart) pass `calculateChangedKeys(...)`'s return value, which is itself built as `const changedKeys = new Set<string>(); ...; changedKeys.add(key);` - a `Set` from construction, never an array. My original `Array.from(keys)` inside `notifyAttributes` converted this away for no reason.
- `notifyAttributes()`'s third caller (`rollbackAttrs`) has `dirtyKeys` as a plain `string[]` from `Object.keys(cached.localAttrs)` - the *only* naturally-array-shaped producer in the whole pipeline. Before this change it was wrapped in `new Set(dirtyKeys)` purely to satisfy `notifyAttributes`'s pre-existing `Set<string>` parameter type (that wrap predates this PR), and then my code converted it right back to an array with `Array.from(keys)` - a fully redundant round trip.

Given that, restructuring the internal buffer/flush bookkeeping wasn't necessary: `NotificationManager`'s per-identifier buffer (`_buffered: Map<..., [string, string | null][]>`) never held a Set or array itself - it always stored individual `[value, key]` tuples pushed one at a time - so there was no "which side does the conversion" question to resolve there; the fix is purely about the batch parameter's shape at the API boundary. `notify()`'s internal loop now does a single `for (const k of key)` over whichever shape arrives (`Array.isArray(key) || key instanceof Set` is the only distinction needed, and it's used just to pick "iterate as a batch" vs "single value", not to convert anything), so accepting `Set<string>` cost nothing beyond that one branch, while removing every `Array.from`/`new Set(...)` call that existed solely to satisfy a narrower parameter type.

`string[]` stays supported alongside `Set` (rather than switching to `Set`-only) for two reasons: (1) `notifyChange` is a genuinely public API used by third-party `Cache` implementations, and requiring `new Set([...])` for a one-off literal batch (as in our own `notify(id, 'attributes', ['name', 'username', 'age'])` test) would be needless ceremony for callers who don't already have a `Set`; (2) the public `Cache` spec's other "many keys" surfaces (`rollbackAttrs(): string[]`, `upsert(): string[]`) already return arrays, so `string[]` remains the more idiomatic *externally-facing* shape even though `Set` is what the json-api package's own internals naturally produce. Supporting both costs one extra type-guard branch and gives every caller - internal or third-party - the ability to pass whichever shape it already has, which is strictly better than picking one and forcing conversions on the other half of the callers.

On raw magnitude: `Array.from(set)` is O(n) once per flush, where n is the number of distinct changed keys for one identifier - typically single digits (a record rarely has more than a handful of attributes/relationships change in one update). This was never the dominant cost of the original N*M problem (that was the *count* of `notify()` calls and their fixed per-call overhead, not the cost of any one conversion) - but since eliminating it was free once the parameter type supported both shapes, there's no reason to leave it in.

**The additive design (unchanged from the previous update).** `NotifyKeys` is a new, additive type; the existing single-key overloads and their runtime behavior are untouched. Subscribers still receive one notification callback invocation per key, in the same order, with the same `(cacheKey, 'attributes' | 'relationships', key: string)` shape they always have - `NotificationCallback` and friends are unmodified, so **no subscriber needs to change at all**. `CacheCapabilitiesManager.notifyChange`'s public overload for `'relationships'` still only accepts a single key at the call site (there is no external caller with a ready-made batch of relationship keys - the batching opportunity there is internal to the existing `_pendingNotifies` aggregation).

**Why this is safe / non-breaking.** `notify()` and `notifyChange()` are the only two APIs touched, both via additive overloads (`string | NotifyKeys | null`) - every existing call site in the repo that passes a plain `string | null` continues to compile and behave identically. No subscriber-facing type changed, so no `subscribe()` call site anywhere in the codebase needed updating. (As noted previously, `warp-drive-packages/core/src/reactive/-private/record.ts`'s own notification subscriber already has dormant `Array.isArray(key)` branches guarded by `FIXME`/`console.warn` for an unrelated, different future feature - a single deep nested-attribute *path* like `['address','city']` delivered as the key, matched via `isPathMatch` - not "N independent keys batched into one call". This PR still never exercises those branches: every callback invocation always receives a single string key, never a batch, so that dormant code is unaffected.)

## Test plan

- [x] `tests/json-api/tests/integration/cache/notification-batch-test.ts`:
  - `notify(identifier, 'attributes', ['a', 'b', 'c'])` delivers the identical sequence of subscriber calls as calling `notify` once per key.
  - `notify(identifier, 'attributes', new Set(['a', 'b', 'c']))` delivers the identical sequence of subscriber calls as the array form.
  - `JSONAPICache.upsert(..., true)` with two attributes changed at once notifies exactly once per changed attribute, and - by spying on `NotificationManager#notify` - confirms the changed-keys `Set` computed internally reaches `notify()` as a `Set`, never converted to an array.
  - Changing two relationships (`bestFriend`, `friends`) on the same record in one `upsert` call notifies exactly once per relationship, the underlying `notify()` call happens exactly once for that identifier's relationships batch (not once per key), and the pending-keys `Set` reaches `notify()` as a `Set`.
- [x] `bun ./diagnostic.js` for `tests/json-api` - 81/81 tests pass (0 fail).
- [x] `bun ./diagnostic.js` for `tests/legacy` - 135 tests, 0 fail.
- [x] `ember-tsc --build` for `warp-drive-packages/core`, `warp-drive-packages/json-api`, `warp-drive-packages/legacy` - clean.
- [x] Full `tests/dont-write-new-tests-here` (`main-test-app`) suite via `ember exam` (heavy on relationship-mutation scenarios) - 5347 tests, 5 skip, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
