### PR TITLE
docs: document ConfiguredStore cache constraint, reactive hooks, and notification types

### DIFF
--- a/warp-drive-packages/core/src/index.ts
+++ b/warp-drive-packages/core/src/index.ts
@@ -68,9 +68,15 @@ export {
  */
 export interface StoreSetupOptions<T extends Cache = Cache> {
   /**
-   * The Cache implementation to use
+   * A constructor for the {@link Cache} implementation to use, receiving the
+   * store's {@link CacheCapabilitiesManager} when instantiated.
    */
-  cache: new (capabilities: CacheCapabilitiesManager) => T;
+  cache: {
+    /**
+     * Constructs a new {@link Cache} instance for the store.
+     */
+    new (capabilities: CacheCapabilitiesManager): T;
+  };
   /**
    * The Cache policy to use.
    *
@@ -130,7 +136,15 @@ export interface StoreSetupOptions<T extends Cache = Cache> {
   CAUTION_MEGA_DANGER_ZONE_extensions?: CAUTION_MEGA_DANGER_ZONE_Extension[];
 }
 
-export declare class ConfiguredStore<T extends { cache: Cache }> extends Store {
+export declare class ConfiguredStore<
+  T extends {
+    /**
+     * The {@link Cache} instance type this configured store's `createCache`
+     * method produces.
+     */
+    cache: Cache;
+  },
+> extends Store {
   // get cache(): T extends OptionsWithCache<infer R> ? R : never;
   createCache(capabilities: CacheCapabilitiesManager): T['cache'];
 }

--- a/warp-drive-packages/core/src/reactive/-private/document.ts
+++ b/warp-drive-packages/core/src/reactive/-private/document.ts
@@ -107,6 +107,12 @@ export interface ReactiveDocumentBase<T> {
   toJSON(): object;
 }
 
+/**
+ * The variant of {@link ReactiveDocument} returned for a request whose
+ * response contained no primary data, e.g. an error response.
+ *
+ * @public
+ */
 export interface ReactiveErrorDocument<T> extends ReactiveDocumentBase<T> {
   /**
    * The primary data for this document, if any.
@@ -129,6 +135,12 @@ export interface ReactiveErrorDocument<T> extends ReactiveDocumentBase<T> {
   readonly errors: object[];
 }
 
+/**
+ * The variant of {@link ReactiveDocument} returned for a request whose
+ * response contained primary data.
+ *
+ * @public
+ */
 export interface ReactiveDataDocument<T> extends ReactiveDocumentBase<T> {
   /**
    * The primary data for this document, if any.

--- a/warp-drive-packages/core/src/reactive/-private/hooks.ts
+++ b/warp-drive-packages/core/src/reactive/-private/hooks.ts
@@ -7,6 +7,17 @@ import { ReactiveResource } from './record.ts';
 import type { SchemaService } from './schema.ts';
 import { Destroy } from './symbols.ts';
 
+/**
+ * The store's default `instantiateRecord` hook implementation, which
+ * produces a {@link ReactiveResource} for `identifier` using the resource
+ * schema registered for its type.
+ *
+ * `createArgs` are only applied (via `Object.assign`) when the resource's
+ * schema is `legacy`, matching the historical behavior of assigning initial
+ * properties when creating a new legacy record.
+ *
+ * @public
+ */
 export function instantiateRecord(
   store: Store,
   identifier: ResourceKey,
@@ -39,6 +50,13 @@ function assertReactiveResource(record: unknown): asserts record is ReactiveReso
   assert('Expected a ReactiveResource', record && typeof record === 'object' && Destroy in record);
 }
 
+/**
+ * The store's default `teardownRecord` hook implementation, which asserts
+ * that `record` is a {@link ReactiveResource} and invokes its `Destroy`
+ * behavior.
+ *
+ * @public
+ */
 export function teardownRecord(record: unknown): void {
   assertReactiveResource(record);
   record[Destroy]();

--- a/warp-drive-packages/core/src/reactive/-private/symbols.ts
+++ b/warp-drive-packages/core/src/reactive/-private/symbols.ts
@@ -37,6 +37,17 @@ export const Destroy: '___(unique) Symbol(Destroy)' = getOrSetGlobal(
   'Destroy',
   Symbol.dispose || Symbol.for('Dispose')
 );
+/**
+ * Symbol for the method used to request a mutable copy of an otherwise
+ * immutable {@link ReactiveResource}.
+ *
+ * @deprecated use the {@link checkout} utility function instead.
+ */
 export const Checkout: '___(unique) Symbol(Checkout)' = getOrSetGlobal('Checkout', Symbol('Checkout'));
 export const Commit: '___(unique) Symbol(Commit)' = getOrSetGlobal('Commit', Symbol('Commit'));
+
+/**
+ * Symbol used to stash the internal field/resource context (schema, store,
+ * mutability, etc.) on a {@link ReactiveResource} or reactive field instance.
+ */
 export const Context: '___(unique) Symbol(Context)' = getOrSetGlobal('Context', Symbol('Context'));

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -9,7 +9,13 @@ import { isRequestKey, isResourceKey } from './cache-key-manager.ts';
 
 export type UnsubscribeToken = object;
 
+/**
+ * The kinds of change notifications the {@link NotificationManager} can emit for a resource.
+ */
 export type CacheOperation = 'added' | 'removed' | 'updated' | 'state';
+/**
+ * The kinds of change notifications the {@link NotificationManager} can emit for a request document.
+ */
 export type DocumentCacheOperation = 'invalidated' | 'added' | 'removed' | 'updated' | 'state';
 
 function isCacheOperationValue(value: NotificationType | DocumentCacheOperation): value is DocumentCacheOperation {
@@ -18,6 +24,10 @@ function isCacheOperationValue(value: NotificationType | DocumentCacheOperation)
   );
 }
 
+/**
+ * The full set of notification kinds the {@link NotificationManager} can emit for a resource,
+ * including both {@link CacheOperation}s and finer-grained field-level change notifications.
+ */
 export type NotificationType = 'attributes' | 'relationships' | 'identity' | 'errors' | 'meta' | CacheOperation;
 
 export interface NotificationCallback {


### PR DESCRIPTION
## Summary
- Documents `ConfiguredStore`'s cache type constraint and `StoreSetupOptions.cache`'s constructor signature (`index.ts`), `Checkout`/`Context` symbols, `instantiateRecord`/`teardownRecord`, `ReactiveDataDocument`/`ReactiveErrorDocument`, and `CacheOperation`/`DocumentCacheOperation`/`NotificationType`.

## Test plan
- [x] `eslint` clean
- [x] `tsc --noEmit` clean
- [x] Scoped typedoc `notDocumented` validation confirms all listed warnings resolved
- [x] `pnpm run build:pkg` confirms declarations build cleanly and no `@internal`-tagged members were needed (verified repo-wide usage before choosing any `@private`/no-tag convention)

Verified as part of a combined 41-file/1194-line change covering all of `warp-drive-packages/core`'s remaining undocumented API surface, then split into focused per-area PRs for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)