### PR TITLE
fix: docs build type error in RESTAdapter#handleResponse

### DIFF
--- a/warp-drive-packages/legacy/src/adapter/rest.ts
+++ b/warp-drive-packages/legacy/src/adapter/rest.ts
@@ -958,9 +958,8 @@ class RESTAdapter extends AdapterWithBuildURLMixin {
       return payload;
     } else if (this.isInvalid(status, headers, payload)) {
       const errorPayload = payload ?? {};
-      // @ts-expect-error needs cast to ApiError
       return new InvalidError(
-        typeof errorPayload === 'object' && 'errors' in errorPayload ? errorPayload.errors : undefined
+        typeof errorPayload === 'object' && 'errors' in errorPayload ? (errorPayload.errors as unknown[]) : undefined
       );
     }
 


### PR DESCRIPTION
## Summary
- Fixes the failing docs build/deploy job (https://github.com/warp-drive-data/warp-drive/actions/runs/31364472829/job/93379825594)
- `warp-drive-packages/legacy/src/adapter/rest.ts` used a `@ts-expect-error` comment immediately before a multi-line `return new InvalidError(...)` statement, intending to suppress a type error on the argument expression. Because the argument spans onto the next line, TypeScript attributes the diagnostic to that line instead of the one directly following the comment, so the directive was reported as unused (`TS2578`) while the real `TS2345` error ("Argument of type 'unknown' is not assignable to parameter of type 'unknown[] | undefined'") still surfaced. This came from #10646.
- The docs build type-checks source files directly (via typedoc), so these two errors failed the `Generate Artifact` step of the docs deploy workflow.
- Replaced the suppression hack with an explicit `as unknown[]` cast on `errorPayload.errors`, which resolves both errors without changing runtime behavior.

## Test plan
- [x] `pnpm exec tsc --build warp-drive-packages/legacy/tsconfig.json` no longer reports errors in `rest.ts` (confirmed the two errors reproduce on `main` and disappear with this change)
- [x] `pnpm exec eslint src/adapter/rest.ts --quiet` passes
- [x] `pnpm exec prettier --check` passes
- [ ] CI docs build job (`Generate Artifact`) passes
