### PR TITLE
docs: document request pipeline Context, Deferred, and priority types

### DIFF
--- a/warp-drive-packages/core/src/request/-private/context.ts
+++ b/warp-drive-packages/core/src/request/-private/context.ts
@@ -155,10 +155,31 @@ export class ContextOwner {
   }
 }
 
+/**
+ * The context object given to each {@link Handler} (or {@link CacheHandler})
+ * as it processes a request. It exposes the (immutable, enhanced) request
+ * along with the methods a handler uses to build up the {@link Future} and
+ * {@link StructuredDataDocument} that will ultimately be returned by the
+ * {@link RequestManager}.
+ *
+ * @public
+ */
 export class Context {
   /** @internal */
   declare private ___owner: ContextOwner;
+  /**
+   * A readonly, immutable version of the request being handled, including
+   * any defaults or enhancements applied by the {@link RequestManager}.
+   *
+   * @public
+   */
   declare request: ImmutableRequestInfo;
+  /**
+   * The id of this request as assigned by the {@link RequestManager}. Not
+   * unique across manager instances.
+   *
+   * @public
+   */
   declare id: number;
   /** @internal */
   declare private _isCacheHandler: boolean;
@@ -172,13 +193,33 @@ export class Context {
     this._isCacheHandler = isCacheHandler;
     this._finalized = false;
   }
+  /**
+   * Set the response stream for this request. May be called at most once,
+   * and may be called at any point up until the handler's `request` method
+   * resolves.
+   *
+   * @public
+   */
   setStream(stream: ReadableStream | Promise<ReadableStream | null>): void {
     this.___owner.setStream(stream);
   }
+  /**
+   * Set the {@link ResponseInfo} (or raw `Response`) associated with this
+   * request. Used to populate the response information available on the
+   * resulting {@link StructuredDataDocument}.
+   *
+   * @public
+   */
   setResponse(response: ResponseInfo | Response | null): void {
     this.___owner.setResponse(response);
   }
 
+  /**
+   * Associate a {@link RequestKey} with this request. May only be called
+   * synchronously from a {@link CacheHandler}.
+   *
+   * @public
+   */
   setIdentifier(identifier: RequestKey): void {
     assert(
       `setIdentifier may only be used synchronously from a CacheHandler`,
@@ -187,6 +228,13 @@ export class Context {
     this.___owner.god.identifier = identifier;
   }
 
+  /**
+   * Whether the application (or a downstream handler) has requested access
+   * to the response stream via {@link Future.getStream}. Handlers can use
+   * this to avoid the cost of streaming when nothing will consume it.
+   *
+   * @public
+   */
   get hasRequestedStream(): boolean {
     return this.___owner.hasRequestedStream;
   }

--- a/warp-drive-packages/core/src/request/-private/types.ts
+++ b/warp-drive-packages/core/src/request/-private/types.ts
@@ -23,13 +23,34 @@ export interface GodContext {
   requester: RequestManager | Store;
 }
 
+/**
+ * A promise paired with the `resolve`/`reject` callbacks that settle it,
+ * allowing the promise to be created before the work that will settle it
+ * has begun. See {@link createDeferred}.
+ *
+ * @public
+ */
 export type Deferred<T> = {
+  /** Resolve {@link Deferred.promise | promise} with the given value. */
   resolve(v: T): void;
+  /** Reject {@link Deferred.promise | promise} with the given reason. */
   reject(v: unknown): void;
+  /** The promise controlled by {@link Deferred.resolve | resolve} and {@link Deferred.reject | reject}. */
   promise: Promise<T>;
 };
 
-export type ManagedRequestPriority = { blocking: boolean };
+/**
+ * Describes whether a managed (deduped) request should be treated as
+ * blocking the caller's promise (e.g. a `fetch`) or as a non-blocking
+ * background reload that other requests may dedupe against without
+ * waiting on it.
+ *
+ * @public
+ */
+export type ManagedRequestPriority = {
+  /** Whether the request should gate the promise it is associated with. */
+  blocking: boolean;
+};
 
 export type DeferredStream = {
   resolve(v: ReadableStream | null): void;
@@ -107,6 +128,13 @@ export type DeferredFuture<T> = {
   promise: Future<T>;
 };
 
+/**
+ * The `next` function passed to a {@link Handler} (or {@link CacheHandler}),
+ * used to forward a request to the next handler in the chain. Resolves to a
+ * {@link Future} carrying the downstream response.
+ *
+ * @public
+ */
 export type NextFn<P = unknown> = (req: RequestInfo) => Future<P>;
 
 /**


### PR DESCRIPTION
## Summary
- Documents `NextFn`, `Deferred`, `ManagedRequestPriority` (`types.ts`) and the `Context` interface (`context.ts`) used by request handlers.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)