### PR TITLE
fix: guard against null payload in RESTAdapter#handleResponse

### DIFF
--- a/tests/dont-write-new-tests-here/tests/integration/adapter/handle-response-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/adapter/handle-response-test.js
@@ -210,7 +210,7 @@ module('integration/adapter/handle-response', function (hooks) {
     let handleResponseCalled = 0;
 
     this.server.get('/people', function () {
-      return ['422', { 'Content-Type': 'application/json' }, 'null'];
+      return [422, { 'Content-Type': 'application/json' }, 'null'];
     });
 
     class TestAdapter extends JSONAPIAdapter {

--- a/tests/dont-write-new-tests-here/tests/integration/adapter/handle-response-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/adapter/handle-response-test.js
@@ -205,4 +205,31 @@ module('integration/adapter/handle-response', function (hooks) {
 
     assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
   });
+
+  test('handleResponse does not throw when the payload is null on a 422 response', async function (assert) {
+    let handleResponseCalled = 0;
+
+    this.server.get('/people', function () {
+      return ['422', { 'Content-Type': 'application/json' }, 'null'];
+    });
+
+    class TestAdapter extends JSONAPIAdapter {
+      handleResponse(status, headers, payload, requestData) {
+        handleResponseCalled++;
+
+        return super.handleResponse(status, headers, payload, requestData);
+      }
+    }
+
+    this.owner.register('adapter:application', TestAdapter);
+
+    try {
+      await this.store.findAll('person');
+      assert.ok(false, 'promise should reject');
+    } catch (e) {
+      assert.true(e.isAdapterError, 'promise rejected with an AdapterError, not a TypeError');
+    }
+
+    assert.strictEqual(handleResponseCalled, 1, 'handle response is called');
+  });
 });

--- a/warp-drive-packages/legacy/src/adapter/rest.ts
+++ b/warp-drive-packages/legacy/src/adapter/rest.ts
@@ -957,8 +957,9 @@ class RESTAdapter extends AdapterWithBuildURLMixin {
     if (this.isSuccess(status, headers, payload)) {
       return payload;
     } else if (this.isInvalid(status, headers, payload)) {
+      const errorPayload = payload ?? {};
       // @ts-expect-error needs cast to ApiError
-      return new InvalidError(typeof payload === 'object' && 'errors' in payload ? payload.errors : undefined);
+      return new InvalidError(typeof errorPayload === 'object' && 'errors' in errorPayload ? errorPayload.errors : undefined);
     }
 
     const errors = this.normalizeErrorResponse(status, headers, payload);

--- a/warp-drive-packages/legacy/src/adapter/rest.ts
+++ b/warp-drive-packages/legacy/src/adapter/rest.ts
@@ -959,7 +959,9 @@ class RESTAdapter extends AdapterWithBuildURLMixin {
     } else if (this.isInvalid(status, headers, payload)) {
       const errorPayload = payload ?? {};
       // @ts-expect-error needs cast to ApiError
-      return new InvalidError(typeof errorPayload === 'object' && 'errors' in errorPayload ? errorPayload.errors : undefined);
+      return new InvalidError(
+        typeof errorPayload === 'object' && 'errors' in errorPayload ? errorPayload.errors : undefined
+      );
     }
 
     const errors = this.normalizeErrorResponse(status, headers, payload);


### PR DESCRIPTION
## Summary
- `RESTAdapter#handleResponse` throws when a `422` response body is the literal JSON `null`, because `typeof null === 'object'` lets it past the existing guard and `'errors' in payload` then throws on `null`.
- Defaults the payload to `{}` before checking for an `errors` key, so a null payload resolves to an `InvalidError` with no errors instead of throwing.

Fixes #7916

## Test plan
- [x] Added a regression test in `handle-response-test.js` covering a `422` response with a literal `null` body, asserting it rejects with an `AdapterError` rather than throwing a `TypeError`.
- [x] `eslint` passes on both changed files.
- [ ] CI test suite (trusting CI over local run per project convention)