### PR TITLE
docs: document LegacyNetworkHandler, expectId, SerializerOptions, AdapterPayload

### DIFF
--- a/warp-drive-packages/legacy/src/compat/legacy-network-handler/legacy-network-handler.ts
+++ b/warp-drive-packages/legacy/src/compat/legacy-network-handler/legacy-network-handler.ts
@@ -47,6 +47,13 @@ const PotentialLegacyOperations = new Set([
   'deleteRecord',
 ]);
 
+/**
+ * A {@link Handler} that fulfills legacy `findRecord`/`findAll`/`query`/
+ * `queryRecord`/`findBelongsTo`/`findHasMany`/`createRecord`/`updateRecord`/
+ * `deleteRecord` requests using the store's configured {@link MinimumAdapterInterface | adapter}
+ * and {@link MinimumSerializerInterface | serializer}, passing any other
+ * request through to the next handler unchanged.
+ */
 export const LegacyNetworkHandler: Handler = {
   request<T>(context: StoreRequestContext, next: NextFn<T>): Future<T> | Promise<StructuredDataDocument<T>> {
     // if we are not a legacy request, move on

--- a/warp-drive-packages/legacy/src/compat/legacy-network-handler/minimum-adapter-interface.ts
+++ b/warp-drive-packages/legacy/src/compat/legacy-network-handler/minimum-adapter-interface.ts
@@ -6,6 +6,8 @@ import type { LegacyQueryArray } from '@warp-drive/core/store/-private';
 import type { ModelSchema } from '@warp-drive/core/types';
 import type { LegacyRelationshipField as RelationshipSchema } from '@warp-drive/core/types/schema/fields';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { MinimumSerializerInterface } from './minimum-serializer-interface.ts';
 import type { Snapshot } from './snapshot.ts';
 import type { SnapshotRecordArray } from './snapshot-record-array.ts';
 
@@ -15,6 +17,10 @@ type Group = Snapshot[];
 // however those deserialization cases are handled
 // far easier in the adapter itself and are unlikely
 // to be passed to the serializer today.
+/**
+ * The raw payload shape returned by a legacy adapter's request methods,
+ * prior to being normalized by a {@link MinimumSerializerInterface}.
+ */
 export type AdapterPayload = Record<string, unknown> | unknown[];
 
 /**

--- a/warp-drive-packages/legacy/src/compat/legacy-network-handler/minimum-serializer-interface.ts
+++ b/warp-drive-packages/legacy/src/compat/legacy-network-handler/minimum-serializer-interface.ts
@@ -9,7 +9,16 @@ import type { JsonApiDocument, SingleResourceDocument } from '@warp-drive/core/t
 import type { AdapterPayload } from './minimum-adapter-interface.ts';
 import type { Snapshot } from './snapshot.ts';
 
-export type SerializerOptions = { includeId?: boolean };
+/**
+ * Options accepted by {@link MinimumSerializerInterface.serialize | serialize}
+ * and related legacy serializer methods.
+ */
+export type SerializerOptions = {
+  /**
+   * whether the resource's id should be included in the serialized output
+   */
+  includeId?: boolean;
+};
 export type RequestType =
   | 'findRecord'
   | 'queryRecord'

--- a/warp-drive-packages/legacy/src/compat/utils.ts
+++ b/warp-drive-packages/legacy/src/compat/utils.ts
@@ -163,7 +163,18 @@ export function formattedId(id: string | number | null): string | null {
   return id === null ? null : String(id);
 }
 
+/**
+ * Like {@link formattedId}, but asserts that `id` is not `null` rather
+ * than allowing and passing through `null`.
+ *
+ * @public
+ */
 export function expectId(id: string | number): string;
+/**
+ * Throws, since `id` is `null`.
+ *
+ * @public
+ */
 export function expectId(id: null): never;
 export function expectId(id: string | number | null): string {
   AssertFn('expectId: id must not be null', id !== null);


### PR DESCRIPTION
## Summary
- \`LegacyNetworkHandler\`, \`expectId\` (both overloads), \`SerializerOptions\`, and \`AdapterPayload\` had no doc comments.

Part of an ongoing pass to bring \`warp-drive-packages/*\` API doc coverage up to standard (see #10569).