### PR TITLE
feat: migrate @ember-data/legacy-compat's build to rolldown via tsdown

### DIFF
--- a/packages/legacy-compat/package.json
+++ b/packages/legacy-compat/package.json
@@ -37,10 +37,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -59,8 +59,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "ember": {
     "edition": "octane"

--- a/packages/legacy-compat/tsdown.config.mjs
+++ b/packages/legacy-compat/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['src/index.ts', 'src/builders.ts', 'src/-private.ts', 'src/utils.ts'];

--- a/packages/legacy-compat/typedoc.config.mjs
+++ b/packages/legacy-compat/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -826,12 +826,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/model:
     dependencies:
@@ -20413,9 +20413,6 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
@@ -20442,9 +20439,6 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/eslint-scope@3.7.7':
     dependencies:


### PR DESCRIPTION
## Summary
- Continues the tsdown (rolldown-based) build migration already completed for all `warp-drive-packages/*` packages, now applied to `@ember-data/legacy-compat`.
- Replaces `vite.config.mjs` with `tsdown.config.mjs`, using the shared `@warp-drive/internal-config/tsdown/config.js` helper with the same `entryPoints`/`externals` unchanged.
- Updates `package.json`: `build:pkg` -> `tsdown`, `start` -> `tsdown --watch`, devDependencies swap `vite` for `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs`'s import of `entryPoints` from `./vite.config.mjs` to `./tsdown.config.mjs`.
- No tsconfig changes needed (`isolatedDeclarations`/`isolatedModules` already enabled).

## Test plan
- [x] `pnpm install` (full, non-filtered)
- [x] `pnpm --filter @ember-data/legacy-compat run build:pkg` succeeds, producing the same `dist/*.js` + `unstable-preview-types/*.d.ts` shape as before
- [x] Rebuilt dependent `ember-data` (packages/-ember-data) via `build:pkg` — succeeds
- [x] `tests/ember-data__model`: `check:types` (tsc --noEmit), `build:tests`, `test` — all pass (2/2)
- [x] `tests/ember-data__adapter`: `check:types` (tsc --noEmit), `build:tests`, `test` — all pass (52/52)
- [x] `pnpm exec eslint . --quiet` in packages/legacy-compat — clean
- [x] `pnpm exec prettier --check` on changed files — clean