### PR TITLE
feat: migrate @ember-data/tracking's build to rolldown via tsdown

### DIFF
--- a/packages/tracking/eslint.config.mjs
+++ b/packages/tracking/eslint.config.mjs
@@ -2,7 +2,7 @@
 import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -42,10 +42,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -65,8 +65,8 @@
     "@ember/test-waiters": "^4.1.1",
     "@warp-drive/internal-config": "workspace:*",
     "ember-source": "~6.12.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "ember": {
     "edition": "octane"

--- a/packages/tracking/tsdown.config.mjs
+++ b/packages/tracking/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@glimmer/validator',

--- a/packages/tracking/typedoc.config.mjs
+++ b/packages/tracking/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1137,12 +1137,12 @@ importers:
       ember-source:
         specifier: ~6.12.0
         version: 6.12.0
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/unpublished-eslint-rules: {}
 
@@ -20375,9 +20375,6 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20413,16 +20410,10 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -20442,9 +20433,6 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/eslint-scope@3.7.7':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `@ember-data/tracking`'s build from vite/rollup to tsdown (rolldown-based), continuing the migration already completed for all of `warp-drive-packages/*`.
- Replaces `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; `entryPoints`/`externals` are unchanged.
- Updates `package.json`: `build:pkg` -> `tsdown`, `start` -> `tsdown --watch`, removes `vite` devDependency, adds `tsdown@^0.22.14` (matching the version already used across `warp-drive-packages/*`).
- Repoints `typedoc.config.mjs` and `eslint.config.mjs` imports from `./vite.config.mjs` to `./tsdown.config.mjs`.

## Test plan
- [x] `pnpm install` (full workspace install)
- [x] `pnpm --filter @ember-data/tracking run build:pkg` succeeds, producing the same `dist/index.js` + `unstable-preview-types/index.d.ts` shape as before
- [x] Rebuilt in-tree dependents that consume `@ember-data/tracking` via `workspace:*`: `@ember-data/store` and `ember-data` (`packages/-ember-data`) both build successfully
- [x] `pnpm --filter ember-data__model run check:types` (tsc --noEmit) passes
- [x] `pnpm --filter ember-data__model run build:tests && run test` — 2/2 tests pass
- [x] `pnpm --filter @warp-drive/legacy-tests run check:types` (ember-tsc --noEmit) passes
- [x] `pnpm --filter @warp-drive/legacy-tests run build:tests && run test` — 132 pass, 1 skip, 2 todo, 0 fail
- [x] `eslint . --quiet` in `packages/tracking` clean
- [x] `prettier --check` on changed files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)