### PR TITLE
feat: migrate @warp-drive/react's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3352,6 +3352,9 @@ importers:
       '@nullvoxpopuli/ember-rolldown':
         specifier: ^2.7.0
         version: 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@rolldown/pluginutils':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
@@ -3806,12 +3809,12 @@ importers:
       rollup:
         specifier: ^4.48.0
         version: 4.48.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   warp-drive-packages/schema-dsl:
     dependencies:
@@ -21274,6 +21277,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21337,6 +21341,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(5ea8c13813352e102e7b60b4a20ecf96)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(8467c3c9fe5290d7e333f65ec1b8a929)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21400,6 +21405,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(@glint/template@1.6.1)(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(5159dbb6ccbb10b65fdffb41dc84bb6f)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21463,6 +21469,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(@glint/template@1.6.1)(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(5159dbb6ccbb10b65fdffb41dc84bb6f)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21526,6 +21533,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21589,6 +21597,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21652,6 +21661,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21715,6 +21725,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(5aaf6904f4b62bc3ebd1ed7a2b8749af)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -21778,6 +21789,7 @@ snapshots:
       '@embroider/addon-dev': 8.1.0(rollup@4.48.1)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(21b3de1a5cac6d42a0c904ef4f131b45)
+      '@rolldown/pluginutils': 1.0.1
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(rollup@4.48.1)
       '@types/debug': 4.1.12
       '@typescript-eslint/eslint-plugin': 8.41.0(ad3e4b2f3df4fca831ef47c5e1339106)
@@ -30467,7 +30479,7 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@5.9.2):
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       typescript: 5.9.2
 
   tsconfig-paths@3.15.0:

--- a/tools/internal-config/package.json
+++ b/tools/internal-config/package.json
@@ -8,6 +8,7 @@
     "@babel/core": "^7.28.3",
     "@babel/eslint-parser": "7.28.0",
     "@nullvoxpopuli/ember-rolldown": "^2.7.0",
+    "@rolldown/pluginutils": "^1.0.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",

--- a/tools/internal-config/tsdown/config.js
+++ b/tools/internal-config/tsdown/config.js
@@ -2,6 +2,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { ember } from '@nullvoxpopuli/ember-rolldown';
+import { id, include } from '@rolldown/pluginutils';
+import { babel } from '@rollup/plugin-babel';
 import { defineConfig } from 'tsdown';
 
 import { entryPoints, external } from '../rollup/external.js';
@@ -78,6 +80,33 @@ function withMacroImportsAlwaysBabeled(emberOptions) {
   };
 }
 
