### PR TITLE
feat: migrate @ember-data/rest's build to rolldown via tsdown

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -39,10 +39,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -55,7 +55,7 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "ember": {
     "edition": "octane"

--- a/packages/rest/tsdown.config.mjs
+++ b/packages/rest/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['src/request.ts'];

--- a/packages/rest/typedoc.config.mjs
+++ b/packages/rest/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,9 +980,9 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14
 
   packages/schema:
     devDependencies:
@@ -29175,6 +29175,18 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.3):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.3
+      yuku-ast: 0.8.4
+      yuku-codegen: 0.8.4
+      yuku-parser: 0.8.4
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.27.14(rolldown@1.2.3)(typescript@5.9.2):
     dependencies:
       dts-resolver: 3.0.0
@@ -30487,6 +30499,29 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.22.14:
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
 
   tsdown@0.22.14(2d08bf30f09f74acf5c22716525a3b86):
     dependencies:


### PR DESCRIPTION
## Summary
- Continues the tsdown (rolldown) build migration already completed across `warp-drive-packages/*`, now applied to `@ember-data/rest` in the legacy `packages/*` tree.
- Replaces `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; `entryPoints`/`externals` are unchanged.
- Updates `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, `vite` devDependency swapped for `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs` to import `entryPoints` from `tsdown.config.mjs`.

## Test plan
- [x] Full `pnpm install` succeeds
- [x] `pnpm --filter @ember-data/rest run build:pkg` succeeds, producing `dist/request.js` + `unstable-preview-types/request.d.ts` (same shape as before)
- [x] No other `packages/*` depend on `@ember-data/rest` via `workspace:*`
- [x] `tests/utilities` (the only test package depending on `@ember-data/rest`): `pnpm exec ember-tsc --noEmit` passes with no errors
- [x] `tests/utilities` `pnpm run test` passes (75/75)
- [x] `eslint . --quiet` clean in `packages/rest`
- [x] `prettier --check` clean on changed files