### PR TITLE
docs: document BuildURLMixin variable and legacy store setup option interfaces

### DIFF
--- a/warp-drive-packages/legacy/src/adapter/-private/build-url-mixin.ts
+++ b/warp-drive-packages/legacy/src/adapter/-private/build-url-mixin.ts
@@ -799,4 +799,10 @@ const mixinProps: BuildURLMixin = {
   pathForType,
 };
 
+/**
+ * The `Mixin` implementation of {@link BuildURLMixin}, ready to be applied
+ * to an `EmberObject` subclass such as an `Adapter`.
+ *
+ * @public
+ */
 export const BuildURLMixin: Mixin = Mixin.create(mixinProps);

--- a/warp-drive-packages/legacy/src/index.ts
+++ b/warp-drive-packages/legacy/src/index.ts
@@ -61,6 +61,12 @@ interface _LegacyStoreSetupOptions<T extends Cache> extends Omit<StoreSetupOptio
   modelFragments?: boolean;
 }
 
+/**
+ * Setup options for a legacy store configured to use `Model` with `linksMode`
+ * enabled, meaning no legacy adapter/serializer request infrastructure is required.
+ *
+ * @public
+ */
 export interface LegacyModelStoreSetupOptions<T extends Cache> extends _LegacyStoreSetupOptions<T> {
   /**
    * If true, it is presumed that no requests require use of the LegacyNetworkHandler
@@ -82,6 +88,13 @@ export interface LegacyModelStoreSetupOptions<T extends Cache> extends _LegacySt
   legacyRequests?: false;
 }
 
+/**
+ * Setup options for a legacy store configured to use `Model` along with the
+ * legacy adapter/serializer network layer, but without the deprecated
+ * `store.findRecord`/`findAll`/`query`/etc. request methods.
+ *
+ * @public
+ */
 export interface LegacyModelAndNetworkStoreSetupOptions<T extends Cache> extends _LegacyStoreSetupOptions<T> {
   /**
    * If true, it is presumed that no requests require use of the LegacyNetworkHandler
@@ -101,6 +114,13 @@ export interface LegacyModelAndNetworkStoreSetupOptions<T extends Cache> extends
   legacyRequests?: false;
 }
 
+/**
+ * Setup options for a legacy store configured to use `Model` along with the
+ * legacy adapter/serializer network layer and the deprecated
+ * `store.findRecord`/`findAll`/`query`/etc. request methods.
+ *
+ * @public
+ */
 export interface LegacyModelAndNetworkAndRequestStoreSetupOptions<T extends Cache> extends _LegacyStoreSetupOptions<T> {
   /**
    * If true, it is presumed that no requests require use of the LegacyNetworkHandler
@@ -135,7 +155,14 @@ export type LegacyStoreSetupOptions<T extends Cache = Cache> =
   | LegacyModelAndNetworkStoreSetupOptions<T>
   | LegacyModelAndNetworkAndRequestStoreSetupOptions<T>;
 
-export declare class ConfiguredStore<T extends { cache: Cache }> extends Store {
+export declare class ConfiguredStore<
+  T extends {
+    /**
+     * The {@link Cache} implementation this store was configured with.
+     */
+    cache: Cache;
+  },
+> extends Store {
   // get cache(): T extends OptionsWithCache<infer R> ? R : never;
   createCache(capabilities: CacheCapabilitiesManager): T['cache'];
 }


### PR DESCRIPTION
## Summary
- Documents the exported `BuildURLMixin` const (previously only its merged interface had docs)
- Documents `LegacyModelStoreSetupOptions`, `LegacyModelAndNetworkStoreSetupOptions`, `LegacyModelAndNetworkAndRequestStoreSetupOptions`
- Documents `ConfiguredStore`'s `cache` type constraint property

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms no declarations were stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)