+/**
+ * `@nullvoxpopuli/ember-build-tooling-utils`'s `maybeBabel()` (which powers
+ * `ember()`'s babel routing) matches against a hardcoded extension allowlist
+ * that mirrors Embroider's canonical Ember source extensions -- `.gjs`/`.gts`/
+ * `.js`/`.ts`/etc -- and does not include `.jsx`/`.tsx`. Its file-extension
+ * check is an AND-gate alongside the imports/decorator heuristics, so a
+ * `.tsx` file is *never* routed through babel by `ember()`, regardless of
+ * what it imports: `assert()`/macro calls in `.tsx` files silently survive
+ * unstripped into every build (dev and prod alike) otherwise. This runs a
+ * second, independent babel pass scoped to just `.jsx`/`.tsx`, reusing
+ * whatever babel config the package already has (auto-discovered, same as
+ * `ember()`'s own babel step) so JSX/macro/decorator handling stays
+ * consistent with `.ts`/`.gts` files in the same package.
+ */
+function jsxBabel() {
+  const plugin = babel({
+    babelHelpers: 'bundled',
+    extensions: ['.jsx', '.tsx'],
+  });
+  // `@rollup/plugin-babel`'s own `extensions`-based file matching isn't
+  // honored by rolldown's transform pipeline (only rolldown-native `filter`
+  // objects are) -- same reason `maybeBabel()` above sets this explicitly
+  // rather than trusting the plugin's own `extensions` option.
+  plugin.transform.filter = [include(id(/\.[jt]sx$/))];
+  return { ...plugin, enforce: 'pre', name: 'warp-drive:jsx-babel' };
+}
+
 export function createConfig(options, resolve) {
   options.srcDir = options.srcDir ?? './src';
   options.compileTypes = options.compileTypes ?? true;
@@ -103,6 +132,7 @@ export function createConfig(options, resolve) {
     plugins: [
       selfReferenceEntries(entryMap),
       ...ember(withMacroImportsAlwaysBabeled(options.ember)),
+      options.jsx ? jsxBabel() : null,
       options.compileTypes ? MoveTypesToDestination(options, resolve) : null,
       ...(options.plugins || []),
     ].filter(Boolean),

--- a/warp-drive-packages/react/eslint.config.mjs
+++ b/warp-drive-packages/react/eslint.config.mjs
@@ -2,7 +2,7 @@
 import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/warp-drive-packages/react/package.json
+++ b/warp-drive-packages/react/package.json
@@ -18,11 +18,11 @@
     "warp-drive"
   ],
   "scripts": {
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "declarations",
@@ -64,8 +64,8 @@
     "decorator-transforms": "^2.3.0",
     "react": "^19.1.1",
     "rollup": "^4.48.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/react/package.json
+++ b/warp-drive-packages/react/package.json
@@ -18,7 +18,7 @@
     "warp-drive"
   ],
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "NODE_ENV=production tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",

--- a/warp-drive-packages/react/tsdown.config.mjs
+++ b/warp-drive-packages/react/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['react'];
 export const entryPoints = ['./src/index.ts', './src/install.ts'];
@@ -7,7 +7,7 @@ export default createConfig(
   {
     entryPoints,
     externals,
-    plugins: [],
+    jsx: true,
     compileTypes: process.env.IS_UNPKG_BUILD !== 'true',
   },
   import.meta.resolve

--- a/warp-drive-packages/react/typedoc.config.mjs
+++ b/warp-drive-packages/react/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {


### PR DESCRIPTION
## Summary
- Continues the Vite/Rollup → rolldown migration (#10643) with `@warp-drive/react`.
- Migrates `warp-drive-packages/react` to `tsdown` using the same curated-entry-point pattern as core.
- **Fixes a real gap in the shared tsdown pipeline**: `@nullvoxpopuli/ember-build-tooling-utils`'s `maybeBabel()` (which powers `ember()`'s babel routing) has a hardcoded extension allowlist mirroring Ember's canonical source extensions, which does not include `.jsx`/`.tsx`. Since that check is an AND-gate alongside the imports/decorator heuristics, `.tsx` files were never routed through babel at all — confirmed by inspecting the naively-migrated build output: `assert()` calls survived as raw, never-eliminated runtime calls, and JSX fell back to rolldown's native oxc transform, which ignores `@babel/preset-react`'s dev/prod runtime selection entirely.
- Adds a second, independent babel pass (`jsxBabel()` in `tools/internal-config/tsdown/config.js`, opt-in via a new `jsx: true` config option) scoped specifically to `.jsx`/`.tsx` via a rolldown-native transform filter, reusing the package's own auto-discovered `babel.config.mjs`.

## Test plan
- [x] `assert()` calls now correctly expand to `macroCondition(...)` in the built output (matching core's already-migrated behavior) — verified by inspecting `dist/index.js` directly.
- [x] JSX correctly resolves `jsx()` vs `jsxDEV()` based on `NODE_ENV`, matching the pre-migration Vite pipeline's behavior (which unconditionally routed `.tsx` through the same `babel.config.mjs`).
- [x] `tests/framework-react`: `ember-tsc --noEmit` clean.
- [x] `tests/framework-react` diagnostic suite: 39/39 pass in both dev and production modes.
- [x] ESLint and Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)