### PR TITLE
docs: document deprecated ModelSchema and legacy record array types

### DIFF
--- a/warp-drive-packages/core/src/store/-private/record-arrays/legacy-live-array.ts
+++ b/warp-drive-packages/core/src/store/-private/record-arrays/legacy-live-array.ts
@@ -72,11 +72,18 @@ import { createReactiveResourceArray } from './resource-array.ts';
  * @legacy we recommend againt using LiveArrays. Use {@link Store.request} instead
  */
 export interface LegacyLiveArray<T = unknown> extends LegacyArray<T> {
+  /**
+   * Whether this LiveArray has loaded. LiveArrays are always considered
+   * loaded once created.
+   */
   isLoaded: boolean;
 
   /** @internal */
   DEPRECATED_CLASS_NAME: string;
 
+  /**
+   * The resource type (`ResourceType`) whose records this LiveArray contains.
+   */
   modelName: TypeFromInstanceOrString<T>;
 }
 

--- a/warp-drive-packages/core/src/store/-private/record-arrays/legacy-many-array.ts
+++ b/warp-drive-packages/core/src/store/-private/record-arrays/legacy-many-array.ts
@@ -62,7 +62,21 @@ import { createReactiveResourceArray, destroy, type ReactiveResourceArray } from
   @public
 */
 export interface LegacyManyArray<T = unknown> extends ReactiveResourceArray<T> {
+  /**
+    The meta data for the has-many relationship, as returned in the
+    relationship's payload from the server.
+
+    @public
+  */
   meta: Meta | null;
+
+  /**
+    The links for the has-many relationship, as returned in the
+    relationship's payload from the server. Used to refetch the
+    relationship when reloading.
+
+    @public
+  */
   links: Links | PaginationLinks | null;
 
   /** @internal */

--- a/warp-drive-packages/core/src/store/-private/record-arrays/legacy-query.ts
+++ b/warp-drive-packages/core/src/store/-private/record-arrays/legacy-query.ts
@@ -82,9 +82,23 @@ import { createReactiveResourceArray, destroy, type ReactiveResourceArray } from
  * @legacy we recommend againt using QueryArrays. Use {@link Store.request} instead
  */
 export interface LegacyQueryArray<T = unknown> extends LegacyLiveArray<T> {
+  /**
+   * The query originally passed to `store.query()` that produced this
+   * QueryArray. Used by `update()` to re-run the query.
+   */
   query: ImmutableRequestInfo | Record<string, unknown> | null;
   destroy(): void;
+
+  /**
+   * The JSON:API `links` included in the response that produced this
+   * QueryArray, if any.
+   */
   links: PaginationLinks | Links | null;
+
+  /**
+   * The JSON:API `meta` included in the response that produced this
+   * QueryArray, if any.
+   */
   meta: Meta | null;
 }
 

--- a/warp-drive-packages/core/src/store/-private/record-arrays/native-proxy-type-fix.ts
+++ b/warp-drive-packages/core/src/store/-private/record-arrays/native-proxy-type-fix.ts
@@ -131,4 +131,11 @@ interface ProxyConstructor {
   new <TSource extends object, TTarget extends object>(target: TSource, handler: ProxyHandler<TSource>): TTarget;
 }
 
+/**
+ * The global `Proxy` constructor, retyped with the corrected
+ * {@link ProxyConstructor} signature above so that `target` and `receiver`
+ * may differ.
+ *
+ * @private
+ */
 export const NativeProxy: ProxyConstructor = Proxy as unknown as ProxyConstructor;

--- a/warp-drive-packages/core/src/store/-private/record-arrays/resource-array.ts
+++ b/warp-drive-packages/core/src/store/-private/record-arrays/resource-array.ts
@@ -107,6 +107,18 @@ interface ReactiveResourceArrayContext extends ReactiveResourceArrayCreateOption
   boundFns: Map<KeyType, ProxiedMethod>;
 }
 
+/**
+ * A reactive Array of records, backed by a {@link ResourceKey} array in the
+ * cache. Returned by {@link Store.request} for collection responses and used
+ * as the base for relationship and legacy record-array types such as
+ * {@link LegacyLiveArray}, {@link LegacyQueryArray} and {@link LegacyManyArray}.
+ *
+ * Behaves like a native Array: `Array.isArray(arr)` and `arr instanceof Array`
+ * both report `true`. The array stays in sync with the cache, updating
+ * reactively as the underlying {@link ResourceKey}s change.
+ *
+ * @public
+ */
 export interface ReactiveResourceArray<T = unknown> extends Omit<Array<T>, '[]'> {
   /** @internal */
   isDestroying: boolean;
@@ -120,11 +132,24 @@ export interface ReactiveResourceArray<T = unknown> extends Omit<Array<T>, '[]'>
   [Context]: ReactiveResourceArrayContext;
 }
 
