### PR TITLE
docs: fix incorrect includeId behavior claim in JSONSerializer#serialize

### DIFF
--- a/warp-drive-packages/legacy/src/serializer/json.ts
+++ b/warp-drive-packages/legacy/src/serializer/json.ts
@@ -1014,8 +1014,15 @@ const JSONSerializer: any = Serializer.extend({
     `includeId`. If this option is `true`, `serialize` will,
     by default include the ID in the JSON object it builds.
 
-    The adapter passes in `includeId: true` when serializing
-    a record for `createRecord`, but not for `updateRecord`.
+    Whether `includeId` is `true` or `false` depends on the
+    adapter and the operation being performed, since it is the
+    adapter that invokes `serialize` and decides which options
+    to pass. For instance, `RESTAdapter` passes `includeId: true`
+    when serializing a record for `createRecord`, but not for
+    `updateRecord`, while `JSONAPIAdapter` passes `includeId: true`
+    for both `createRecord` and `updateRecord`. Refer to the
+    documentation for the adapter and serializer pairing you are
+    using for specifics.
 
     ## Customization
 

--- a/warp-drive-packages/legacy/src/serializer/rest.ts
+++ b/warp-drive-packages/legacy/src/serializer/rest.ts
@@ -542,7 +542,7 @@ const RESTSerializer: any = (JSONSerializer as typeof EmberObject).extend({
     `includeId`. If this option is `true`, `serialize` will,
     by default include the ID in the JSON object it builds.
 
-    The adapter passes in `includeId: true` when serializing
+    The RESTAdapter passes in `includeId: true` when serializing
     a record for `createRecord`, but not for `updateRecord`.
 
     ## Customization


### PR DESCRIPTION
## Summary

- `JSONSerializer#serialize`'s doc claimed the adapter always passes `includeId: true` for `createRecord` and not for `updateRecord`. That's only true for `RESTAdapter` — `JSONAPIAdapter` passes `includeId: true` for both `createRecord` and `updateRecord` (see `serializeIntoHash` calls in `RESTAdapter#createRecord`/`#updateRecord` vs `JSONAPIAdapter#updateRecord`).
- Since `JSONSerializer` is the shared base class (both `RESTSerializer` and `JSONAPISerializer` extend it directly), its doc shouldn't assume one specific adapter pairing. Updated it to explain that behavior depends on the adapter/operation and to point at the adapter-specific docs.
- `RESTSerializer#serialize`'s doc already correctly describes `RESTAdapter`'s behavior, but referred to "the adapter" generically — updated to name `RESTAdapter` explicitly for consistency with `JSONAPISerializer#serialize`'s doc, which already names `JSONAPIAdapter`.
- `JSONAPISerializer#serialize`'s doc was already correct, no change needed there.

Fixes #7320

## Test plan

- [x] Doc-only change to comment blocks; verified surrounding code is untouched and syntax is intact.
- [x] Confirmed the described behavior against the actual `serializeIntoHash` call sites in `RESTAdapter` and `JSONAPIAdapter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)