### PR TITLE
docs: document AutoCompress/Gate handler properties and serialize return types

### DIFF
--- a/warp-drive-packages/utilities/src/-private/handlers/auto-compress.ts
+++ b/warp-drive-packages/utilities/src/-private/handlers/auto-compress.ts
@@ -184,7 +184,16 @@ const TypedArray = Object.getPrototypeOf(Uint8Array) as typeof Uint8Array;
  * @since 5.5.0
  */
 export class AutoCompress implements Handler {
-  declare options: Required<CompressionOptions> & { constraints: Required<Constraints> };
+  /**
+   * The resolved options this handler was configured with, with all
+   * defaults (including `constraints` defaults) applied.
+   */
+  declare options: Required<CompressionOptions> & {
+    /**
+     * The resolved size constraints used to decide whether to compress a given request body.
+     */
+    constraints: Required<Constraints>;
+  };
 
   constructor(options: CompressionOptions = {}) {
     const opts = {

--- a/warp-drive-packages/utilities/src/-private/handlers/gated.ts
+++ b/warp-drive-packages/utilities/src/-private/handlers/gated.ts
@@ -13,7 +13,13 @@ type CheckFn = (context: RequestContext) => boolean;
  * @public
  */
 export class Gate implements Handler {
+  /**
+   * The wrapped handler to invoke when {@link Gate.checkFn | checkFn} returns `true`.
+   */
   declare handler: Handler;
+  /**
+   * The predicate used to decide whether {@link Gate.handler | handler} should run for a given request.
+   */
   declare checkFn: CheckFn;
 
   constructor(handler: Handler, checkFn: CheckFn) {

--- a/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/serialize.ts
@@ -37,8 +37,24 @@ export type JsonApiResourcePatch =
  * @param identifiers - the resource(s) to serialize
  * @return an object with a `data` property containing the serialized resource(s)
  */
-export function serializeResources(cache: Cache, identifiers: ResourceKey): { data: ResourceObject };
-export function serializeResources(cache: Cache, identifiers: ResourceKey[]): { data: ResourceObject[] };
+export function serializeResources(
+  cache: Cache,
+  identifiers: ResourceKey
+): {
+  /**
+   * The serialized resource.
+   */
+  data: ResourceObject;
+};
+export function serializeResources(
+  cache: Cache,
+  identifiers: ResourceKey[]
+): {
+  /**
+   * The serialized resources.
+   */
+  data: ResourceObject[];
+};
 export function serializeResources(
   cache: Cache,
   identifiers: ResourceKey | ResourceKey[]
@@ -142,7 +158,12 @@ export function serializePatch(
   cache: Cache,
   identifier: ResourceKey
   // options: { include?: string[] } = {}
-): { data: JsonApiResourcePatch } {
+): {
+  /**
+   * The serialized resource patch.
+   */
+  data: JsonApiResourcePatch;
+} {
   const { id, lid, type } = identifier;
   assert(
     `A record with id ${String(id)} and type ${type} for lid ${lid} was not found not in the supplied Cache.`,


### PR DESCRIPTION
## Summary
- Documents `AutoCompress.options` (and its `constraints` field)
- Documents `Gate.handler`/`Gate.checkFn`
- Documents the `data` property on `serializeResources`/`serializePatch`'s return types

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)