### PR TITLE
docs: document graph edge types and internal graph utilities

### DIFF
--- a/warp-drive-packages/core/src/graph/-private.ts
+++ b/warp-drive-packages/core/src/graph/-private.ts
@@ -30,11 +30,14 @@ function getWrapper(store: CacheCapabilitiesManager | Store): CacheCapabilitiesM
   return isStore(store) ? store._instanceCache._storeWrapper : store;
 }
 
+/** Returns the {@link Graph} associated with the given store or capabilities manager, if one has been created. */
 export function peekGraph(store: CacheCapabilitiesManager | Store): Graph | undefined {
   return Graphs.get(getWrapper(store));
 }
+/** The type of the {@link peekGraph} function. */
 export type peekGraph = typeof peekGraph;
 
+/** Returns the {@link Graph} for the given store, creating (and caching) one first if it does not yet exist. */
 export function graphFor(store: CacheCapabilitiesManager | Store): Graph {
   const wrapper = getWrapper(store);
   let graph = Graphs.get(wrapper);

--- a/warp-drive-packages/core/src/graph/-private/-utils.ts
+++ b/warp-drive-packages/core/src/graph/-private/-utils.ts
@@ -17,21 +17,29 @@ import type { ImplicitEdge } from './edges/implicit.ts';
 import type { ResourceEdge } from './edges/resource.ts';
 import type { Graph, GraphEdge } from './graph.ts';
 
+/** Retrieves the private {@link Store} instance from a capabilities manager (or any object exposing `_store`). */
 export function getStore(wrapper: CacheCapabilitiesManager | { _store: Store }): Store {
   assert(`expected a private _store property`, '_store' in wrapper);
   return wrapper._store;
 }
 
+/** Reads a value from a two-level keyed cache, without creating the first-level entry if it is missing. */
 export function expandingGet<T>(cache: Record<string, Record<string, T>>, key1: string, key2: string): T | undefined {
   const mainCache = (cache[key1] = cache[key1] || Object.create(null));
   return mainCache[key2];
 }
 
+/** Writes a value into a two-level keyed cache, lazily creating the first-level entry if it does not yet exist. */
 export function expandingSet<T>(cache: Record<string, Record<string, T>>, key1: string, key2: string, value: T): void {
   const mainCache = (cache[key1] = cache[key1] || Object.create(null));
   mainCache[key2] = value;
 }
 
+/**
+ * Asserts (dev-only) that a relationship update operation's payload is well-formed for the
+ * relationship's kind (`belongsTo` vs `hasMany`), warning or asserting on common payload mistakes
+ * such as a missing `data` alongside `links`, or `data` of the wrong shape.
+ */
 export function assertValidRelationshipPayload(
   graph: Graph,
   op: UpdateRelationshipOperation | UpdateResourceRelationshipOperation
@@ -108,6 +116,7 @@ function inspect(value: unknown) {
   return 'object';
 }
 
+/** Returns whether the given resource is new, i.e. it has no `id` or is flagged as new by the cache. */
 export function checkIfNew(store: Store, resourceKey: ResourceKey): boolean {
   if (!resourceKey.id) {
     return true;
@@ -115,18 +124,22 @@ export function checkIfNew(store: Store, resourceKey: ResourceKey): boolean {
   return store.cache.isNew(resourceKey);
 }
 
+/** A type-guard returning whether the given edge is a `belongsTo` {@link ResourceEdge}. */
 export function isBelongsTo(relationship: GraphEdge): relationship is ResourceEdge {
   return relationship.definition.kind === 'belongsTo';
 }
 
+/** A type-guard returning whether the given edge is an {@link ImplicitEdge}. */
 export function isImplicit(relationship: GraphEdge): relationship is ImplicitEdge {
   return relationship.definition.isImplicit;
 }
 
+/** A type-guard returning whether the given edge is a `hasMany` {@link CollectionEdge}. */
 export function isHasMany(relationship: GraphEdge): relationship is CollectionEdge {
   return relationship.definition.kind === 'hasMany';
 }
 
+/** Invokes `cb` for every resource identifier currently related through `rel`, covering both local and remote membership regardless of the edge's kind. */
 export function forAllRelatedIdentifiers(rel: GraphEdge, cb: (resourceKey: ResourceKey) => void): void {
   if (isBelongsTo(rel)) {
     if (rel.remoteState) {
@@ -154,12 +167,12 @@ export function forAllRelatedIdentifiers(rel: GraphEdge, cb: (resourceKey: Resou
   }
 }
 
-/*
-  Removes the given identifier from BOTH remote AND local state.
-
-  This method is useful when either a deletion or a rollback on a new record
-  needs to entirely purge itself from an inverse relationship.
-  */
+/**
+ * Removes the given identifier from BOTH remote AND local state.
+ *
+ * This method is useful when either a deletion or a rollback on a new record
+ * needs to entirely purge itself from an inverse relationship.
+ */
 export function removeIdentifierCompletelyFromRelationship(
   graph: Graph,
   relationship: GraphEdge,
@@ -208,6 +221,7 @@ export function removeIdentifierCompletelyFromRelationship(
   }
 }
 
+/** Notifies the store that a relationship has changed, provided the relationship has been accessed and is not currently being removed. */
 export function notifyChange(graph: Graph, relationship: CollectionEdge | ResourceEdge): void {
   if (!relationship.accessed) {
     return;
@@ -231,6 +245,11 @@ export function notifyChange(graph: Graph, relationship: CollectionEdge | Resour
   graph.store.notifyChange(resourceKey, 'relationships', key);
 }
 
+/**
+ * Asserts (dev-only) that a pushed relationship data payload conforms to the JSON:API resource
+ * identifier shape (correct `type`/`id`, correct array-ness for the relationship's kind) and
+ * references a resource type known to the schema.
+ */
 export function assertRelationshipData(
   store: Store,
   resourceKey: ResourceKey,

--- a/warp-drive-packages/core/src/graph/-private/edges/collection.ts
+++ b/warp-drive-packages/core/src/graph/-private/edges/collection.ts
@@ -6,20 +6,33 @@ import type { UpgradedMeta } from '../-edge-definition.ts';
 import type { RelationshipState } from '../-state.ts';
 import { createState } from '../-state.ts';
 
+/**
+ * Stores the graph's internal state for one side of a collection (`hasMany`) relationship.
+ */
 export interface CollectionEdge {
+  /** The upgraded relationship definition (schema metadata) for this edge. */
   definition: UpgradedMeta;
+  /** The resource this relationship belongs to. */
   identifier: ResourceKey;
+  /** Bookkeeping flags describing what we know about this relationship's data. */
   state: RelationshipState;
 
+  /** The set of members known to be part of the remote (server-provided) state, used for fast membership checks. */
   remoteMembers: Set<ResourceKey>;
+  /** The ordered list of members that make up the remote (server-provided) state of the relationship. */
   remoteState: ResourceKey[];
 
+  /** Members that have been locally added to the relationship but not yet reflected in remote state. */
   additions: Set<ResourceKey> | null;
+  /** Members that have been locally removed from the relationship but not yet reflected in remote state. */
   removals: Set<ResourceKey> | null;
 
+  /** The most recently received JSON:API `meta` for this relationship. */
   meta: Meta | null;
+  /** The most recently received JSON:API `links` for this relationship. */
   links: Links | PaginationLinks | null;
 
+  /** The computed local (client-side) ordering of members, incorporating any pending {@link CollectionEdge.additions} and {@link CollectionEdge.removals}. Cached until `isDirty` is set. */
   localState: ResourceKey[] | null;
   /**
    * Whether the localState for this edge is out-of-sync
@@ -30,6 +43,7 @@ export interface CollectionEdge {
    *
    */
   isDirty: boolean;
+  /** The transaction id of the last transaction that touched this relationship, used to detect stale/out-of-order remote updates. */
   transactionRef: number;
   /**
    * Whether data for this edge has been accessed at least once
@@ -38,12 +52,20 @@ export interface CollectionEdge {
    */
   accessed: boolean;
 
+  /**
+   * The most recently computed diff between the prior and new remote state, retained so that
+   * consumers (e.g. a `ManyArray`) may patch themselves incrementally instead of recomputing
+   * from scratch.
+   */
   _diff?: {
+    /** Members present in the new remote state that were not present previously. */
     add: Set<ResourceKey>;
+    /** Members present in the previous remote state that are no longer present. */
     del: Set<ResourceKey>;
   };
 }
 
+/** Creates a new {@link CollectionEdge} for the given definition and identifier. */
 export function createCollectionEdge(definition: UpgradedMeta, identifier: ResourceKey): CollectionEdge {
   return {
     definition,
@@ -67,6 +89,10 @@ export function createCollectionEdge(definition: UpgradedMeta, identifier: Resou
 
 const cp = structuredClone;
 
+/**
+ * Builds a legacy `{ data, links, meta }` {@link CollectionRelationship} payload for this edge,
+ * using either the remote or the computed local state, and marks the edge as accessed.
+ */
 export function legacyGetCollectionRelationshipData(
   source: CollectionEdge,
   getRemoteState: boolean

--- a/warp-drive-packages/core/src/graph/-private/edges/implicit.ts
+++ b/warp-drive-packages/core/src/graph/-private/edges/implicit.ts
@@ -1,7 +1,16 @@
 import type { ResourceKey } from '../../../types/identifier.ts';
 import type { UpgradedMeta } from '../-edge-definition.ts';
 
-export type ImplicitMeta = UpgradedMeta & { kind: 'implicit'; isImplicit: true };
+/**
+ * The relationship definition (schema metadata) backing an {@link ImplicitEdge}, tagging
+ * the {@link UpgradedMeta} as belonging to an implicit inverse relationship.
+ */
+export type ImplicitMeta = UpgradedMeta & {
+  /** Always `'implicit'` for the definition of an {@link ImplicitEdge}. */
+  kind: 'implicit';
+  /** Always `true`, allowing this definition to be discriminated from `hasMany`/`belongsTo` definitions. */
+  isImplicit: true;
+};
 
 /**
    Implicit relationships are relationships which have not been declared but the inverse side exists on
@@ -34,12 +43,17 @@ export type ImplicitMeta = UpgradedMeta & { kind: 'implicit'; isImplicit: true }
    to be do things like remove the comment from the post if the comment were to be deleted.
 */
 export interface ImplicitEdge {
+  /** The definition (schema metadata) for this implicit inverse relationship. */
   definition: ImplicitMeta;
+  /** The resource this implicit relationship belongs to. */
   identifier: ResourceKey;
+  /** Members added locally that have not yet been confirmed by a remote update. */
   localMembers: Set<ResourceKey>;
+  /** Members known to be part of the relationship from remote (server-provided) state. */
   remoteMembers: Set<ResourceKey>;
 }
 
+/** Creates a new {@link ImplicitEdge} for the given definition and identifier. */
 export function createImplicitEdge(definition: ImplicitMeta, identifier: ResourceKey): ImplicitEdge {
   return {
     definition,


### PR DESCRIPTION
## Summary
- Documents `CollectionEdge`, `ImplicitEdge`/`ImplicitMeta`, `peekGraph`/`graphFor`, and the internal helper functions in `-utils.ts` (`isBelongsTo`, `isImplicit`, etc.).

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)