### PR TITLE
docs: document log/logGroup and constructResource overloads

### DIFF
--- a/warp-drive-packages/core/src/store/-private/debug/utils.ts
+++ b/warp-drive-packages/core/src/store/-private/debug/utils.ts
@@ -72,7 +72,19 @@ function colorForBucket(isLight: boolean, scope: SCOPE, bucket: string) {
   return badge(isLight, TEXT_COLORS[scope][3], BG_COLORS[scope][3], NOTIFY_BORDER[scope][3]);
 }
 
+/**
+ * Opens a collapsed console group for a `cache` scoped debug message, using
+ * `type`/`lid`/`bucket`/`key` to build the colorized group label.
+ *
+ * @private
+ */
 export function logGroup(scope: 'cache', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+/**
+ * Opens a collapsed console group for a `reactive-ui` scoped debug message.
+ * The trailing `key` segment is unused for this scope and must be an empty string.
+ *
+ * @private
+ */
 export function logGroup(
   scope: 'reactive-ui',
   prefix: string,
@@ -81,7 +93,19 @@ export function logGroup(
   bucket: string,
   key: ''
 ): void;
+/**
+ * Opens a collapsed console group for a `notify` scoped debug message, using
+ * `type`/`lid`/`bucket`/`key` to build the colorized group label.
+ *
+ * @private
+ */
 export function logGroup(scope: 'notify', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+/**
+ * Implementation for {@link logGroup}. Builds the colorized label for the
+ * given scope via `_log` and opens it as a collapsed `console.groupCollapsed`.
+ *
+ * @private
+ */
 export function logGroup(
   scope: SCOPE,
   prefix: string,
@@ -94,10 +118,40 @@ export function logGroup(
   console.groupCollapsed(..._log(scope, prefix, subScop1, subScop2, subScop3, subScop4));
 }
 
+/**
+ * Logs a colorized, scoped debug message to the console for the `request`
+ * scope, using `type`/`lid`/`bucket`/`key` to describe the request being logged.
+ *
+ * @private
+ */
 export function log(scope: 'request', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+/**
+ * Logs a colorized, scoped debug message to the console for the `cache`
+ * scope, using `type`/`lid`/`bucket`/`key` to describe the cache operation being logged.
+ *
+ * @private
+ */
 export function log(scope: 'cache', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+/**
+ * Logs a colorized, scoped debug message to the console for the `reactive-ui`
+ * scope. The trailing `key` segment is unused for this scope and must be an empty string.
+ *
+ * @private
+ */
 export function log(scope: 'reactive-ui', prefix: string, type: string, lid: string, bucket: string, key: ''): void;
+/**
+ * Logs a colorized, scoped debug message to the console for the `notify`
+ * scope, using `type`/`lid`/`bucket`/`key` to describe the notification being logged.
+ *
+ * @private
+ */
 export function log(scope: 'notify', prefix: string, type: string, lid: string, bucket: string, key: string): void;
+/**
+ * Implementation for {@link log}. Builds the colorized message for the given
+ * scope via `_log` and writes it to the console with `console.log`.
+ *
+ * @private
+ */
 export function log(
   scope: SCOPE,
   prefix: string,

--- a/warp-drive-packages/core/src/store/-private/utils/construct-resource.ts
+++ b/warp-drive-packages/core/src/store/-private/utils/construct-resource.ts
@@ -5,19 +5,57 @@ import { isResourceKey } from '../managers/cache-key-manager.ts';
 import { coerceId } from './coerce-id.ts';
 import { isNonEmptyString } from './is-non-empty-string.ts';
 
+/**
+ * Given an existing resource identifier object (or a {@link ResourceKey}),
+ * returns it unchanged aside from coercing its `id`, if present, to a string.
+ *
+ * @private
+ */
 export function constructResource(type: ResourceIdentifierObject): ResourceIdentifierObject;
+/**
+ * Builds a resource identifier from a `type`, `id`, and `lid`, all of which
+ * are known to be present, producing an {@link ExistingResourceIdentifierObject}.
+ *
+ * @private
+ */
 export function constructResource(type: string, id: string, lid: string): ExistingResourceIdentifierObject;
+/**
+ * Builds a resource identifier from a `lid` alone, for the case where `type`
+ * and `id` are not (yet) known.
+ *
+ * @private
+ */
 export function constructResource(
   type: string | undefined,
   id: null | undefined,
   lid: string
 ): ExistingResourceIdentifierObject;
+/**
+ * Builds a resource identifier from a `type` and `id`, with an optional `lid`,
+ * producing an {@link ExistingResourceIdentifierObject}.
+ *
+ * @private
+ */
 export function constructResource(type: string, id: string, lid?: string | null): ExistingResourceIdentifierObject;
+/**
+ * Builds a resource identifier from a `type` and an optional `id`/`lid`. If no
+ * usable `id` is provided, falls back to constructing a `lid`-only identifier.
+ *
+ * @private
+ */
 export function constructResource(
   type: string,
   id?: string | number | null,
   lid?: string | null
 ): ResourceIdentifierObject;
+/**
+ * Implementation for {@link constructResource}. Normalizes the supplied
+ * `type`/`id`/`lid` (or existing resource identifier object) into a valid
+ * {@link ResourceIdentifierObject}, coercing the id and asserting that enough
+ * information was provided to identify the resource.
+ *
+ * @private
+ */
 export function constructResource(
   type: string | ResourceIdentifierObject | undefined,
   id?: string | number | null,


### PR DESCRIPTION
## Summary
- Documents all overload signatures of `log`/`logGroup` (`debug/utils.ts`) and `constructResource` (`utils/construct-resource.ts`), each with distinct text describing its specific parameter shape.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)