### PR TITLE
feat: migrate @ember-data/model's build to rolldown via tsdown

### DIFF
--- a/packages/model/eslint.config.mjs
+++ b/packages/model/eslint.config.mjs
@@ -3,7 +3,7 @@ import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -15,10 +15,10 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -64,8 +64,8 @@
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
     "expect-type": "^1.2.2",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/model/tsdown.config.mjs
+++ b/packages/model/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['src/index.ts', 'src/-private.ts', 'src/hooks.ts', 'src/migration-support.ts'];

--- a/packages/model/typedoc.config.mjs
+++ b/packages/model/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -878,12 +878,12 @@ importers:
       expect-type:
         specifier: ^1.2.2
         version: 1.2.2
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/request:
     dependencies:
@@ -20413,9 +20413,6 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `@ember-data/model`'s build from vite/rollup to tsdown (rolldown-based), continuing the migration already completed across all `warp-drive-packages/*` and several `packages/*` packages.
- Renames `vite.config.mjs` to `tsdown.config.mjs`, switching the import to `@warp-drive/internal-config/tsdown/config.js` (same `entryPoints`/`externals`).
- Updates `package.json`: `build:pkg` → `tsdown`, `start` → `tsdown --watch`, replaces `vite` devDependency with `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs` and `eslint.config.mjs` to import from `tsdown.config.mjs` instead of `vite.config.mjs`.

## Test plan
- [x] `pnpm install` (full workspace install)
- [x] `pnpm --filter @ember-data/model run build:pkg` succeeds, producing the same `dist/*.js` + `unstable-preview-types/*.d.ts` shape as before
- [x] Rebuilt dependent `packages/-ember-data` (`ember-data` package) via its existing vite build — unaffected
- [x] `pnpm exec ember-tsc --noEmit` in `tests/ember-data__model` and `tests/ember-data__adapter` — no errors
- [x] `pnpm run test` in `tests/ember-data__model` (2/2 passing) and `tests/ember-data__adapter` (52/52 passing)
- [x] `pnpm exec eslint . --quiet` in `packages/model` — clean
- [x] `pnpm exec prettier --check` on changed files — clean