### PR TITLE
feat: migrate @warp-drive/holodeck's build to rolldown via tsdown

### DIFF
--- a/packages/holodeck/package.json
+++ b/packages/holodeck/package.json
@@ -40,11 +40,11 @@
   },
   "scripts": {
     "check:pkg-types": "tsc --noEmit",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "peerDependencies": {
     "@warp-drive/utilities": "workspace:*",
@@ -69,7 +69,7 @@
     "@warp-drive/legacy": "workspace:*",
     "@warp-drive/core": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "exports": {
     ".": {

--- a/packages/holodeck/tsdown.config.mjs
+++ b/packages/holodeck/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['./src/index.ts', './src/mock.ts'];
@@ -7,7 +7,6 @@ export default createConfig(
   {
     entryPoints,
     externals,
-    fixModule: false,
   },
   import.meta.resolve
 );

--- a/packages/holodeck/typedoc.config.mjs
+++ b/packages/holodeck/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,9 +755,9 @@ importers:
       '@warp-drive/utilities':
         specifier: workspace:*
         version: file:warp-drive-packages/utilities(ac1631a7da983377f84b100525d730a6)
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14
 
   packages/json-api:
     dependencies:
@@ -29175,6 +29175,18 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.3):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.3
+      yuku-ast: 0.8.4
+      yuku-codegen: 0.8.4
+      yuku-parser: 0.8.4
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.27.14(rolldown@1.2.3)(typescript@5.9.2):
     dependencies:
       dts-resolver: 3.0.0
@@ -30487,6 +30499,29 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.22.14:
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
 
   tsdown@0.22.14(2d08bf30f09f74acf5c22716525a3b86):
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `packages/holodeck` (`@warp-drive/holodeck`) from vite/rollup to `tsdown` (rolldown-based), continuing the tsdown migration series already completed across `warp-drive-packages/*` and other `packages/*`.
- Replaced `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; same `entryPoints`/`externals` carried over unchanged.
- Dropped the vite-only `fixModule: false` option — tsdown always emits `.js` and doesn't have the extension resolution problem that option worked around.
- Updated `typedoc.config.mjs` to import `entryPoints` from the new config file.
- `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, `vite` devDependency swapped for `tsdown@^0.22.14` (matching the version already used elsewhere in the repo).

## Test plan
- [x] Full `pnpm install` succeeds
- [x] `pnpm --filter @warp-drive/holodeck run build:pkg` succeeds, producing the same `dist/*.js` + `declarations/*.d.ts` shape as before (`index`/`mock`)
- [x] No other `packages/*` depend on holodeck via `workspace:*`
- [x] `pnpm exec ember-tsc --noEmit` passes in `tests/core`, `tests/json-api`, `tests/legacy` (the test suites that most directly exercise holodeck's mock HTTP server)
- [x] Full test suites pass with 0 failures: `tests/core` (187 pass / 2 skip), `tests/json-api` (82 pass / 6 todo), `tests/legacy` (132 pass / 1 skip / 2 todo)
- [x] `eslint . --quiet` clean in `packages/holodeck`
- [x] `prettier --check` clean on changed files