### PR TITLE
docs: document Boolean/Date/Number/String transforms, fix stale @ember-data/model imports

### DIFF
--- a/warp-drive-packages/legacy/src/serializer/-private/transforms/boolean.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/transforms/boolean.ts
@@ -4,6 +4,9 @@ import type { TransformName } from '@warp-drive/core/types/symbols';
 import type { attr } from '../../../model';
 
 export interface BooleanTransform {
+  /**
+   * see {@link TransformName}
+   */
   [TransformName]: 'boolean';
 }
 
@@ -42,6 +45,10 @@ export interface BooleanTransform {
   @public
  */
 export class BooleanTransform {
+  /**
+   * Converts a serialized (raw payload) value into a `boolean` (or `null`
+   * when `allowNull` is set and the value is nullish).
+   */
   deserialize(serialized: boolean | null | number | string, options?: { allowNull?: boolean }): boolean | null {
     if ((serialized === null || serialized === undefined) && options?.allowNull === true) {
       return null;
@@ -58,6 +65,9 @@ export class BooleanTransform {
     }
   }
 
+  /**
+   * Converts a `boolean` attribute value into its serialized (raw payload) form.
+   */
   serialize(deserialized: boolean | null, options?: { allowNull?: boolean }): boolean | null {
     if ((deserialized === null || deserialized === undefined) && options?.allowNull === true) {
       return null;
@@ -66,6 +76,9 @@ export class BooleanTransform {
     return Boolean(deserialized);
   }
 
+  /**
+   * Creates a new instance of this transform.
+   */
   static create(): BooleanTransform {
     return new this();
   }

--- a/warp-drive-packages/legacy/src/serializer/-private/transforms/date.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/transforms/date.ts
@@ -4,6 +4,9 @@ import type { TransformName } from '@warp-drive/core/types/symbols';
 import type { attr } from '../../../model';
 
 export interface DateTransform {
+  /**
+   * see {@link TransformName}
+   */
   [TransformName]: 'date';
 }
 /**
@@ -14,7 +17,7 @@ export interface DateTransform {
  standard.
 
  ```js [app/models/score.js]
- import Model, { attr, belongsTo } from '@ember-data/model';
+ import Model, { attr, belongsTo } from '@warp-drive/legacy/model';
 
  export default class ScoreModel extends Model {
     @attr('number') value;
@@ -27,6 +30,10 @@ export interface DateTransform {
  */
 
 export class DateTransform {
+  /**
+   * Converts a serialized (raw payload) `ISO 8601` string, epoch number,
+   * or nullish value into a `Date` (or `null`/`undefined`).
+   */
   deserialize(serialized: string | number | null, _options?: Record<string, unknown>): Date | null {
     if (typeof serialized === 'string') {
       let offset = serialized.indexOf('+');
@@ -47,6 +54,10 @@ export class DateTransform {
     }
   }
 
+  /**
+   * Converts a `Date` attribute value into an `ISO 8601` string, or `null`
+   * if the value is not a valid `Date`.
+   */
   serialize(date: Date, _options?: Record<string, unknown>): string | null {
     // @ts-expect-error isNaN accepts date as it is coercible
     if (date instanceof Date && !isNaN(date)) {
@@ -56,6 +67,9 @@ export class DateTransform {
     }
   }
 
+  /**
+   * Creates a new instance of this transform.
+   */
   static create(): DateTransform {
     return new this();
   }

--- a/warp-drive-packages/legacy/src/serializer/-private/transforms/number.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/transforms/number.ts
@@ -8,6 +8,9 @@ function isNumber(value: number) {
 }
 
 export interface NumberTransform {
+  /**
+   * see {@link TransformName}
+   */
   [TransformName]: 'number';
 }
 
@@ -20,7 +23,7 @@ export interface NumberTransform {
   Usage
 
   ```js [app/models/score.js]
-  import Model, { attr, belongsTo } from '@ember-data/model';
+  import Model, { attr, belongsTo } from '@warp-drive/legacy/model';
 
   export default class ScoreModel extends Model {
     @attr('number') value;
@@ -32,6 +35,10 @@ export interface NumberTransform {
   @public
  */
 export class NumberTransform {
+  /**
+   * Converts a serialized (raw payload) value into a `number`, or `null`
+   * if the value is empty, nullish, or not a valid number.
+   */
   deserialize(serialized: string | number | null | undefined, _options?: Record<string, unknown>): number | null {
     if (serialized === '' || serialized === null || serialized === undefined) {
       return null;
@@ -42,6 +49,9 @@ export class NumberTransform {
     }
   }
 
+  /**
+   * Converts a `number` attribute value into its serialized (raw payload) form.
+   */
   serialize(deserialized: string | number | null | undefined, _options?: Record<string, unknown>): number | null {
     if (deserialized === '' || deserialized === null || deserialized === undefined) {
       return null;
@@ -52,6 +62,9 @@ export class NumberTransform {
     }
   }
 
+  /**
+   * Creates a new instance of this transform.
+   */
   static create(): NumberTransform {
     return new this();
   }

--- a/warp-drive-packages/legacy/src/serializer/-private/transforms/string.ts
+++ b/warp-drive-packages/legacy/src/serializer/-private/transforms/string.ts
@@ -4,6 +4,9 @@ import type { TransformName } from '@warp-drive/core/types/symbols';
 import type { attr } from '../../../model';
 
 export interface StringTransform {
+  /**
+   * see {@link TransformName}
+   */
   [TransformName]: 'string';
 }
 /**
@@ -15,7 +18,7 @@ export interface StringTransform {
   Usage
 
   ```js [app/models/user.js]
-  import Model, { attr, belongsTo } from '@ember-data/model';
+  import Model, { attr, belongsTo } from '@warp-drive/legacy/model';
 
   export default class UserModel extends Model {
     @attr('boolean') isAdmin;
@@ -27,13 +30,23 @@ export interface StringTransform {
   @public
  */
 export class StringTransform {
+  /**
+   * Converts a serialized (raw payload) value into a `string`, or `null`
+   * if the value is falsy (and not an empty string).
+   */
   deserialize(serialized: unknown, _options?: Record<string, unknown>): string | null {
     return !serialized && serialized !== '' ? null : String(serialized);
   }
+  /**
+   * Converts a `string` attribute value into its serialized (raw payload) form.
+   */
   serialize(deserialized: unknown, _options?: Record<string, unknown>): string | null {
     return !deserialized && deserialized !== '' ? null : String(deserialized);
   }
 
+  /**
+   * Creates a new instance of this transform.
+   */
   static create(): StringTransform {
     return new this();
   }


### PR DESCRIPTION
## Summary
- \`BooleanTransform\`, \`DateTransform\`, \`NumberTransform\`, \`StringTransform\`'s \`deserialize\`/\`serialize\`/\`create\` methods and \`[TransformName]\` interface property had no doc comments, despite each class having a top-level doc comment.
- While in these files, also fixed stale \`@ember-data/model\` imports in the \`number.ts\`/\`date.ts\`/\`string.ts\` code examples to \`@warp-drive/legacy/model\` (the same stale-import pattern fixed elsewhere for #10359; \`boolean.ts\`'s example was already correct).

Part of an ongoing pass to bring \`warp-drive-packages/*\` API doc coverage up to standard (see #10569).