### PR TITLE
docs: document remaining Model/Store/Serializer legacy leftover APIs

### DIFF
--- a/warp-drive-packages/legacy/src/model/-private/hooks.ts
+++ b/warp-drive-packages/legacy/src/model/-private/hooks.ts
@@ -11,6 +11,13 @@ import { normalizeModelName } from './util.ts';
 
 function recast(context: Store): asserts context is ModelStore {}
 
+/**
+ * The `instantiateRecord` hook implementation for use with `Model`. Pass
+ * this to your store's `instantiateRecord` method when configuring the
+ * store to use `Model` for schema/record instantiation.
+ *
+ * @public
+ */
 export function instantiateRecord(
   this: Store,
   identifier: ResourceKey,
@@ -39,15 +46,34 @@ export function instantiateRecord(
   return factory.class.create(createOptions);
 }
 
+/**
+ * The `teardownRecord` hook implementation for use with `Model`. Pass this
+ * to your store's `teardownRecord` method when configuring the store to
+ * use `Model` for schema/record instantiation.
+ *
+ * @public
+ */
 export function teardownRecord(record: Model): void {
   assert(
-    `expected to receive an instance of Model from @ember-data/model. If using a custom model make sure you implement teardownRecord`,
+    `expected to receive an instance of Model from @warp-drive/legacy/model. If using a custom model make sure you implement teardownRecord`,
     'destroy' in record
   );
   record.destroy();
 }
 
+/**
+ * The `modelFor` implementation for use with `Model`, exposed on the store
+ * as `store.modelFor(type)` when the store is configured to use `Model`.
+ * Returns the `Model` subclass registered for the given type, if any.
+ *
+ * @public
+ */
 export function modelFor<T>(type: TypeFromInstance<T>): typeof Model | void;
+/**
+ * Overload accepting a raw type string instead of a typed record instance.
+ *
+ * @public
+ */
 export function modelFor(type: string): typeof Model | void;
 export function modelFor<T>(this: Store, modelName: TypeFromInstanceOrString<T>): typeof Model | void {
   assertPrivateStore(this);

--- a/warp-drive-packages/legacy/src/model/-private/schema-provider.ts
+++ b/warp-drive-packages/legacy/src/model/-private/schema-provider.ts
@@ -264,6 +264,13 @@ if (ENABLE_LEGACY_SCHEMA_SERVICE) {
   };
 }
 
+/**
+ * The `createSchemaService` implementation for use with `Model`. Pass
+ * the result of this to your store's `createSchemaService` method when
+ * configuring the store to use `Model` for schema information.
+ *
+ * @public
+ */
 export function buildSchema(store: Store): SchemaService {
   return new ModelSchemaProvider(store as ModelStore);
 }

--- a/warp-drive-packages/legacy/src/serializer.ts
+++ b/warp-drive-packages/legacy/src/serializer.ts
@@ -142,7 +142,6 @@ const service = s.service ?? s.inject;
 */
 
 export class Serializer extends EmberObject {
-  @service declare store: Store;
   /**
     The `store` property is the application's `store` that contains
     all records. It can be used to look up serializers for other model
@@ -160,10 +159,9 @@ export class Serializer extends EmberObject {
     });
     ```
 
-    @property store
-    @type {Store}
     @public
   */
+  @service declare store: Store;
 
   /**
     The `normalizeResponse` method is used to normalize a payload from the

--- a/warp-drive-packages/legacy/src/store.ts
+++ b/warp-drive-packages/legacy/src/store.ts
@@ -24,6 +24,13 @@ import type {
 } from './store/-private.ts';
 import { getShimClass, preloadData, RecordReference, resourceIsFullyDeleted } from './store/-private.ts';
 
+/**
+ * Restores the deprecated `findRecord`/`findAll`/`query`/`queryRecord`/
+ * `findBelongsTo`/`findHasMany`/`createRecord`/`deleteRecord`/`saveRecord`
+ * legacy-network-layer implementations of these methods onto the given
+ * `Store` subclass, for apps that have not yet migrated to the
+ * `RequestManager`-based equivalents.
+ */
 export function restoreDeprecatedStoreBehaviors(StoreKlass: typeof Store): void {
   StoreKlass.prototype.findRecord = function (
     resource: string | ResourceIdentifierObject,


### PR DESCRIPTION
## Summary
- Documents `instantiateRecord`/`teardownRecord`/`modelFor` (model/-private/hooks.ts) and `buildSchema` (schema-provider.ts)
- Fixes a misplaced doc comment on `Serializer.store` (was positioned after the field instead of before it)
- Documents `restoreDeprecatedStoreBehaviors` (store.ts)

(Note: this PR originally also touched `AsyncHasMany`/`PromiseManyArray` docs, but that was independently merged in #10619, so it's been rebased out here.)

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms no declarations were stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)