### PR TITLE
fix: ImageFetch.load() object url + move ImageWorker docs into published API page

### DIFF
--- a/warp-drive-packages/experiments/README.md
+++ b/warp-drive-packages/experiments/README.md
@@ -27,5 +27,5 @@
 
 - [DataWorker](./src/data-worker/README.md)
 - [DocumentStorage](./src/document-storage/README.md)
-- [ImageWorker](./src/image-worker/README.md)
+- [ImageWorker](./src/image-worker.md)
 - ReactiveStorage

--- a/warp-drive-packages/experiments/src/image-fetch.ts
+++ b/warp-drive-packages/experiments/src/image-fetch.ts
@@ -1,1 +1,5 @@
+/**
+ * {@include ./image-worker.md}
+ * @module
+ */
 export { ImageFetch } from './image-worker/fetch';

--- a/warp-drive-packages/experiments/src/image-worker.md
+++ b/warp-drive-packages/experiments/src/image-worker.md
@@ -1,20 +1,3 @@
-<p align="center">
-  <img
-    class="project-logo"
-    src="../../logos/warp-drive-logo-dark.svg#gh-light-mode-only"
-    alt="WarpDrive"
-    width="200px"
-    title="WarpDrive" />
-  <img
-    class="project-logo"
-    src="../../logos/warp-drive-logo-gold.svg#gh-dark-mode-only"
-    alt="WarpDrive"
-    width="200px"
-    title="WarpDrive" />
-</p>
-
-<h3 align="center">ImageWorker</h3>
-
 - Fetches images from a `Worker`/`SharedWorker` instead of the main thread
 - Caches and dedupes fetches for the same url within the worker
 - Shares fetched-image state cross-tab when using a `SharedWorker`
@@ -25,8 +8,6 @@
 ```sh
 pnpm add @warp-drive/experiments
 ```
-
-Or use your favorite javascript package manager.
 
 ## About
 

--- a/warp-drive-packages/experiments/src/image-worker.ts
+++ b/warp-drive-packages/experiments/src/image-worker.ts
@@ -1,1 +1,5 @@
+/**
+ * {@include ./image-worker.md}
+ * @module
+ */
 export { ImageWorker } from './image-worker/worker';

--- a/warp-drive-packages/experiments/src/image-worker/README.md
+++ b/warp-drive-packages/experiments/src/image-worker/README.md
@@ -72,6 +72,26 @@ import { ImageWorker } from '@warp-drive/experiments/image-worker';
 new ImageWorker();
 ```
 
+> [!TIP]
+> Your worker file is loaded via `new URL(...)`, not a static import, so bundlers
+> that statically analyze/prune app files need to be told to leave it alone.
+> With Embroider, add its containing directory to `staticAppPaths`; with Vite,
+> exclude it from dependency optimization:
+>
+> ```js
+> // ember-cli-build.js
+> return maybeEmbroider(app, {
+>   staticAppPaths: ['workers'],
+> });
+> ```
+>
+> ```js
+> // vite.config.mjs
+> optimizeDeps: {
+>   exclude: ['!workers*', '!*workers'],
+> },
+> ```
+
 ### Step 2. Use It From Your Application
 
 ```ts
@@ -86,6 +106,65 @@ await images.load('https://example.com/cat.png');
 > [!TIP]
 > SharedWorker and Worker are both supported; however, SharedWorker is preferred.
 > Worker is only usable in test environments.
