### PR TITLE
feat: migrate @warp-drive/build-config's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3518,12 +3518,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(08d339ab80698bc6d2b26efaef736218)
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@20.19.11)
 
   warp-drive-packages/core:
     dependencies:
@@ -7883,6 +7883,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -14145,9 +14146,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.1:
-    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -15366,7 +15364,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.3.0
-      tinyexec: 1.0.1
+      tinyexec: 1.3.0
 
   '@antfu/utils@9.2.0': {}
 
@@ -20209,11 +20207,17 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20726,7 +20730,7 @@ snapshots:
       alien-signals: 2.0.6
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     optionalDependencies:
       typescript: 5.9.2
 
@@ -29476,7 +29480,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 1.1.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   sort-package-json@3.6.1:
     dependencies:
@@ -29486,7 +29490,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 2.1.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   source-map-js@1.2.1: {}
 
@@ -30089,8 +30093,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
-
-  tinyexec@1.0.1: {}
 
   tinyexec@1.3.0: {}
 

--- a/tools/internal-config/tsdown/config.js
+++ b/tools/internal-config/tsdown/config.js
@@ -96,7 +96,7 @@ export function createConfig(options, resolve) {
     minify: false,
     report: false,
     dts: options.compileTypes ? { sourcemap: true } : false,
-    outExtensions: () => ({ js: '.js', dts: '.d.ts' }),
+    outExtensions: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.js', dts: '.d.ts' }),
     deps: {
       neverBundle: external(options.externals),
     },

--- a/warp-drive-packages/build-config/package.json
+++ b/warp-drive-packages/build-config/package.json
@@ -14,11 +14,11 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "build:pkg": "vite build; vite build -c ./vite.config-cjs.mjs;",
+    "build:pkg": "tsdown; tsdown -c ./tsdown.config-cjs.mjs;",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "type": "module",
   "files": [
@@ -57,8 +57,8 @@
     "@types/node": "^20.19.11",
     "@types/semver": "^7.7.1",
     "@warp-drive/internal-config": "workspace:*",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/build-config/tsdown.config-cjs.mjs
+++ b/warp-drive-packages/build-config/tsdown.config-cjs.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['babel-import-util', 'fs', 'path', 'url'];
 
@@ -19,7 +19,6 @@ export default createConfig(
     externals,
     target: ['esnext', 'firefox121', 'node22'],
     emptyOutDir: false,
-    fixModule: false,
     compileTypes: false,
   },
   import.meta.resolve

--- a/warp-drive-packages/build-config/tsdown.config.mjs
+++ b/warp-drive-packages/build-config/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['fs', 'path', 'semver', 'url'];
 
@@ -12,14 +12,11 @@ export const entryPoints = [
   './src/canary-features.ts',
 ];
 
-const config = createConfig(
+export default createConfig(
   {
     entryPoints,
     flatten: true,
     externals,
-    fixModule: false,
   },
   import.meta.resolve
 );
-
-export default config;

--- a/warp-drive-packages/build-config/typedoc.config.mjs
+++ b/warp-drive-packages/build-config/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {


### PR DESCRIPTION
## Summary
- Continues the Vite/Rollup → rolldown migration (#10643) with `@warp-drive/build-config`.
- Migrates both of the package's builds (ESM macro-config surface + CJS babel transform plugins/addon-shim) to `tsdown`, reusing core's curated-entry-point pattern.
- Extends the shared `tools/internal-config/tsdown/config.js` helper's `outExtensions` to be format-aware (emits `.cjs` for CJS output), since core's original migration only ever needed `.js`.

## Test plan
- [x] Rebuilt `@warp-drive/core` and `@warp-drive/legacy` against the new build-config output and confirmed the babel macro-transform plugins (assert/deprecations/features/logging) still load and strip macros correctly from their new `.cjs` build (`macroCondition(...)` calls present as expected in core's built output).
- [x] `tests/core` and `tests/legacy` diagnostic suites pass in both dev and production modes.
- [x] Clean (`--noEmit`) type-check of `tests/core`, `tests/legacy`, `tests/json-api`, `tests/utilities`.
- [x] Prettier clean on all new/changed files.

## Note
Verifying this surfaced a pre-existing, unrelated bug on `main`: `tests/experiments` fails to type-check because `store.ts` and `index.ts` (both curated core tsdown entry points) each get their own inlined copy of `CacheKeyManager`/`CacheCapabilitiesManager` instead of sharing one chunk, so TypeScript sees two nominally-distinct classes with the same name. This predates this PR (core's entry-point list is untouched here) — will track/fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)