### PR TITLE
docs: document promise-result cache, Awaitable, Fetch.request, and RequestSignature brands

### DIFF
--- a/warp-drive-packages/core/src/request.ts
+++ b/warp-drive-packages/core/src/request.ts
@@ -31,9 +31,7 @@ export type { Context } from './request/-private/context.ts';
  * ```
  *
  */
-export function withResponseType<T>(
-  obj: RequestInfo
-): RequestInfo<T> & {
+export function withResponseType<T>(obj: RequestInfo): RequestInfo<T> & {
   /** The branded response type. Present only at the type level; carries no runtime value. */
   [RequestSignature]: T;
 } {
@@ -60,9 +58,7 @@ export function withResponseType<T>(
  *
  * @public
  */
-export function withReactiveResponse<T>(
-  obj: RequestInfo
-): RequestInfo<ReactiveDataDocument<T>> & {
+export function withReactiveResponse<T>(obj: RequestInfo): RequestInfo<ReactiveDataDocument<T>> & {
   /** The branded response type. Present only at the type level; carries no runtime value. */
   [RequestSignature]: ReactiveDataDocument<T>;
 } {

--- a/warp-drive-packages/core/src/request.ts
+++ b/warp-drive-packages/core/src/request.ts
@@ -31,7 +31,12 @@ export type { Context } from './request/-private/context.ts';
  * ```
  *
  */
-export function withResponseType<T>(obj: RequestInfo): RequestInfo<T> & { [RequestSignature]: T } {
+export function withResponseType<T>(
+  obj: RequestInfo
+): RequestInfo<T> & {
+  /** The branded response type. Present only at the type level; carries no runtime value. */
+  [RequestSignature]: T;
+} {
   return obj as RequestInfo<T> & {
     [RequestSignature]: T;
   };
@@ -57,7 +62,10 @@ export function withResponseType<T>(obj: RequestInfo): RequestInfo<T> & { [Reque
  */
 export function withReactiveResponse<T>(
   obj: RequestInfo
-): RequestInfo<ReactiveDataDocument<T>> & { [RequestSignature]: ReactiveDataDocument<T> } {
+): RequestInfo<ReactiveDataDocument<T>> & {
+  /** The branded response type. Present only at the type level; carries no runtime value. */
+  [RequestSignature]: ReactiveDataDocument<T>;
+} {
   return obj as RequestInfo<ReactiveDataDocument<T>> & {
     [RequestSignature]: ReactiveDataDocument<T>;
   };

--- a/warp-drive-packages/core/src/request/-private/fetch.ts
+++ b/warp-drive-packages/core/src/request/-private/fetch.ts
@@ -131,6 +131,13 @@ const ERROR_STATUS_CODE_FOR = new Map([
  * @public
  */
 const Fetch = {
+  /**
+   * Issues the request via native `fetch`, setting the response and
+   * (when requested) streaming the decoded body via {@link Context.setStream}
+   * as it downloads, then resolves with the parsed JSON body.
+   *
+   * @public
+   */
   async request<T>(context: Context): Promise<T> {
     let response: Response;
 

--- a/warp-drive-packages/core/src/request/-private/future.ts
+++ b/warp-drive-packages/core/src/request/-private/future.ts
@@ -9,6 +9,13 @@ export function isFuture<T>(maybe: unknown): maybe is Future<T> {
   return Boolean(maybe && maybe instanceof Promise && (maybe as Future<T>)[IS_FUTURE] === true);
 }
 
+/**
+ * Create a {@link Deferred}: a promise along with the `resolve`/`reject`
+ * callbacks that settle it, so the promise can be handed out before the
+ * work that will settle it has started.
+ *
+ * @public
+ */
 export function createDeferred<T>(): Deferred<T> {
   let resolve!: (v: T) => void;
   let reject!: (v: unknown) => void;

--- a/warp-drive-packages/core/src/request/-private/promise-cache.ts
+++ b/warp-drive-packages/core/src/request/-private/promise-cache.ts
@@ -2,9 +2,32 @@ import { getOrSetUniversal } from '../../types/-private';
 
 export type CacheResult<T = unknown, E = unknown> = { isError: true; result: E } | { isError: false; result: T };
 
+/**
+ * The minimal, structural subset of the `Promise` interface required to be
+ * cached and inspected by {@link setPromiseResult} / {@link getPromiseResult}
+ * (and by `getPromiseState`). Anything that is at least `then`/`catch`/`finally`
+ * "shaped" (including a real `Promise` or {@link Future}) satisfies this.
+ *
+ * @public
+ */
 export type Awaitable<T = unknown, E = unknown> = {
+  /**
+   * Registers fulfillment/rejection handlers, `Promise.prototype.then`-style.
+   *
+   * @public
+   */
   then: (onFulfilled: (value: T) => unknown, onRejected: (reason: E) => unknown) => unknown;
+  /**
+   * Registers a rejection handler, `Promise.prototype.catch`-style.
+   *
+   * @public
+   */
   catch: (onRejected: (reason: E) => unknown) => unknown;
+  /**
+   * Registers a handler run on settlement, `Promise.prototype.finally`-style.
+   *
+   * @public
+   */
   finally: (onFinally: () => unknown) => unknown;
 };
 
@@ -24,10 +47,23 @@ export function getRequestResult(requestId: number): CacheResult | undefined {
   return RequestMap.get(requestId);
 }
 
+/**
+ * Cache the settled result (or error) of a promise-like value so that its
+ * outcome can be synchronously read later via {@link getPromiseResult},
+ * without needing to await it again.
+ *
+ * @public
+ */
 export function setPromiseResult(promise: Promise<unknown> | Awaitable, result: CacheResult): void {
   PromiseCache.set(promise, result);
 }
 
+/**
+ * Synchronously read the settled result (or error) previously recorded for
+ * a promise-like value via {@link setPromiseResult}, if any.
+ *
+ * @public
+ */
 export function getPromiseResult<T, E>(promise: Promise<T> | Awaitable<T, E>): CacheResult<T, E> | undefined {
   return PromiseCache.get(promise) as CacheResult<T, E> | undefined;
 }


### PR DESCRIPTION
## Summary
- Documents `setPromiseResult`/`getPromiseResult`/`Awaitable` (including its `then`/`catch`/`finally` members, which needed real body text rather than a bare tag to satisfy typedoc's validator), `Fetch.request`, `createDeferred`, and the `[RequestSignature]` brand properties in `request.ts`.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)