### PR TITLE
docs: fix dead links breaking docs build

### DIFF
--- a/guides/contributing/writing-documentation/writing-api-docs.md
+++ b/guides/contributing/writing-documentation/writing-api-docs.md
@@ -536,7 +536,7 @@ that consumers should stop using the tagged function, component, or
 object because it is actively being removed.
 
 - Whenever possible, link the `@recommended` replacement.
-- If the deprecation is tracked by [the deprecations guide](/api/@warp-drive/build-config/deprecations)
+- If the deprecation is tracked by [the deprecations guide](/api/@warp-drive/build-config/deprecations/)
   (i.e. it has a deprecation id like `ember-data:deprecate-store-extends-ember-object`
   and a corresponding `DEPRECATE_*` flag), link both the guide and the
   specific deprecation id using `@id`.

--- a/guides/linting/index.md
+++ b/guides/linting/index.md
@@ -26,6 +26,18 @@ bun add --exact eslint-plugin-warp-drive@latest
 
 See the API docs for [eslint-plugin-warp-drive](/api/eslint-plugin-warp-drive/)
 
+## Template Rules
+
+Template rules operate on the Glimmer template AST rather than the JS/TS AST. They require
+[`ember-eslint-parser`](https://github.com/NullVoxPopuli/ember-eslint-parser) (a dependency of
+`eslint-plugin-warp-drive`) to be configured as the parser for the files being linted, since that's
+what exposes template nodes to ESLint as `Glimmer`-prefixed selectors (e.g. `GlimmerElementNode`) for
+`.gjs`/`.gts` files, or `ember-eslint-parser/hbs` for classic `.hbs` files. This mirrors the approach
+[`eslint-plugin-ember`](https://github.com/ember-cli/eslint-plugin-ember) uses for its own
+`template-*` rules, and the direction laid out in the
+[First-Class Component Templates RFC](https://rfcs.emberjs.com/id/0779-first-class-component-templates/#linting-and-formatting)
+for integrating template linting into ESLint.
+
 ## Usage
 
 Recommended Rules are available as a flat config for easy consumption:

--- a/packages/eslint-plugin-warp-drive/src/rules/template-always-use-request-content.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/template-always-use-request-content.md
@@ -3,7 +3,7 @@
 | `template-always-use-request-content` | 🐞 | |
 
 > [!TIP]
-> This rule requires a template-aware parser. See [Template Rules](https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive#template-rules) for setup.
+> This rule requires a template-aware parser. See [Template Rules](/guides/linting/#template-rules) for setup.
 
 `<Request>` is a component for declaratively resolving a request's `idle` / `loading` / `cancelled`
 / `error` / `content` states in a template. Using it without ever consuming the resolved result is

--- a/packages/eslint-plugin-warp-drive/src/rules/template-always-use-request-content.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/template-always-use-request-content.md
@@ -3,7 +3,7 @@
 | `template-always-use-request-content` | 🐞 | |
 
 > [!TIP]
-> This rule requires a template-aware parser. See [Template Rules](../../README.md#template-rules) for setup.
+> This rule requires a template-aware parser. See [Template Rules](https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive#template-rules) for setup.
 
 `<Request>` is a component for declaratively resolving a request's `idle` / `loading` / `cancelled`
 / `error` / `content` states in a template. Using it without ever consuming the resolved result is


### PR DESCRIPTION
## Summary
- Fixes the failing docs deploy build (see [run 31348158318](https://github.com/warp-drive-data/warp-drive/actions/runs/31348158318/job/93333890008)), which fails vitepress's dead-link check on 2 links.
- `guides/contributing/writing-documentation/writing-api-docs.md`: the deprecations guide link was missing the trailing slash required for a directory-index route (`/api/@warp-drive/build-config/deprecations` → `/api/@warp-drive/build-config/deprecations/`).
- `packages/eslint-plugin-warp-drive/src/rules/template-always-use-request-content.md`: the "Template Rules" link pointed at the package README via a relative path, but typedoc excludes READMEs from the generated API docs (`readme: 'none'`), so the link can never resolve on the docs site. Pointed it at the README on GitHub instead.

## Test plan
- [x] Reproduced the failure locally by running the exact CI build command (`bun ./src/sync-guides.ts --build --force` via `docs-viewer`)
- [x] Confirmed the same 2 dead links locally, applied the fixes, and reran the build — it now completes successfully with `build complete`