### PR TITLE
docs: document remaining Await/Request/install APIs in ember and react packages

### DIFF
--- a/warp-drive-packages/ember/src/-private/await.gts
+++ b/warp-drive-packages/ember/src/-private/await.gts
@@ -89,14 +89,23 @@ interface AwaitSignature<T, E = Error | string | object> {
  * @public
  */
 export class Await<T, E> extends Component<AwaitSignature<T, E>> {
+  /**
+   * The reactive {@link PromiseState} for the awaited promise.
+   */
   get state(): Readonly<PromiseState<T, E>> {
     return getPromiseState<T, E>(this.args.promise);
   }
 
+  /**
+   * The rejection reason, once {@link Await.state | state} has errored.
+   */
   get error() {
     return this.state.error as E;
   }
 
+  /**
+   * The resolved value, once {@link Await.state | state} has succeeded.
+   */
   get result() {
     return this.state.result as T;
   }

--- a/warp-drive-packages/ember/src/-private/request.gts
+++ b/warp-drive-packages/ember/src/-private/request.gts
@@ -330,6 +330,10 @@ export class Request<RT, E> extends Component<RequestSignature<RT, E>> {
    */
   @consume('store') declare _store: Store;
 
+  /**
+   * The store or request manager used to make the request, resolved from
+   * either the `@store` arg or the consumed context/service.
+   */
   get store(): Store | RequestManager {
     const store = this.args.store || this._store;
     assert(
@@ -341,7 +345,14 @@ export class Request<RT, E> extends Component<RequestSignature<RT, E>> {
     return store;
   }
 
+  /**
+   * @private
+   */
   _state: RequestSubscription<RT, E> | null = null;
+  /**
+   * The active {@link RequestSubscription} for this component's request,
+   * created lazily and recreated if the store changes or a `@subscription` is provided.
+   */
   get state(): RequestSubscription<RT, E> {
     let { _state } = this;
     const { store } = this;

--- a/warp-drive-packages/ember/src/install.ts
+++ b/warp-drive-packages/ember/src/install.ts
@@ -12,6 +12,13 @@ import { setupSignals, type SignalHooks } from '@warp-drive/core/configure';
 type Tag = ReturnType<typeof tagForProperty>;
 const emberDirtyTag = dirtyTag as unknown as (tag: Tag) => void;
 
+/**
+ * Builds the {@link SignalHooks} implementation backed by Ember's
+ * `@glimmer/validator` tags, used to wire WarpDrive's reactivity
+ * primitives into Ember's autotracking system.
+ *
+ * @public
+ */
 export function buildSignalConfig(options: {
   wellknown: {
     Array: symbol | string;

--- a/warp-drive-packages/react/src/-private/reactive-context.tsx
+++ b/warp-drive-packages/react/src/-private/reactive-context.tsx
@@ -141,7 +141,12 @@ export function useWatcher(): { watcher: Signal.subtle.Watcher } | null {
 /**
  * @category Contexts
  */
-export const WatcherContext: Context<{ watcher: Signal.subtle.Watcher } | null> = createContext<{
+export const WatcherContext: Context<{
+  /**
+   * The `Signal.subtle.Watcher` used to observe signal changes for the nearest {@link ReactiveContext}.
+   */
+  watcher: Signal.subtle.Watcher;
+} | null> = createContext<{
   watcher: Signal.subtle.Watcher;
 } | null>(null);
 

--- a/warp-drive-packages/react/src/-private/request.tsx
+++ b/warp-drive-packages/react/src/-private/request.tsx
@@ -102,6 +102,12 @@ interface RequestStates<RT, E> {
   content: React.FC<{ result: RT; features: ContentFeatures<RT> }>;
 }
 
+/**
+ * Throws the given error. Used internally to rethrow request errors that
+ * are not otherwise handled by a provided error/cancelled block.
+ *
+ * @private
+ */
 export function Throw({ error }: { error: Error }): never {
   throw error;
 }

--- a/warp-drive-packages/react/src/install.ts
+++ b/warp-drive-packages/react/src/install.ts
@@ -40,6 +40,13 @@ function tryConsumeContext(signal: Signal.State<unknown> | Signal.Computed<unkno
 }
 
 let pending: Promise<unknown>[];
+/**
+ * Resolves once all pending requests started via WarpDrive's React signal
+ * integration have settled. Only tracks requests while `TESTING` is enabled;
+ * a no-op otherwise.
+ *
+ * @public
+ */
 export async function settled(): Promise<void> {
   if (TESTING) {
     // in testing mode we provide a test waiter integration
@@ -55,6 +62,13 @@ export async function settled(): Promise<void> {
   }
 }
 
+/**
+ * Builds the {@link SignalHooks} implementation backed by the
+ * [Signal Polyfill](https://github.com/proposal-signals/signal-polyfill),
+ * used to wire WarpDrive's reactivity primitives into React.
+ *
+ * @public
+ */
 export function buildSignalConfig(options: HooksOptions): SignalHooks {
   return {
     createSignal: (obj: object, key: string | symbol) =>


### PR DESCRIPTION
## Summary
- Documents `Await.state`/`.error`/`.result` and `Request.store`/`.state`/`._state` (`@warp-drive/ember`)
- Documents `buildSignalConfig` in both `@warp-drive/ember` and `@warp-drive/react`
- Documents `settled` and `Throw` (`@warp-drive/react`)
- Documents `WatcherContext`'s `watcher` property (`@warp-drive/react`) — required moving the doc onto the explicit `Context<...>` type annotation rather than the `createContext<...>` call, since TS declaration emit uses the former

## Test plan
- [x] `eslint`/`tsc --noEmit` clean (ember's own typecheck script only runs via its embroider/vite toolchain; verified `tsc` errors on `.gts` imports are pre-existing and unrelated)
- [x] Verified via a clean worktree off `origin/main` that `pnpm run build:pkg` succeeds for both packages and the doc comments survive into `declarations/**/*.d.ts`
- [x] Scoped typedoc `notDocumented` validation against the built declarations confirms all listed warnings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)