### PR TITLE
docs: document legacy store finder option types

### DIFF
--- a/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
@@ -84,16 +84,35 @@ export type CacheCapabilitiesManager = {
   /**
    * Notify subscribers of the NotificationManager that cache state has changed.
    *
-   * `attributes` and `relationships` do not require a key, but if one is specified it
-   * is assumed to be the name of the attribute or relationship that has been updated.
-   *
-   * No other namespaces currently expect the `key` argument.
+   * This overload notifies that a resource has been added to or removed from
+   * the cache. `key` is always `null` for these namespaces.
    *
    * @public
    */
   notifyChange(identifier: ResourceKey, namespace: 'added' | 'removed', key: null): void;
+  /**
+   * Notify subscribers that a request (as identified by a {@link RequestKey})
+   * has been added, updated, or removed from the cache. `key` is always
+   * `null` for these namespaces.
+   *
+   * @public
+   */
   notifyChange(identifier: RequestKey, namespace: 'added' | 'updated' | 'removed', key: null): void;
+  /**
+   * Notify subscribers of a change to a resource for any other
+   * {@link NotificationType}. `attributes` and `relationships` do not
+   * require a key, but if one is specified it is assumed to be the name
+   * of the attribute or relationship that has been updated.
+   *
+   * @public
+   */
   notifyChange(identifier: ResourceKey, namespace: NotificationType, key: string | null): void;
+  /**
+   * Implementation signature for {@link CacheCapabilitiesManager.notifyChange}
+   * covering all supported combinations of identifier, namespace, and key.
+   *
+   * @public
+   */
   notifyChange(
     identifier: ResourceKey | RequestKey,
     namespace: NotificationType | 'added' | 'removed' | 'updated',

--- a/warp-drive-packages/core/src/store/-types/q/store.ts
+++ b/warp-drive-packages/core/src/store/-types/q/store.ts
@@ -1,11 +1,44 @@
 import type { Value } from '../../../types/json/raw';
 
+/**
+ * Options shared by {@link FindRecordOptions} and {@link FindAllOptions}
+ * for controlling reload behavior and adapter/serializer specific
+ * configuration when using the legacy Adapter/Serializer network layer.
+ */
 export interface BaseFinderOptions {
+  /**
+   * If `true`, forces the request to go to the adapter even if a cached
+   * copy of the requested resource(s) already exists in the store. If
+   * omitted, the adapter's `shouldReloadRecord`/`shouldReloadAll` hook
+   * decides whether to reload.
+   */
   reload?: boolean;
+
+  /**
+   * If `true` or `false`, forces or prevents a background reload of the
+   * cached resource(s) after resolving with the cached data. If omitted,
+   * the adapter's `shouldBackgroundReloadRecord`/`shouldBackgroundReloadAll`
+   * hook decides whether to reload in the background.
+   */
   backgroundReload?: boolean;
+
+  /**
+   * The names of relationships to load along with this request, used to
+   * build the `include` query parameter for adapters (such as the
+   * JSON:API adapter) that support it.
+   */
   include?: string | string[];
+
+  /**
+   * Arbitrary options made available to the adapter via the request's
+   * snapshot (`snapshot.adapterOptions`). The store does not interpret
+   * this value itself.
+   */
   adapterOptions?: Record<string, unknown>;
 }
+/**
+ * Options for `store.findRecord()`.
+ */
 export interface FindRecordOptions extends BaseFinderOptions {
   /**
    * Data to preload into the store before the request is made.
@@ -25,12 +58,32 @@ export interface FindRecordOptions extends BaseFinderOptions {
   preload?: Record<string, Value>;
 }
 
+/**
+ * Options for `store.query()` and `store.queryRecord()`. Unlike
+ * {@link LegacyResourceQuery}, these options are not sent to the server;
+ * only `adapterOptions` is recognized by the store, and it is passed
+ * through to `adapter.query`/`adapter.queryRecord` via the request snapshot.
+ */
 export type QueryOptions = {
   [K in string | 'adapterOptions']?: K extends 'adapterOptions' ? Record<string, unknown> : unknown;
 };
 
+/**
+ * Options for `store.findAll()`.
+ */
 export type FindAllOptions = BaseFinderOptions;
+
+/**
+ * An opaque query object for `store.query()` and `store.queryRecord()`
+ * that is passed as-is to the adapter, which is responsible for turning
+ * it into request query parameters.
+ */
 export type LegacyResourceQuery = {
+  /**
+   * The names of relationships to load along with this query, used to
+   * build the `include` query parameter for adapters (such as the
+   * JSON:API adapter) that support it.
+   */
   include?: string | string[];
   [key: string]: Value | undefined;
 };


### PR DESCRIPTION
## Summary
- Documents `BaseFinderOptions`/`FindRecordOptions`/`LegacyResourceQuery`/`QueryOptions`/`FindAllOptions` and all 3 overloads of `CacheCapabilitiesManager.notifyChange`.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)