### PR TITLE
feat: migrate @ember-data/store's build to rolldown via tsdown

### DIFF
--- a/packages/store/eslint.config.mjs
+++ b/packages/store/eslint.config.mjs
@@ -3,7 +3,7 @@ import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 import * as js from '@warp-drive/internal-config/eslint/browser.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,10 +32,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "dependencies": {
     "@embroider/macros": "^1.20.6",
@@ -62,8 +62,8 @@
     "@ember/test-waiters": "^4.1.1",
     "@warp-drive/internal-config": "workspace:*",
     "ember-source": "~6.12.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/store/tsdown.config.mjs
+++ b/packages/store/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['@ember/debug'];
 export const entryPoints = ['./src/index.ts', './src/types.ts', './src/-private.ts', './src/configure.ts'];

--- a/packages/store/typedoc.config.mjs
+++ b/packages/store/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,12 +1100,12 @@ importers:
       ember-source:
         specifier: ~6.12.0
         version: 6.12.0
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/tracking:
     dependencies:
@@ -20413,16 +20413,10 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `@ember-data/store`'s build from vite/rollup to tsdown (rolldown-based), continuing the migration already completed across all `warp-drive-packages/*` and several `packages/*` packages.
- Renames `vite.config.mjs` to `tsdown.config.mjs`, switching the import to `@warp-drive/internal-config/tsdown/config.js` (same `entryPoints`/`externals`).
- Updates `package.json`: `build:pkg` → `tsdown`, `start` → `tsdown --watch`, replaces `vite` devDependency with `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs` and `eslint.config.mjs` to import from `tsdown.config.mjs` instead of `vite.config.mjs`.

## Test plan
- [x] `pnpm install` (full workspace install)
- [x] `pnpm --filter @ember-data/store run build:pkg` succeeds, producing the same `dist/*.js` + `unstable-preview-types/*.d.ts` shape as before
- [x] Rebuilt dependent `packages/-ember-data` (`ember-data` package) via its existing vite build — unaffected
- [x] `pnpm exec ember-tsc --noEmit` in `tests/ember-data__model` — no errors
- [x] `pnpm run test` in `tests/ember-data__model` — 2/2 passing
- [x] `pnpm exec eslint . --quiet` in `packages/store` — clean
- [x] `pnpm exec prettier --check` on changed files — clean