### PR TITLE
fix: drop svelte's dead vite build step from build:pkg

### DIFF
--- a/warp-drive-packages/svelte/package.json
+++ b/warp-drive-packages/svelte/package.json
@@ -14,7 +14,7 @@
   "bugs": "https://github.com/warp-drive-data/warp-drive/issues",
   "keywords": [],
   "scripts": {
-    "build:pkg": "vite build && npm run prepack",
+    "build:pkg": "svelte-package",
     "prepack": "svelte-package",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",


### PR DESCRIPTION
## Summary
`@warp-drive/svelte`'s `build:pkg` ran `vite build && npm run prepack`. The vite step builds a full throwaway SvelteKit app server bundle into `.svelte-kit/output/` — unrelated to what's actually published. This package has no `svelte.config.js`/adapter, and its real packaging tool is `svelte-package` (already the separate `prepack` script), which compiles `src/lib` → `dist` directly without going through Vite/Rollup/rolldown at all. So there's no "vite → rolldown" migration applicable here (unlike the other framework packages in this series) — just dead work to remove.

`vite`/`@sveltejs/vite-plugin-svelte`/`@sveltejs/kit` devDependencies are left in place since `start` still uses them for local dev preview.

## Test plan
- [x] `dist/` output unchanged: `index.js`, `index.d.ts`, `install.svelte.js`, `install.svelte.d.ts`, matching the `exports` map.
- [x] `tests/framework-svelte`: `ember-tsc --noEmit` clean, diagnostic suite 1/1 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)