### PR TITLE
feat: migrate @warp-drive/legacy's build to rolldown via tsdown

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3753,12 +3753,12 @@ importers:
       expect-type:
         specifier: ^1.2.2
         version: 1.2.2
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   warp-drive-packages/react:
     dependencies:

--- a/warp-drive-packages/legacy/eslint.config.mjs
+++ b/warp-drive-packages/legacy/eslint.config.mjs
@@ -3,7 +3,7 @@ import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [

--- a/warp-drive-packages/legacy/package.json
+++ b/warp-drive-packages/legacy/package.json
@@ -13,11 +13,11 @@
     "directory": "warp-drive-packages/legacy"
   },
   "scripts": {
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "dist",
@@ -56,8 +56,8 @@
     "decorator-transforms": "^2.3.0",
     "ember-source": "~6.12.0",
     "expect-type": "^1.2.2",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/warp-drive-packages/legacy/tsdown.config.mjs
+++ b/warp-drive-packages/legacy/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 // FIXME audit this list
 export const externals = [
@@ -9,6 +9,7 @@ export const externals = [
   '@ember/object/mixin', // BuildURLMixin
   '@ember/object/observers',
   '@ember/application', // getOwner
+  '@ember/application/instance', // instance-initializer signature
   '@ember/object/computed',
   '@ember/object/internals',
   '@ember/object/promise-proxy-mixin',

--- a/warp-drive-packages/legacy/typedoc.config.mjs
+++ b/warp-drive-packages/legacy/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {


### PR DESCRIPTION
## Summary
- Continues the Vite/Rollup → rolldown migration (#10643) with `@warp-drive/legacy`, the largest package migrated so far (20 curated entry points spanning adapter/compat/model/serializer/store/model-fragments).
- Surfaced one gap in the (already "FIXME audit this list"-flagged) externals list: `src/model-fragments/instance-initializers/fragment-extensions.ts` imports `@ember/application/instance`, which was never in the externals array but built fine under the old Vite pipeline. rolldown's module-graph walk hit the shared `external()` guardrail's "neither a dependency nor a peerDependency" throw for it — added it alongside the adjacent `@ember/application` entry.

## Test plan
- [x] Full 20-entry build produces all expected `dist/*.js` + `declarations/*.d.ts`.
- [x] `tests/legacy`: `ember-tsc --noEmit` clean.
- [x] `tests/legacy` diagnostic suite: 129/129 pass, 0 failures (matching baseline) in both dev and production modes.
- [x] ESLint and Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)