+
+#### Usage as an Ember Service
+
+Registering `ImageFetch` as a service makes it easy to inject anywhere you
+need to load or preload an image, and to pair with
+[`getPromiseState`](https://docs.warp-drive.io/guides/the-manual/reactivity/derivation)
+from `@warp-drive/ember` to render its result reactively.
+
+```ts
+// app/services/images.ts
+import { ImageFetch } from '@warp-drive/experiments/image-fetch';
+
+export default {
+  create() {
+    return new ImageFetch(
+      new SharedWorker(new URL('../workers/image-worker.ts', import.meta.url), {
+        name: 'ImageWorker',
+        type: 'module',
+      }),
+    );
+  },
+};
+```
+
+```gts
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+import { cached } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { getPromiseState } from '@warp-drive/ember';
+import type { ImageFetch } from '@warp-drive/experiments/image-fetch';
+
+export default class Thumbnail extends Component<{ Args: { url: string; hiresUrl: string } }> {
+  @service declare images: ImageFetch;
+
+  // warm the worker's cache for the hires image before the user clicks into it
+  preload = () => this.images.load(this.args.hiresUrl);
+
+  @cached
+  get thumbnailUrl() {
+    const state = getPromiseState(this.images.load(this.args.url));
+    return state.isPending || state.isError ? null : state.result;
+  }
+
+  <template>
+    {{#if this.thumbnailUrl}}
+      <img src={{this.thumbnailUrl}} {{on 'pointerenter' this.preload}} alt='' />
+    {{else}}
+      <div class='thumbnail-loading'></div>
+    {{/if}}
+  </template>
+}
+```
+
+> [!NOTE]
+> Because of the limitation noted above, `thumbnailUrl` above resolves to the
+> original image url rather than a blob url — the `<img>` still benefits from
+> the worker's fetch deduplication and the browser's HTTP cache, just not from
+> an in-memory blob url.
 
 #### Usage in SSR
 
@@ -109,3 +188,10 @@ const worker = macroCondition(isTesting())
 
 const images = new ImageFetch(worker);
 ```
+
+## Example App
+
+[ember-polaris-pokedex](https://github.com/IgnaceMaes/ember-polaris-pokedex/pull/2)
+wires up `ImageWorker`/`ImageFetch` (alongside `DataWorker`) in a real Ember app,
+including the service + `getPromiseState` pattern shown above and the
+Embroider/Vite bundler config needed to ship the worker files.

--- a/warp-drive-packages/experiments/src/image-worker/README.md
+++ b/warp-drive-packages/experiments/src/image-worker/README.md
@@ -15,9 +15,9 @@
 
 <h3 align="center">ImageWorker</h3>
 
-- Caches Images for Reuse
-- Supports Preloading
-- Shares image-memory cross-tab
+- Fetches images from a `Worker`/`SharedWorker` instead of the main thread
+- Dedupes concurrent fetches for the same url within the worker
+- Shares fetched-image state cross-tab when using a `SharedWorker`
 
 ## Install
 
@@ -27,9 +27,85 @@ pnpm add @warp-drive/experiments
 
 Or use your favorite javascript package manager.
 
-## How It Works
+## About
 
-- The main thread requests the worker to either load or preload an image
-- the worker downloads the image if needed via `fetch`, putting the response into the browser's http cache
-- the worker generates a blob containing the image bytes
-- the worker returns an object url for the blob
+`ImageWorker` offloads image fetching to a dedicated `Worker` or `SharedWorker`.
+The worker downloads each requested url via `fetch` (letting the browser's
+normal HTTP cache do its job) and dedupes concurrent requests for the same url,
+so multiple tabs/windows sharing a `SharedWorker` never fetch the same image
+twice at once.
+
+`ImageFetch` is the main-thread client used to talk to an `ImageWorker`.
+Construct it with your `Worker`/`SharedWorker` instance and call `load(url)`
+to ask the worker to fetch that url.
+
+## Known Limitations
+
+This is an early experiment; the following gaps exist today:
+
+- `ImageFetch.load(url)` resolves with the original `url`, not an object url.
+  The worker does convert the fetched image into a `Blob` and create an object
+  url for it internally, but that object url is not currently surfaced back to
+  the caller — `load` is only useful today as a way to pre-warm a url through
+  the worker's fetch/dedupe logic, not to obtain a blob url for the image.
+- Calling `load` again for the same url while a prior call for that same url
+  is still in-flight on the same `ImageFetch` instance replaces the pending
+  request rather than joining it; only the most recently issued call resolves,
+  and the earlier call's promise never settles.
+- If the underlying `fetch` in the worker rejects, no response is sent back to
+  the requesting thread, so `load`'s returned promise hangs indefinitely
+  instead of rejecting.
+- `SharedWorker` is the intended target. A plain `Worker` is only accepted
+  when running in a `TESTING` build; using one outside of tests will fail an
+  assertion.
+- `ImageWorker`'s `persisted` constructor option is accepted but not yet
+  implemented.
+
+## Configure
+
+### Step 1. Create The Worker
+
+```ts
+// app/workers/image-worker.ts
+import { ImageWorker } from '@warp-drive/experiments/image-worker';
+
+new ImageWorker();
+```
+
+### Step 2. Use It From Your Application
+
+```ts
+import { ImageFetch } from '@warp-drive/experiments/image-fetch';
+
+const worker = new SharedWorker(new URL('./workers/image-worker.ts', import.meta.url));
+const images = new ImageFetch(worker);
+
+await images.load('https://example.com/cat.png');
+```
+
+> [!TIP]
+> SharedWorker and Worker are both supported; however, SharedWorker is preferred.
+> Worker is only usable in test environments.
+
+#### Usage in SSR
+
+In SSR, `ImageFetch` deactivates itself and resolves `load` with the given url
+immediately. When in SSR mode, the worker argument is allowed to be `null` to
+support guarding its creation.
+
+```ts
+const worker = isFastBoot ? null : new SharedWorker(new URL('./workers/image-worker.ts', import.meta.url));
+const images = new ImageFetch(worker);
+```
+
+#### Usage in Tests
+
+In tests, it's often best to use a `Worker` instead of a `SharedWorker`.
+
+```ts
+const worker = macroCondition(isTesting())
+  ? new Worker(new URL('./workers/image-worker.ts', import.meta.url))
+  : new SharedWorker(new URL('./workers/image-worker.ts', import.meta.url));
+
+const images = new ImageFetch(worker);
+```

--- a/warp-drive-packages/experiments/src/image-worker/README.md
+++ b/warp-drive-packages/experiments/src/image-worker/README.md
@@ -16,8 +16,9 @@
 <h3 align="center">ImageWorker</h3>
 
 - Fetches images from a `Worker`/`SharedWorker` instead of the main thread
-- Dedupes concurrent fetches for the same url within the worker
+- Caches and dedupes fetches for the same url within the worker
 - Shares fetched-image state cross-tab when using a `SharedWorker`
+- Resolves to a reusable object url for the fetched image's blob
 
 ## Install
 
@@ -30,24 +31,22 @@ Or use your favorite javascript package manager.
 ## About
 
 `ImageWorker` offloads image fetching to a dedicated `Worker` or `SharedWorker`.
-The worker downloads each requested url via `fetch` (letting the browser's
-normal HTTP cache do its job) and dedupes concurrent requests for the same url,
-so multiple tabs/windows sharing a `SharedWorker` never fetch the same image
-twice at once.
+The worker downloads each requested url via `fetch`, converts the response
+into a `Blob`, and creates an object url for it via `URL.createObjectURL`.
+That object url is cached in-memory by source url for the lifetime of the
+worker, so multiple tabs/windows sharing a `SharedWorker` — or repeat requests
+from the same tab — never fetch or decode the same image twice.
 
 `ImageFetch` is the main-thread client used to talk to an `ImageWorker`.
 Construct it with your `Worker`/`SharedWorker` instance and call `load(url)`
-to ask the worker to fetch that url.
+to get back an object url you can assign directly to an `<img src>`.
+`ImageFetch` also caches the resolved object url locally, so repeat calls for
+a url already loaded by this instance resolve without messaging the worker.
 
 ## Known Limitations
 
 This is an early experiment; the following gaps exist today:
 
-- `ImageFetch.load(url)` resolves with the original `url`, not an object url.
-  The worker does convert the fetched image into a `Blob` and create an object
-  url for it internally, but that object url is not currently surfaced back to
-  the caller — `load` is only useful today as a way to pre-warm a url through
-  the worker's fetch/dedupe logic, not to obtain a blob url for the image.
 - Calling `load` again for the same url while a prior call for that same url
   is still in-flight on the same `ImageFetch` instance replaces the pending
   request rather than joining it; only the most recently issued call resolves,
@@ -100,7 +99,11 @@ import { ImageFetch } from '@warp-drive/experiments/image-fetch';
 const worker = new SharedWorker(new URL('./workers/image-worker.ts', import.meta.url));
 const images = new ImageFetch(worker);
 
-await images.load('https://example.com/cat.png');
+const objectUrl = await images.load('https://example.com/cat.png');
+
+const img = document.createElement('img');
+img.src = objectUrl;
+document.body.appendChild(img);
 ```
 
 > [!TIP]
@@ -159,12 +162,6 @@ export default class Thumbnail extends Component<{ Args: { url: string; hiresUrl
   </template>
 }
 ```
-
-> [!NOTE]
-> Because of the limitation noted above, `thumbnailUrl` above resolves to the
-> original image url rather than a blob url — the `<img>` still benefits from
-> the worker's fetch deduplication and the browser's HTTP cache, just not from
-> an in-memory blob url.
 
 #### Usage in SSR
 

--- a/warp-drive-packages/experiments/src/image-worker/fetch.ts
+++ b/warp-drive-packages/experiments/src/image-worker/fetch.ts
@@ -4,6 +4,8 @@ import type { Deferred } from '@warp-drive/core/request';
 import { createDeferred } from '@warp-drive/core/request';
 
 import type { MainThreadEvent, RequestEventData } from './types';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { ImageWorker } from './worker';
 
 export interface FastBoot {
   require(moduleName: string): unknown;
@@ -14,6 +16,19 @@ export interface FastBoot {
 // @ts-expect-error untyped global
 const isServerEnv = typeof FastBoot !== 'undefined';
 
+/**
+ * Main-thread client for an {@link ImageWorker}. Sends image `load`
+ * requests to a `Worker` or `SharedWorker` running an `ImageWorker`.
+ *
+ * In FastBoot/SSR, or when constructed with a `null` worker, `ImageFetch`
+ * skips worker communication entirely: {@link ImageFetch.load} resolves
+ * immediately with the given url.
+ *
+ * A plain `Worker` is only accepted when running in a `TESTING` build;
+ * production usage requires a `SharedWorker`.
+ *
+ * @public
+ */
 export class ImageFetch {
   declare worker: Worker | SharedWorker;
   declare threadId: string;
@@ -21,6 +36,11 @@ export class ImageFetch {
   declare channel: MessageChannel;
   declare cache: Map<string, string>;
 
+  /**
+   * @param worker - the `Worker` or `SharedWorker` running an
+   * {@link ImageWorker}, or `null` to disable worker communication (e.g.
+   * in FastBoot/SSR).
+   */
   constructor(worker: Worker | SharedWorker | null) {
     this.threadId = isServerEnv ? '' : crypto.randomUUID();
     this.pending = new Map();
@@ -73,6 +93,18 @@ export class ImageFetch {
     this.worker instanceof SharedWorker ? this.worker.port.postMessage(event) : this.channel.port1.postMessage(event);
   }
 
+  /**
+   * Requests that the given image url be loaded by the connected
+   * {@link ImageWorker}, resolving with the same `url` once the worker
+   * confirms the image has been fetched (or immediately, in SSR/FastBoot
+   * or when this instance was constructed with a `null` worker).
+   *
+   * Calling `load` again for a url that is already in-flight on this
+   * instance replaces the pending request rather than joining it — only
+   * the most recently issued call for a given url will resolve.
+   *
+   * @public
+   */
   load(url: string): Promise<string> {
     if (isServerEnv) {
       return Promise.resolve(url);

--- a/warp-drive-packages/experiments/src/image-worker/fetch.ts
+++ b/warp-drive-packages/experiments/src/image-worker/fetch.ts
@@ -59,7 +59,9 @@ export class ImageFetch {
         }
 
         if (type === 'success-response') {
-          deferred.resolve(url);
+          const { objectUrl } = event.data;
+          this.cache.set(url, objectUrl);
+          deferred.resolve(objectUrl);
           return;
         }
 
@@ -95,13 +97,19 @@ export class ImageFetch {
 
   /**
    * Requests that the given image url be loaded by the connected
-   * {@link ImageWorker}, resolving with the same `url` once the worker
-   * confirms the image has been fetched (or immediately, in SSR/FastBoot
-   * or when this instance was constructed with a `null` worker).
+   * {@link ImageWorker}, resolving with an object url for the fetched
+   * image's blob once the worker responds (or immediately with the
+   * original `url`, in SSR/FastBoot or when this instance was constructed
+   * with a `null` worker).
    *
-   * Calling `load` again for a url that is already in-flight on this
-   * instance replaces the pending request rather than joining it — only
-   * the most recently issued call for a given url will resolve.
+   * The resolved object url is cached in-memory by source url on this
+   * instance, so subsequent calls for the same url resolve immediately
+   * without another round-trip to the worker.
+   *
+   * Calling `load` again for a url that is already in-flight (not yet
+   * cached) on this instance replaces the pending request rather than
+   * joining it — only the most recently issued call for a given url will
+   * resolve.
    *
    * @public
    */

--- a/warp-drive-packages/experiments/src/image-worker/types.ts
+++ b/warp-drive-packages/experiments/src/image-worker/types.ts
@@ -6,15 +6,15 @@ import type { ImageWorker } from './worker';
 /**
  * Sent by the {@link ImageWorker} once an image has finished loading.
  *
- * @remarks
- * The worker also attaches an `objectUrl` for the fetched image's blob to
- * this message, but {@link ImageFetch} does not currently read it — the
- * `url` field is used to resolve the pending `load` request instead.
+ * `objectUrl` is the url created via `URL.createObjectURL` for the fetched
+ * image's blob; {@link ImageFetch} resolves the pending `load` request with
+ * it.
  */
 export type SuccessResponseEventData = {
   type: 'success-response';
   thread: string;
   url: string;
+  objectUrl: string;
 };
 /**
  * Reserved for future use — the {@link ImageWorker} does not currently

--- a/warp-drive-packages/experiments/src/image-worker/types.ts
+++ b/warp-drive-packages/experiments/src/image-worker/types.ts
@@ -1,20 +1,40 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { ImageFetch } from './fetch';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { ImageWorker } from './worker';
+
+/**
+ * Sent by the {@link ImageWorker} once an image has finished loading.
+ *
+ * @remarks
+ * The worker also attaches an `objectUrl` for the fetched image's blob to
+ * this message, but {@link ImageFetch} does not currently read it — the
+ * `url` field is used to resolve the pending `load` request instead.
+ */
 export type SuccessResponseEventData = {
   type: 'success-response';
   thread: string;
   url: string;
 };
+/**
+ * Reserved for future use — the {@link ImageWorker} does not currently
+ * send this message. A failed image fetch instead leaves the requesting
+ * thread's `load` request pending indefinitely.
+ */
 export type ErrorResponseEventData = {
   type: 'error-response';
   thread: string;
   url: string;
 };
 
+/** Sent by {@link ImageFetch} to request that an image url be loaded. */
 export type RequestEventData = {
   type: 'load';
   thread: string;
   url: string;
 };
 
+/** Sent to register a thread's {@link MessagePort} with the {@link ImageWorker}. */
 export type ThreadInitEventData = {
   type: 'connect';
   thread: string;

--- a/warp-drive-packages/experiments/src/image-worker/worker.ts
+++ b/warp-drive-packages/experiments/src/image-worker/worker.ts
@@ -64,7 +64,10 @@ export class ImageWorker {
       return pending;
     }
 
-    const promise = loadImage(url);
+    const promise = loadImage(url).then((loadedObjectUrl) => {
+      this.cache.set(url, loadedObjectUrl);
+      return loadedObjectUrl;
+    });
     this.pendingImages.set(url, promise);
     return promise.finally(() => {
       this.pendingImages.delete(url);

--- a/warp-drive-packages/experiments/src/image-worker/worker.ts
+++ b/warp-drive-packages/experiments/src/image-worker/worker.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { ImageFetch } from './fetch';
 import type { RequestEventData, ThreadInitEventData, WorkerThreadEvent } from './types';
 
 const WorkerScope = (globalThis as unknown as { SharedWorkerGlobalScope: FunctionConstructor }).SharedWorkerGlobalScope;
@@ -8,6 +10,25 @@ async function loadImage(url: string): Promise<string> {
   return URL.createObjectURL(fileBlob);
 }
 
+/**
+ * Runs inside a `Worker` or `SharedWorker` to fetch images on behalf of
+ * one or more {@link ImageFetch} instances running on the main thread(s)
+ * that connect to it.
+ *
+ * Each connecting thread registers itself by sending a `connect` message
+ * along with a {@link MessagePort}. When a thread sends a `load` request
+ * for a url, the worker fetches the image via `fetch`, converts the
+ * response into a `Blob`, and creates an object url for it via
+ * `URL.createObjectURL`. The fetch for a given url is deduped and cached
+ * in-memory for the lifetime of the worker, so repeat `load` requests for
+ * the same url — whether from the same or a different connected thread —
+ * do not trigger another network request.
+ *
+ * Only intended for use inside a Worker context: constructing an
+ * `ImageWorker` on the main thread is a no-op.
+ *
+ * @public
+ */
 export class ImageWorker {
   declare private threads: Map<string, MessagePort>;
   declare private pendingImages: Map<string, Promise<string>>;
@@ -15,6 +36,9 @@ export class ImageWorker {
   declare private isSharedWorker: boolean;
   declare private cache: Map<string, string>;
 
+  /**
+   * @param options.persisted - reserved for a future on-disk cache; currently unused.
+   */
   constructor(options?: { persisted: boolean }) {
     // disable if running on main thread
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- **Fix:** `ImageFetch.load(url)` now resolves with the object url `ImageWorker` actually creates via `URL.createObjectURL`, instead of the original source `url`. `ImageWorker`'s own in-memory cache (previously declared but never written to) is now populated too, so sequential and cross-tab requests for an already-loaded url resolve from cache instead of re-fetching/re-decoding the image.
- **Docs content:** TSDoc on `ImageWorker`/`ImageFetch`/message types, plus an overview covering:
  - Bundler config (Embroider `staticAppPaths`, Vite `optimizeDeps.exclude`) needed to ship a worker file loaded via `new URL(...)`.
  - A plain example resolving `load()` into an `<img src>`.
  - An Ember service + `getPromiseState` usage pattern.
  - A link to a real app ([ember-polaris-pokedex#2](https://github.com/IgnaceMaes/ember-polaris-pokedex/pull/2)) using both.
- **Docs placement:** moved that overview from `src/image-worker/README.md` to `src/image-worker.md`, since package READMEs aren't picked up by the TypeDoc build (`readme: 'none'` for `@warp-drive/experiments`) and never reached the published docs site. It's now pulled into both the `image-worker` and `image-fetch` generated pages via a `{@include}` module doc comment, matching the sibling-markdown pattern `@warp-drive/react` already uses for `install.ts`/`install.md`.

The fix was motivated by the linked real app independently hitting the bug and shipping a hand-patched copy of `ImageFetch` to work around it — confirming it as a real gap, not just a theoretical one found by reading the source.

Remaining known limitations (documented, not fixed here): `load()` doesn't dedupe concurrent in-flight calls for the same url on one `ImageFetch` instance, and the worker never sends an `error-response` on a failed fetch (so a failed `load()` hangs rather than rejects).

## Test plan
- [x] `eslint` clean on all edited `.ts` files
- [x] `tsc --noEmit` clean on all edited `.ts` files
- [ ] Couldn't fully verify the `{@include}` renders via a local TypeDoc build — `typedoc-plugin-markdown` failed to resolve outside of `docs-viewer`'s own pnpm scope when invoked directly. The pattern mirrors `@warp-drive/react`'s working `install.ts`/`install.md`, but worth a sanity check against the real docs build.
- [ ] No automated test exists for this experimental module yet (none existed before this change either); happy to add one in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
