### PR TITLE
feat: migrate @ember-data/debug's build to rolldown via tsdown

### DIFF
--- a/packages/debug/eslint.config.mjs
+++ b/packages/debug/eslint.config.mjs
@@ -2,7 +2,7 @@
 import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -15,10 +15,10 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "unstable-preview-types",
@@ -53,8 +53,8 @@
     "@warp-drive/internal-config": "workspace:*",
     "decorator-transforms": "^2.3.0",
     "ember-source": "~6.12.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/debug/tsdown.config.mjs
+++ b/packages/debug/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@ember-data/debug/data-adapter',

--- a/packages/debug/typedoc.config.mjs
+++ b/packages/debug/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,12 +568,12 @@ importers:
       ember-source:
         specifier: ~6.12.0
         version: 6.12.0
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/diagnostic:
     dependencies:
@@ -20442,9 +20442,6 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/eslint-scope@3.7.7':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `packages/debug` (`@ember-data/debug`) from vite/rollup to tsdown (rolldown-based), following the same pattern already applied across `warp-drive-packages/*`.
- Renamed `vite.config.mjs` → `tsdown.config.mjs`, now importing `createConfig` from `@warp-drive/internal-config/tsdown/config.js`. `entryPoints`/`externals` are unchanged.
- Updated `typedoc.config.mjs` and `eslint.config.mjs` to import from the new `tsdown.config.mjs`.
- `package.json`: `build:pkg` is now `tsdown`, `start` is now `tsdown --watch`, and `vite` devDependency is swapped for `tsdown@^0.22.14`.

## Test plan
- [x] `pnpm install` (full, non-filtered)
- [x] `pnpm --filter @ember-data/debug run build:pkg` succeeds; verified `dist/*.js` + `unstable-preview-types/*.d.ts` output shape matches the previous vite build, including the plain-JS `./src/_app_/data-adapter.js` entry
- [x] Rebuilt the dependent `ember-data` meta-package (`packages/-ember-data`) successfully
- [x] `pnpm exec ember-tsc --noEmit` passes in `tests/ember-data__adapter` and `tests/utilities`
- [x] `tests/ember-data__adapter` full diagnostic test suite passes (52/52)
- [x] `eslint . --quiet` and `prettier --check` pass on changed files