### PR TITLE
feat: migrate @warp-drive/utilities's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3942,12 +3942,12 @@ importers:
       expect-type:
         specifier: ^1.2.2
         version: 1.2.2
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   warp-drive-packages/vue:
     dependencies:

--- a/tools/internal-config/tsdown/config.js
+++ b/tools/internal-config/tsdown/config.js
@@ -1,10 +1,11 @@
 import fs from 'fs';
+import { createRequire, isBuiltin } from 'module';
 import path from 'path';
 
 import { ember } from '@nullvoxpopuli/ember-rolldown';
 import { defineConfig } from 'tsdown';
 
-import { entryPoints, external } from '../rollup/external.js';
+import { entryPoints, explicitExternals, external } from '../rollup/external.js';
 import { MoveTypesToDestination } from './move-types.js';
 
 /**
@@ -61,6 +62,49 @@ const WARP_DRIVE_MACRO_IMPORTS = [
   '@warp-drive/core/build-config/canary-features',
 ];
 
+/**
+ * `@nullvoxpopuli/ember-rolldown`'s `ember()` plugin bundles its own
+ * `emberExternals()` resolveId hook (also `order: 'pre'`), which unconditionally
+ * marks anything listed in this package's own `dependencies`/`peerDependencies`
+ * as external -- there's no option to turn that off. That's the right default
+ * for a normal library build, but it defeats `explicitExternalsOnly` (used for
+ * builds meant to be fully self-contained, e.g. a standalone cjs bundle, where
+ * even a peerDependency subpath import should be inlined). Since the first
+ * `resolveId` hook to return a definitive result wins, placing this plugin
+ * ahead of `ember()`'s plugins in the array lets it resolve (and keep
+ * non-external) anything not in the explicit externals list before
+ * `emberExternals()` ever sees it. `this.resolve()` isn't usable to find the
+ * real file here: it re-enters the same plugin pipeline (`skipSelf` only
+ * skips this plugin, not `emberExternals()`), so it would just hit that same
+ * early `false` return again -- external, without ever touching the
+ * filesystem. Resolving via Node's own resolver directly sidesteps the
+ * plugin pipeline entirely.
+ */
+function forceBundleOverEmberExternals(options) {
+  if (!options.explicitExternalsOnly) {
+    return null;
+  }
+  const manual = new Set(options.externals ?? []);
+
+  return {
+    name: 'warp-drive:force-bundle-over-ember-externals',
+    resolveId: {
+      order: 'pre',
+      handler(id, importer) {
+        if (!importer || manual.has(id) || id.startsWith('.') || id.includes(':') || isBuiltin(id)) {
+          return null;
+        }
+        try {
+          const resolvedPath = createRequire(importer).resolve(id);
+          return { id: resolvedPath, external: false };
+        } catch {
+          return null;
+        }
+      },
+    },
+  };
+}
+
 function withMacroImportsAlwaysBabeled(emberOptions) {
   const userImports = emberOptions?.babel?.filter?.include?.imports ?? [];
   return {
@@ -96,12 +140,29 @@ export function createConfig(options, resolve) {
     minify: false,
     report: false,
     dts: options.compileTypes ? { sourcemap: true } : false,
+    // Keep `.js` for esm output (matching this repo's existing `exports` maps),
+    // but a `format: 'cjs'` build (e.g. a standalone cjs bundle) needs the
+    // real `.cjs` extension -- these packages don't set `"type": "module"`,
+    // so plain `.js` would otherwise be ambiguous/wrong for a cjs artifact.
     outExtensions: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.js', dts: '.d.ts' }),
     deps: {
-      neverBundle: external(options.externals),
+      // `explicitExternalsOnly` opts out of the default "every declared
+      // dependency/peerDependency is external" behavior. This is for builds
+      // meant to be fully self-contained (e.g. a standalone cjs bundle) where
+      // even a peerDependency subpath import should be inlined rather than
+      // left as a bare specifier for the consumer to resolve. tsdown/rolldown's
+      // dependency plugin externalizes any bare (node_modules-style) import by
+      // default regardless of `neverBundle`, so opting out also requires
+      // `alwaysBundle` to force everything but the explicit list back in.
+      neverBundle: options.explicitExternalsOnly ? explicitExternals(options.externals) : external(options.externals),
+      alwaysBundle: options.explicitExternalsOnly ? (id) => !explicitExternals(options.externals)(id) : undefined,
+      // A self-contained bundle bundling its dependencies on purpose doesn't
+      // need tsdown's "did you mean to bundle this?" hint on every build.
+      onlyBundle: options.explicitExternalsOnly ? false : undefined,
     },
     plugins: [
       selfReferenceEntries(entryMap),
+      forceBundleOverEmberExternals(options),
       ...ember(withMacroImportsAlwaysBabeled(options.ember)),
       options.compileTypes ? MoveTypesToDestination(options, resolve) : null,
       ...(options.plugins || []),

--- a/warp-drive-packages/utilities/eslint.config.mjs
+++ b/warp-drive-packages/utilities/eslint.config.mjs
@@ -3,7 +3,7 @@ import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [

--- a/warp-drive-packages/utilities/package.json
+++ b/warp-drive-packages/utilities/package.json
@@ -13,11 +13,11 @@
     "directory": "warp-drive-packages/utilities"
   },
   "scripts": {
-    "build:pkg": "vite build; vite build -c ./vite.config-cjs.mjs;",
+    "build:pkg": "tsdown; tsdown -c ./tsdown.config-cjs.mjs;",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "dist",
@@ -57,8 +57,8 @@
     "@warp-drive/internal-config": "workspace:*",
     "decorator-transforms": "^2.3.0",
     "expect-type": "^1.2.2",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/utilities/tsdown.config-cjs.mjs
+++ b/warp-drive-packages/utilities/tsdown.config-cjs.mjs
@@ -1,4 +1,5 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { fixViteHijack } from '@warp-drive/internal-config/rollup/external.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['./src/string.ts'];
@@ -10,13 +11,13 @@ export default createConfig(
     format: 'cjs',
     externals,
     explicitExternalsOnly: true,
-    babelConfigFile: import.meta
-      .resolve('./babel.config-standalone.mjs')
-      .slice(7)
-      .replace('/node_modules/.vite-temp/', '/'),
+    ember: {
+      babel: {
+        configFile: fixViteHijack(import.meta.resolve('./babel.config-standalone.mjs')).slice(7),
+      },
+    },
     target: ['esnext', 'firefox121', 'node18'],
     emptyOutDir: false,
-    fixModule: false,
     compileTypes: false,
     outDir: 'cjs-dist',
   },

--- a/warp-drive-packages/utilities/tsdown.config.mjs
+++ b/warp-drive-packages/utilities/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['@embroider/macros'];
 

--- a/warp-drive-packages/utilities/typedoc.config.mjs
+++ b/warp-drive-packages/utilities/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {


### PR DESCRIPTION
## Summary

- Migrates `@warp-drive/utilities`'s build from Vite/Rollup to rolldown via `tsdown`, following the same pattern established by `@warp-drive/core` (#10643) and `@warp-drive/build-config` (#10651): `vite.config.mjs` -> `tsdown.config.mjs` (same `entryPoints`/`externals`), `build:pkg`/`start` scripts point at `tsdown`, `vite` devDependency replaced with `tsdown`.
- This package also ships a second, fully self-contained cjs bundle of `string.ts` (`cjs-dist/string.cjs`, from `vite.config-cjs.mjs` -> `tsdown.config-cjs.mjs`) that's meant to have zero runtime dependencies, including on its own `@warp-drive/core` peerDependency. Getting that working under tsdown required extending the shared `tools/internal-config/tsdown/config.js` helper with an `explicitExternalsOnly` option (mirroring the vite config's option of the same name) plus a small `forceBundleOverEmberExternals` plugin, since both tsdown/rolldown's dependency plugin and `@nullvoxpopuli/ember-rolldown`'s `ember()` plugin otherwise externalize every declared dependency/peerDependency unconditionally.
- `outExtensions` in the shared helper is now format-aware, so a `format: 'cjs'` build gets a real `.cjs` extension instead of the previously hardcoded `.js`.

## Test plan

- [x] `pnpm install --filter @warp-drive/utilities` updates the lockfile (vite removed, tsdown added; incidental transitive dep churn only)
- [x] `pnpm --filter @warp-drive/utilities run build:pkg` succeeds and produces all 8 entry points (`index`, `string`, `handlers`, `-private`, `json-api`, `active-record`, `rest`, `derivations`) as `dist/*.js` + `declarations/*.d.ts`
- [x] `cjs-dist/string.cjs` builds and is genuinely self-contained: loads via plain `require()`, exports all expected members, and contains zero `require()` calls to other packages -- matching the pre-migration vite-built output byte-for-byte in behavior
- [x] `cd tests/utilities && pnpm exec ember-tsc --noEmit` passes with no errors
- [x] `cd tests/utilities && pnpm run test` passes (75/75, 0 failures)
- [x] `cd tests/utilities && pnpm run test:production` passes (75/75, 0 failures)
- [x] `pnpm exec eslint .` and `pnpm exec prettier --check` clean on all changed files
- [x] `@warp-drive/legacy` (a downstream consumer of `@warp-drive/utilities`) still builds cleanly (`pnpm --filter @warp-drive/legacy run build:pkg`)
- [x] `@warp-drive/core`'s own build re-verified unaffected by the shared `tools/internal-config/tsdown/config.js` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)