### PR TITLE
docs: document cross-copy transient storage helpers and raw JSON value types

### DIFF
--- a/warp-drive-packages/core/src/store/-private/utils/coerce-id.ts
+++ b/warp-drive-packages/core/src/store/-private/utils/coerce-id.ts
@@ -11,6 +11,16 @@ import { assert } from '@warp-drive/core/build-config/macros';
 // corresponding record, we will not know if it is a string or a number.
 type Coercable = string | number | boolean | null | undefined | symbol;
 
+/**
+ * Normalizes a resource `id` entering the store to a string (or `null`).
+ *
+ * When `DEPRECATE_NON_STRICT_ID` is enabled, any non-string, non-nullish id
+ * is stringified and a deprecation is issued; `''`/`null`/`undefined` all
+ * normalize to `null`. Otherwise, `id` must already be `null` or a
+ * non-empty string, which is asserted.
+ *
+ * @private
+ */
 export function coerceId(id: unknown): string | null {
   if (DEPRECATE_NON_STRICT_ID) {
     let normalized: string | null;
@@ -47,6 +57,15 @@ export function coerceId(id: unknown): string | null {
   return id;
 }
 
+/**
+ * Coerces `id` to a non-empty string, asserting if it is not already a
+ * non-empty string or a valid (non-`NaN`) number.
+ *
+ * Unlike {@link coerceId}, this never returns `null` and does not honor
+ * `DEPRECATE_NON_STRICT_ID`.
+ *
+ * @private
+ */
 export function ensureStringId(id: Coercable): string {
   let normalized: string | null = null;
   if (typeof id === 'string') {

--- a/warp-drive-packages/core/src/store/-private/utils/normalize-model-name.ts
+++ b/warp-drive-packages/core/src/store/-private/utils/normalize-model-name.ts
@@ -4,6 +4,16 @@ import { DEPRECATE_NON_STRICT_TYPES } from '@warp-drive/core/build-config/deprec
 
 import { dasherize } from '../../../utils/string.ts';
 
+/**
+ * Normalizes a resource `type` to its dasherized form, e.g. `myClass` to
+ * `my-class`. Re-exported elsewhere as `_deprecatingNormalize`.
+ *
+ * When `DEPRECATE_NON_STRICT_TYPES` is enabled, dasherizes `type` and issues
+ * a deprecation if it was not already normalized. Otherwise, `type` is
+ * returned unchanged and callers are expected to have already normalized it.
+ *
+ * @private
+ */
 export function normalizeModelName(type: string): string {
   if (DEPRECATE_NON_STRICT_TYPES) {
     const result = dasherize(type);

--- a/warp-drive-packages/core/src/types/-private.ts
+++ b/warp-drive-packages/core/src/types/-private.ts
@@ -143,6 +143,23 @@ Multiple copies of WarpDrive have been detected. This may be due to a bug in emb
 type UniqueSymbol<T extends string> = `___(unique) Symbol(${T})`;
 type UniqueSymbolOr<T, K extends string> = T extends symbol ? UniqueSymbol<K> : T;
 
+/**
+ * Coordinates creation of a singleton `value` (e.g. a symbol, WeakMap, or
+ * error class) for `key` so that duplicate copies of this package loaded
+ * into the same process observe the same instance instead of each creating
+ * their own.
+ *
+ * In `TESTING` builds this stores/reads `value` from a cache namespaced to
+ * this package's name on `globalThis` (see the file-level comments above for
+ * why this is necessary). Outside of `TESTING`, only one copy of the package
+ * is expected to exist, so this is a no-op that always returns `value`
+ * unchanged.
+ *
+ * The return type lies about symbols being unique to work around the d.ts
+ * rollup issue described in `reactive/-private/symbols.ts`.
+ *
+ * @private
+ */
 export function getOrSetGlobal<T, K extends GlobalKey>(key: K, value: T): UniqueSymbolOr<T, K> {
   if (TESTING) {
     const existing = ModuleScopedCaches[key];
@@ -156,16 +173,45 @@ export function getOrSetGlobal<T, K extends GlobalKey>(key: K, value: T): Unique
   }
 }
 
+/**
+ * Reads back the current value stored for `key` by {@link setTransient}, or
+ * `null` if nothing has been stored yet.
+ *
+ * Unlike {@link getOrSetGlobal}, this always reads through the same
+ * package-namespaced cache regardless of the `TESTING` flag, since this is
+ * used for genuinely mutable state (not just singleton values) that must
+ * stay in sync across any duplicate copies of this package.
+ *
+ * @private
+ */
 export function peekTransient<T>(key: TransientKey): T | null {
   const globalKey: `(transient) ${TransientKey}` = `(transient) ${key}`;
   return (ModuleScopedCaches[globalKey] as T) ?? null;
 }
 
+/**
+ * Stores `value` for `key`, overwriting whatever was previously stored, so
+ * that it can later be read back via {@link peekTransient}.
+ *
+ * See {@link peekTransient} for details on when/why this cache is shared.
+ *
+ * @private
+ */
 export function setTransient<T>(key: TransientKey, value: T): T {
   const globalKey: `(transient) ${TransientKey}` = `(transient) ${key}`;
   return (ModuleScopedCaches[globalKey] = value);
 }
 
+/**
+ * Like {@link getOrSetGlobal}, but reads/writes a cache that is shared across
+ * *all* copies of WarpDrive on `globalThis`, regardless of package name.
+ *
+ * This is used for keys (e.g. request/promise caches) that must be
+ * coordinated even across "mirror" packages published under different
+ * names, rather than only across duplicate copies of the same package name.
+ *
+ * @private
+ */
 export function getOrSetUniversal<T, K extends UniversalKey>(key: K, value: T): UniqueSymbolOr<T, K> {
   if (TESTING) {
     const existing = UniversalCache[key];
@@ -179,11 +225,25 @@ export function getOrSetUniversal<T, K extends UniversalKey>(key: K, value: T): 
   }
 }
 
+/**
+ * Like {@link peekTransient}, but reads from the package-name-independent
+ * cache used by {@link getOrSetUniversal}. Always reads through this shared
+ * cache regardless of the `TESTING` flag.
+ *
+ * @private
+ */
 export function peekUniversalTransient<T>(key: UniversalTransientKey): T | null {
   const globalKey: `(transient) ${UniversalTransientKey}` = `(transient) ${key}`;
   return (UniversalCache[globalKey] as T) ?? null;
 }
 
+/**
+ * Like {@link setTransient}, but writes to the package-name-independent
+ * cache used by {@link getOrSetUniversal}, so it can later be read via
+ * {@link peekUniversalTransient}.
+ *
+ * @private
+ */
 export function setUniversalTransient<T>(key: UniversalTransientKey, value: T): T {
   const globalKey: `(transient) ${UniversalTransientKey}` = `(transient) ${key}`;
   return (UniversalCache[globalKey] = value);

--- a/warp-drive-packages/core/src/types/json/raw.ts
+++ b/warp-drive-packages/core/src/types/json/raw.ts
@@ -1,7 +1,30 @@
+/**
+ * A JSON primitive: a string, number, boolean, or `null`.
+ *
+ * @public
+ */
 export type PrimitiveValue = string | number | boolean | null;
+
+/**
+ * A plain JSON object, whose values are themselves valid {@link Value}s.
+ *
+ * @public
+ */
 export interface ObjectValue {
   [key: string]: Value;
 }
+
+/**
+ * A JSON array whose members are valid {@link Value}s.
+ *
+ * @public
+ */
 export type ArrayValue = Value[];
 
+/**
+ * Any valid JSON value: a {@link PrimitiveValue}, an {@link ArrayValue}, or an
+ * {@link ObjectValue}.
+ *
+ * @public
+ */
 export type Value = PrimitiveValue | ArrayValue | ObjectValue;

--- a/warp-drive-packages/core/src/utils/string.ts
+++ b/warp-drive-packages/core/src/utils/string.ts
@@ -88,6 +88,12 @@ export class LRUCache<T, V> {
 
 const STRING_DASHERIZE_REGEXP = /[ _]/g;
 const STRING_DECAMELIZE_REGEXP = /([a-z\d])([A-Z])/g;
+/**
+ * The {@link LRUCache} backing {@link dasherize}, keyed by the original
+ * (un-dasherized) string.
+ *
+ * @private
+ */
 export const STRING_DASHERIZE_CACHE: LRUCache<string, string> = new LRUCache<string, string>((key: string) =>
   key.replace(STRING_DECAMELIZE_REGEXP, '$1_$2').toLowerCase().replace(STRING_DASHERIZE_REGEXP, '-')
 );


### PR DESCRIPTION
## Summary
- Documents `getOrSetGlobal`/`peekTransient`/`setTransient`/`getOrSetUniversal`/`peekUniversalTransient`/`setUniversalTransient` (`types/-private.ts`), `PrimitiveValue`/`ObjectValue`/`ArrayValue`/`Value` (`types/json/raw.ts`), `STRING_DASHERIZE_CACHE`, `coerceId`/`ensureStringId`, and `normalizeModelName`.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)