+/**
+ * A variant of {@link ReactiveResourceArray} that exposes its otherwise
+ * `@internal` members (including the `Context` symbol used to reach the
+ * array's private bookkeeping). Used to upgrade a {@link ReactiveResourceArray}
+ * for intimate access by `@warp-drive/legacy`.
+ *
+ * @private
+ */
 export interface PrivateReactiveResourceArray<T = unknown> extends Omit<Array<T>, '[]'> {
+  /** @private */
   isDestroying: boolean;
+  /** @private */
   isDestroyed: boolean;
+  /** @private */
   destroy: (this: ReactiveResourceArray, clear: boolean) => void;
+  /** @private */
   [IS_COLLECTION]: boolean;
+  /** @private */
   [Context]: ReactiveResourceArrayContext;
 }
 

--- a/warp-drive-packages/core/src/store/-private/record-arrays/resource-array.ts
+++ b/warp-drive-packages/core/src/store/-private/record-arrays/resource-array.ts
@@ -134,7 +134,7 @@ export interface ReactiveResourceArray<T = unknown> extends Omit<Array<T>, '[]'>
 
 /**
  * A variant of {@link ReactiveResourceArray} that exposes its otherwise
- * `@internal` members (including the `Context` symbol used to reach the
+ * internal-only members (including the `Context` symbol used to reach the
  * array's private bookkeeping). Used to upgrade a {@link ReactiveResourceArray}
  * for intimate access by `@warp-drive/legacy`.
  *

--- a/warp-drive-packages/core/src/store/deprecated/-private.ts
+++ b/warp-drive-packages/core/src/store/deprecated/-private.ts
@@ -137,18 +137,52 @@ export type KeyOrString<T> = keyof T & string extends never ? string : keyof T &
  *
  */
 export interface ModelSchema<T = unknown> {
+  /**
+   * The resource type (model name) that this schema describes.
+   */
   modelName: T extends TypedRecordInstance ? TypeFromInstance<T> : string;
+
+  /**
+   * A map of every field defined on this resource type to its kind
+   * (`'attribute'`, `'belongsTo'`, or `'hasMany'`).
+   */
   fields: Map<KeyOrString<T>, 'attribute' | 'belongsTo' | 'hasMany'>;
+
+  /**
+   * A map of every attribute field defined on this resource type, keyed by
+   * attribute name.
+   */
   attributes: Map<KeyOrString<T>, LegacyAttributeField>;
+
+  /**
+   * A map of every relationship (`belongsTo`/`hasMany`) field defined on this
+   * resource type, keyed by relationship name.
+   */
   relationshipsByName: Map<KeyOrString<T>, LegacyRelationshipField>;
+
+  /**
+   * Invokes `callback` once for each attribute field defined on this resource
+   * type, passing the attribute's key and schema.
+   */
   eachAttribute<K extends KeyOrString<T>>(
     callback: (this: ModelSchema<T>, key: K, attribute: LegacyAttributeField) => void,
     binding?: T
   ): void;
+
+  /**
+   * Invokes `callback` once for each relationship field defined on this
+   * resource type, passing the relationship's key and schema.
+   */
   eachRelationship<K extends KeyOrString<T>>(
     callback: (this: ModelSchema<T>, key: K, relationship: LegacyRelationshipField) => void,
     binding?: T
   ): void;
+
+  /**
+   * Invokes `callback` once for each attribute field defined on this resource
+   * type that has a transform (a `type`), passing the attribute's key and the
+   * name of the transform to apply.
+   */
   eachTransformedAttribute<K extends KeyOrString<T>>(
     callback: (this: ModelSchema<T>, key: K, type: string | null) => void,
     binding?: T


### PR DESCRIPTION
## Summary
- Documents the deprecated `ModelSchema` interface, `ReactiveResourceArray`/`PrivateReactiveResourceArray`, and remaining `LegacyLiveArray`/`LegacyQueryArray`/`LegacyManyArray`/`NativeProxy` members.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)