### PR TITLE
feat: migrate @warp-drive/ember's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3628,12 +3628,12 @@ importers:
       rollup:
         specifier: ^4.48.0
         version: 4.48.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   warp-drive-packages/experiments:
     dependencies:

--- a/warp-drive-packages/ember/eslint.config.mjs
+++ b/warp-drive-packages/ember/eslint.config.mjs
@@ -3,7 +3,7 @@ import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 import * as gts from '@warp-drive/internal-config/eslint/gts.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/warp-drive-packages/ember/package.json
+++ b/warp-drive-packages/ember/package.json
@@ -15,11 +15,11 @@
     "ember-addon"
   ],
   "scripts": {
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "declarations",
@@ -73,8 +73,8 @@
     "ember-source": "~6.12.0",
     "ember-template-imports": "^4.3.0",
     "rollup": "^4.48.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/ember/tsdown.config.mjs
+++ b/warp-drive-packages/ember/tsdown.config.mjs
@@ -1,5 +1,4 @@
-import { gjs } from '@warp-drive/internal-config/rollup/gjs.js';
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@ember/template-compilation',
@@ -22,8 +21,6 @@ export default createConfig(
   {
     entryPoints,
     externals,
-    plugins: [gjs()],
-    useGlint: true,
     compileTypes: process.env.IS_UNPKG_BUILD !== 'true',
   },
   import.meta.resolve

--- a/warp-drive-packages/ember/typedoc.config.mjs
+++ b/warp-drive-packages/ember/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {


### PR DESCRIPTION
## Summary
- Continues the Vite/Rollup → rolldown migration (#10643) with `@warp-drive/ember` — the first package in this series with real `.gts` (template-tag) source files (`src/-private/{await,request}.gts`).
- Unlike the old Vite pipeline, which needed the internal-config-provided `gjs()` rollup plugin to handle `.gts`/`.gjs` compilation, tsdown's `ember()` plugin (from `@nullvoxpopuli/ember-rolldown`) already handles this natively — it bundles `content-tag` (for `<template>` tag extraction) and `babel-plugin-ember-template-compilation` (for the handlebars portion), the same tooling core's `tsdown.config.mjs` already depends on. No equivalent plugin was needed in the new config.

## Test plan
- [x] Verified by inspecting the built output directly: `.gts` template content correctly compiles to `precompileTemplate(...)` + `setComponentTemplate(...)` calls (lazy-compilation shape, matching the v2 addon spec).
- [x] `assert()` calls in `.gts` files correctly expand to `macroCondition(...)` (same as `.ts` files, since `.gts` is already in `ember()`'s babel-routing extension allowlist — no extra fix needed here, unlike `@warp-drive/react`'s `.tsx` gap in #10656).
- [x] `tests/framework-ember`: `ember-tsc --noEmit` shows only ~10 pre-existing, unrelated errors from a known bug in `@warp-drive/core`'s own tsdown entry-point configuration (`CacheKeyManager`/`CacheCapabilitiesManager` duplicated across `store.ts`/`index.ts` chunks) — confirmed identical root cause to the one already flagged in the build-config (#10651) and experiments (#10654) PRs.
- [x] `tests/framework-ember` diagnostic suite: 48/48 pass in both dev and production modes.
- [x] ESLint and Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)