### PR TITLE
docs: document Fragment/FragmentArray schema extension APIs

### DIFF
--- a/warp-drive-packages/legacy/src/model-fragments/extensions/fragment-array.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/extensions/fragment-array.ts
@@ -8,11 +8,24 @@ import type Model from '../../model.ts';
 import type { WithFragmentArray } from '../index.ts';
 import type { Fragment } from './fragment.ts';
 
+/**
+ * The features added to an array resource by {@link FragmentArrayExtension}, providing
+ * a subset of the legacy `ModelFragments` fragment-array API for migrated resources.
+ */
 export class FragmentArray<T extends Fragment> {
   // We might want to check the parent values once we move this code to warp-drive.
+  /**
+   * Whether this fragment array is in the process of being destroyed.
+   */
   @tracked isDestroying = false;
+  /**
+   * Whether this fragment array has been destroyed.
+   */
   @tracked isDestroyed = false;
 
+  /**
+   * Whether this fragment array (or any of its members) has uncommitted changes.
+   */
   @cached
   get hasDirtyAttributes(): boolean {
     const array = this as unknown as ManagedArray;
@@ -32,6 +45,9 @@ export class FragmentArray<T extends Fragment> {
     return false;
   }
 
+  /**
+   * Adds an existing fragment to this array, if one was given.
+   */
   addFragment(fragment?: T): Fragment[] | undefined {
     if (!fragment) {
       return;
@@ -40,6 +56,9 @@ export class FragmentArray<T extends Fragment> {
     return (this as unknown as WithFragmentArray<T>).addObject(fragment);
   }
 
+  /**
+   * Appends a new fragment to the end of this array, if one was given.
+   */
   createFragment(fragment?: T): Fragment | undefined {
     if (!fragment) {
       return;
@@ -48,6 +67,9 @@ export class FragmentArray<T extends Fragment> {
     return (this as unknown as WithFragmentArray<T>).pushObject(fragment);
   }
 
+  /**
+   * Removes the given fragment from this array, if present.
+   */
   removeFragment(fragment?: T): void {
     if (!fragment) {
       return;
@@ -60,6 +82,9 @@ export class FragmentArray<T extends Fragment> {
     }
   }
 
+  /**
+   * Reverts each member fragment's attribute back to its last known remote value.
+   */
   rollbackAttributes(): void {
     for (const fragment of this as unknown as WithFragmentArray<T>) {
       // @ts-expect-error TODO: fix these types
@@ -68,9 +93,22 @@ export class FragmentArray<T extends Fragment> {
   }
 }
 
+/**
+ * A schema extension that adds the {@link FragmentArray} API to migrated
+ * `ModelFragments` array resources.
+ */
 export const FragmentArrayExtension: {
+  /**
+   * This extension applies to `'array'` schemas.
+   */
   kind: 'array';
+  /**
+   * The registered name of this extension.
+   */
   name: 'fragment-array';
+  /**
+   * The features ({@link FragmentArray}) added by this extension.
+   */
   features: typeof FragmentArray;
 } = {
   kind: 'array' as const,

--- a/warp-drive-packages/legacy/src/model-fragments/extensions/fragment.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/extensions/fragment.ts
@@ -7,11 +7,24 @@ import type { Value } from '@warp-drive/core/types/json/raw';
 
 import type Model from '../../model.ts';
 
+/**
+ * The features added to an object resource by {@link FragmentExtension}, providing
+ * a subset of the legacy `ModelFragments` fragment API for migrated resources.
+ */
 export class Fragment {
   // We might want to check the parent values once we move this code to warp-drive.
+  /**
+   * Whether this fragment is in the process of being destroyed.
+   */
   @tracked isDestroying = false;
+  /**
+   * Whether this fragment has been destroyed.
+   */
   @tracked isDestroyed = false;
 
+  /**
+   * Whether this fragment (or the attribute it is rooted at) has uncommitted changes.
+   */
   @cached
   get hasDirtyAttributes(): boolean {
     const { path, resourceKey, store } = (this as unknown as PrivateReactiveResource)[Context];
@@ -25,15 +38,24 @@ export class Fragment {
     return false;
   }
 
+  /**
+   * Always `true`. Used to distinguish fragments from other resources.
+   */
   get isFragment() {
     return true;
   }
 
+  /**
+   * The resource type of this fragment, if known.
+   */
   get $type(): string | null | undefined {
     const { field } = (this as unknown as PrivateReactiveResource)[Context];
     return field?.type;
   }
 
+  /**
+   * Reverts this fragment's attribute back to its last known remote value.
+   */
   rollbackAttributes(this: PrivateReactiveResource): void {
     const { path, resourceKey, store } = this[Context];
 
@@ -44,9 +66,22 @@ export class Fragment {
   }
 }
 
+/**
+ * A schema extension that adds the {@link Fragment} API to migrated
+ * `ModelFragments` object resources.
+ */
 export const FragmentExtension: {
+  /**
+   * This extension applies to `'object'` schemas.
+   */
   kind: 'object';
+  /**
+   * The registered name of this extension.
+   */
   name: 'fragment';
+  /**
+   * The features ({@link Fragment}) added by this extension.
+   */
   features: typeof Fragment;
 } = {
   kind: 'object' as const,


### PR DESCRIPTION
## Summary
- Documents the `Fragment` class and its members (`isDestroying`, `isDestroyed`, `hasDirtyAttributes`, `isFragment`, `$type`, `rollbackAttributes`), added to migrated object resources by `FragmentExtension`
- Documents the `FragmentArray` class and its members (`isDestroying`, `isDestroyed`, `hasDirtyAttributes`, `addFragment`, `createFragment`, `removeFragment`, `rollbackAttributes`), added to migrated array resources by `FragmentArrayExtension`
- Documents the `FragmentExtension`/`FragmentArrayExtension` extension objects themselves

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)