### PR TITLE
feat: migrate @warp-drive/schema-dsl's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3840,12 +3840,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.1.3
-        version: 7.3.1
 
   warp-drive-packages/svelte:
     dependencies:
@@ -7883,6 +7883,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -14145,9 +14146,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.1:
-    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -15366,7 +15364,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.3.0
-      tinyexec: 1.0.1
+      tinyexec: 1.3.0
 
   '@antfu/utils@9.2.0': {}
 
@@ -19085,7 +19083,7 @@ snapshots:
     dependencies:
       jju: 1.4.0
       js-yaml: 4.1.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   '@mdit/plugin-footnote@0.22.2':
     dependencies:
@@ -20209,11 +20207,17 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20726,7 +20730,7 @@ snapshots:
       alien-signals: 2.0.6
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     optionalDependencies:
       typescript: 5.9.2
 
@@ -29476,7 +29480,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 1.1.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   sort-package-json@3.6.1:
     dependencies:
@@ -29486,7 +29490,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 2.1.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   source-map-js@1.2.1: {}
 
@@ -30089,8 +30093,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
-
-  tinyexec@1.0.1: {}
 
   tinyexec@1.3.0: {}
 

--- a/warp-drive-packages/schema-dsl/eslint.config.mjs
+++ b/warp-drive-packages/schema-dsl/eslint.config.mjs
@@ -2,7 +2,7 @@
 import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/warp-drive-packages/schema-dsl/package.json
+++ b/warp-drive-packages/schema-dsl/package.json
@@ -13,11 +13,11 @@
   "homepage": "https://github.com/warp-drive-data/warp-drive",
   "bugs": "https://github.com/warp-drive-data/warp-drive/issues",
   "scripts": {
-    "build:pkg": "vite build;",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "dist",
@@ -57,8 +57,8 @@
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
     "@warp-drive/core": "workspace:*",
-    "typescript": "^5.9.2",
-    "vite": "^7.1.3"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.2"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/schema-dsl/tsdown.config.mjs
+++ b/warp-drive-packages/schema-dsl/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['./src/index.ts'];


### PR DESCRIPTION
## Summary

- Continues the package-by-package migration off Vite/Rollup onto rolldown (via tsdown), following the pattern established by `@warp-drive/core` (#10643) and `@warp-drive/build-config` (#10651).
- Replaces `warp-drive-packages/schema-dsl/vite.config.mjs` with `tsdown.config.mjs`, using the shared `createConfig` helper from `@warp-drive/internal-config/tsdown/config.js`. `entryPoints` (`./src/index.ts`) and `externals` (`[]`) are unchanged.
- Updates `package.json`: `build:pkg` is now `tsdown`, `start` is now `tsdown --watch`, and `vite` is swapped for `tsdown@^0.22.14` in devDependencies (matching the version already used by `@warp-drive/core`).
- Repoints `eslint.config.mjs`'s `import { externals } from './vite.config.mjs'` to `./tsdown.config.mjs`.
- Updates `pnpm-lock.yaml` accordingly.

Note: `README.md`'s `vite.config.ts` reference is unrelated — it documents how a *consumer* app wires up the `@warp-drive/schema-dsl/vite` plugin, not this package's own build, so it was left as-is.

## Test plan

- [x] `pnpm install` (full workspace install, needed for pnpm's injected-deps sync to consumers like `tests/core`) — lockfile updates as expected (vite removed, tsdown added, incidental transitive churn only).
- [x] `pnpm --filter @warp-drive/schema-dsl run build:pkg` succeeds, exit code 0, and produces sensible `dist/index.js` + `declarations/index.d.ts` (verified contents match the expected `Resource`/`field`/`id` decorator exports).
- [x] `cd tests/core && pnpm exec ember-tsc --noEmit` — passes with no errors (consumer type-checks cleanly against the new build output).
- [x] `cd tests/core && pnpm run build:tests && pnpm run test` — 189 total, 187 pass, 2 skip, 0 fail (matches baseline).
- [x] `cd tests/core && pnpm run build:production && pnpm run test:production` — 189 total, 187 pass, 2 skip, 0 fail (matches baseline).
- [x] `pnpm exec eslint tsdown.config.mjs eslint.config.mjs` in `warp-drive-packages/schema-dsl` — no errors.
- [x] `pnpm exec prettier --check` on all changed files — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)