### PR TITLE
docs: document ModelFragments schema utility helpers and hooks

### DIFF
--- a/warp-drive-packages/legacy/src/model-fragments/hooks/model-for.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/hooks/model-for.ts
@@ -130,4 +130,11 @@ export function fragmentsModelFor<T extends TypedRecordInstance>(
   return getShimClass(this, modelName);
 }
 
+/**
+ * The `modelFor` fallback used to construct a `ShimModelClass` schema for a
+ * type when ModelFragments support is enabled and no real `Model` subclass
+ * is registered for that type.
+ *
+ * @public
+ */
 export const modelFor: typeof fragmentsModelFor = fragmentsModelFor;

--- a/warp-drive-packages/legacy/src/model-fragments/index.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/index.ts
@@ -2,5 +2,13 @@ import type { WithArrayLike, WithEmberObject } from '../compat/extensions.ts';
 import type { Fragment } from './extensions/fragment.ts';
 import type { FragmentArray } from './extensions/fragment-array.ts';
 
+/**
+ * Adds the classic `EmberObject` API (via {@link WithEmberObject}) and the
+ * {@link Fragment} API to the type of a migrated single-fragment resource.
+ */
 export type WithFragment<T> = T & WithEmberObject<T> & Fragment;
+/**
+ * Adds Ember's classic array-like API (via {@link WithArrayLike}) and the
+ * {@link FragmentArray} API to the type of a migrated fragment-array resource.
+ */
 export type WithFragmentArray<T extends Fragment> = T & WithArrayLike<T> & FragmentArray<T>;

--- a/warp-drive-packages/legacy/src/model-fragments/instance-initializers/fragment-extensions.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/instance-initializers/fragment-extensions.ts
@@ -6,6 +6,12 @@ import type { SchemaService } from '@warp-drive/core/types';
 import FragmentExtension from '../extensions/fragment.ts';
 import FragmentArrayExtension from '../extensions/fragment-array.ts';
 
+/**
+ * Registers the {@link FragmentExtension}/{@link FragmentArrayExtension} schema
+ * extensions on the given `SchemaService`, enabling ModelFragments migration support.
+ *
+ * @public
+ */
 export function registerFragmentExtensions(schema: SchemaService): void {
   schema.CAUTION_MEGA_DANGER_ZONE_registerExtension?.(FragmentExtension);
   schema.CAUTION_MEGA_DANGER_ZONE_registerExtension?.(FragmentArrayExtension);

--- a/warp-drive-packages/legacy/src/model-fragments/utilities/with-array-defaults.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/utilities/with-array-defaults.ts
@@ -11,18 +11,48 @@ export function withArrayDefaults<ArrayName extends string, PrimitiveType extend
   primitiveType?: PrimitiveType
 ): PrimitiveType extends undefined
   ? {
+      /**
+       * This field is an `'array'` schema field.
+       */
       kind: 'array';
+      /**
+       * The name of the array field.
+       */
       name: ArrayName;
+      /**
+       * The array's item type, `'array'` since no `primitiveType` was given.
+       */
       type: 'array';
+      /**
+       * The schema options for this array field.
+       */
       options: {
+        /**
+         * The registered array-schema extensions to apply to this array.
+         */
         arrayExtensions: string[];
       };
     }
   : {
+      /**
+       * This field is an `'array'` schema field.
+       */
       kind: 'array';
+      /**
+       * The name of the array field.
+       */
       name: ArrayName;
+      /**
+       * The array's item type, derived from `primitiveType`.
+       */
       type: `array:${PrimitiveType}`;
+      /**
+       * The schema options for this array field.
+       */
       options: {
+        /**
+         * The registered array-schema extensions to apply to this array.
+         */
         arrayExtensions: string[];
       };
     };

--- a/warp-drive-packages/legacy/src/model-fragments/utilities/with-fragment-array-defaults.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/utilities/with-fragment-array-defaults.ts
@@ -12,11 +12,29 @@ export function withFragmentArrayDefaults<FragmentArrayType extends string, Frag
   fragmentArrayType: FragmentArrayType,
   fragmentArrayName?: FragmentArrayName
 ): {
+  /**
+   * This field is a `'schema-array'` field, an array of fragments.
+   */
   kind: 'schema-array';
+  /**
+   * The resource type of the fragments contained in this array.
+   */
   type: `fragment:${string}`;
+  /**
+   * The name of the fragment-array field.
+   */
   name: string;
+  /**
+   * The schema options for this fragment-array field.
+   */
   options: {
+    /**
+     * The registered array-schema extensions to apply to this array.
+     */
     arrayExtensions: string[];
+    /**
+     * Whether the array defaults to a non-null empty array when unset.
+     */
     defaultValue: boolean;
   };
 } {

--- a/warp-drive-packages/legacy/src/model-fragments/utilities/with-fragment-defaults.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/utilities/with-fragment-defaults.ts
@@ -10,10 +10,25 @@ export function withFragmentDefaults<FragmentType extends string, FragmentName e
   fragmentType: FragmentType,
   fragmentName?: FragmentName
 ): {
+  /**
+   * This field is a `'schema-object'` field, a single fragment.
+   */
   kind: 'schema-object';
+  /**
+   * The resource type of the fragment.
+   */
   type: `fragment:${FragmentType}`;
+  /**
+   * The name of the fragment field.
+   */
   name: FragmentType | FragmentName;
+  /**
+   * The schema options for this fragment field.
+   */
   options: {
+    /**
+     * The registered object-schema extensions to apply to this fragment.
+     */
     objectExtensions: string[];
   };
 } {

--- a/warp-drive-packages/legacy/src/model-fragments/utilities/with-legacy.ts
+++ b/warp-drive-packages/legacy/src/model-fragments/utilities/with-legacy.ts
@@ -3,6 +3,14 @@ import type { WithPartial } from '@warp-drive/core/types/utils';
 
 import { withDefaults } from '../../model/migration-support';
 
+/**
+ * Used as a helper to setup the relevant parts of a legacy resource schema
+ * migrated from `Model`, applying the `ember-object` and `fragment` object
+ * extensions and a default `@id` identity field.
+ *
+ * @param schema the partial legacy resource schema to complete
+ * @returns the completed resource schema
+ */
 export function withLegacy(schema: WithPartial<LegacyResourceSchema, 'legacy' | 'identity'>): ResourceSchema {
   return withDefaults({
     ...schema,


### PR DESCRIPTION
## Summary
- Documents `withArrayDefaults`/`withFragmentArrayDefaults`/`withFragmentDefaults`/`withLegacy` schema field helpers, including their inline return-type properties
- Documents `WithFragment`/`WithFragmentArray` type helpers in `model-fragments/index.ts`
- Documents the `modelFor` hook fallback (`model-fragments/hooks/model-for.ts`)
- Documents `registerFragmentExtensions` (`instance-initializers/fragment-extensions.ts`)

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)