### PR TITLE
feat: migrate @warp-drive/tc39-proposal-signals's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3908,12 +3908,12 @@ importers:
       rollup:
         specifier: ^4.48.0
         version: 4.48.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   warp-drive-packages/utilities:
     dependencies:
@@ -7883,6 +7883,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -14145,9 +14146,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.1:
-    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -15366,7 +15364,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.3.0
-      tinyexec: 1.0.1
+      tinyexec: 1.3.0
 
   '@antfu/utils@9.2.0': {}
 
@@ -19085,7 +19083,7 @@ snapshots:
     dependencies:
       jju: 1.4.0
       js-yaml: 4.1.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   '@mdit/plugin-footnote@0.22.2':
     dependencies:
@@ -20209,11 +20207,17 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20726,7 +20730,7 @@ snapshots:
       alien-signals: 2.0.6
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.3
+      picomatch: 4.0.5
     optionalDependencies:
       typescript: 5.9.2
 
@@ -29476,7 +29480,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 1.1.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   sort-package-json@3.6.1:
     dependencies:
@@ -29486,7 +29490,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 2.1.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
 
   source-map-js@1.2.1: {}
 
@@ -30089,8 +30093,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
-
-  tinyexec@1.0.1: {}
 
   tinyexec@1.3.0: {}
 

--- a/warp-drive-packages/tc39-proposal-signals/eslint.config.mjs
+++ b/warp-drive-packages/tc39-proposal-signals/eslint.config.mjs
@@ -2,7 +2,7 @@
 import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/warp-drive-packages/tc39-proposal-signals/package.json
+++ b/warp-drive-packages/tc39-proposal-signals/package.json
@@ -13,11 +13,11 @@
   "bugs": "https://github.com/warp-drive-data/warp-drive/issues",
   "keywords": [],
   "scripts": {
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "declarations",
@@ -48,8 +48,8 @@
     "@warp-drive/core": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
     "rollup": "^4.48.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/tc39-proposal-signals/tsconfig.json
+++ b/warp-drive-packages/tc39-proposal-signals/tsconfig.json
@@ -44,6 +44,8 @@
       "@warp-drive/core/*": ["../core/declarations/*"]
     },
     "erasableSyntaxOnly": true,
+    "isolatedDeclarations": true,
+    "isolatedModules": true,
     "lib": ["ESNext", "DOM"],
     "moduleDetection": "force"
   },

--- a/warp-drive-packages/tc39-proposal-signals/tsdown.config.mjs
+++ b/warp-drive-packages/tc39-proposal-signals/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['./src/install.ts'];
@@ -7,8 +7,6 @@ export default createConfig(
   {
     entryPoints,
     externals,
-    plugins: [],
-    useGlint: true,
     compileTypes: process.env.IS_UNPKG_BUILD !== 'true',
   },
   import.meta.resolve

--- a/warp-drive-packages/tc39-proposal-signals/typedoc.config.mjs
+++ b/warp-drive-packages/tc39-proposal-signals/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {


### PR DESCRIPTION
## Summary

- Migrates `@warp-drive/tc39-proposal-signals`'s build from Vite/Rollup to `tsdown` (rolldown-powered), following the pattern established by `@warp-drive/core` in #10643.
- Replaces `vite.config.mjs` with `tsdown.config.mjs` using the shared `createConfig` helper from `@warp-drive/internal-config/tsdown/config.js`. The `entryPoints`/`externals` values are unchanged (single entry: `./src/install.ts`).
- Updates `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, and `vite` is swapped for `tsdown` (`^0.22.14`, matching the version already used elsewhere in the repo) in devDependencies.
- Points `eslint.config.mjs` and `typedoc.config.mjs` at `tsdown.config.mjs` instead of the removed `vite.config.mjs`.
- Enables `isolatedDeclarations`/`isolatedModules` in `tsconfig.json`, required by tsdown's declaration-emission plugin (the package's single source file was already fully typed, so this has no type-level effect).

## Test plan

- [x] `pnpm install --filter @warp-drive/tc39-proposal-signals` updates the lockfile as expected (vite removed, tsdown added, incidental transitive churn only).
- [x] `pnpm --filter @warp-drive/tc39-proposal-signals run build:pkg` succeeds and produces a correct `dist/install.js` + `declarations/install.d.ts`.
- [x] Confirmed `@warp-drive/tc39-proposal-signals` is a devDependency of `@warp-drive/react` (used for type-checking via a tsconfig path mapping; not directly imported by `react`'s source, which implements its own signal config).
- [x] `pnpm --filter @warp-drive/react run build:pkg` (still on Vite) succeeds against the new tc39-proposal-signals output.
- [x] `cd tests/framework-react && pnpm exec ember-tsc --noEmit` passes with zero errors.
- [x] `cd tests/framework-react && pnpm run test` passes 39/39.
- [x] `cd tests/framework-react && pnpm run test:production` passes 39/39.
- [x] `eslint` and `prettier --check` pass on all changed config files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)