### PR TITLE
feat: migrate @ember-data/graph's build to rolldown via tsdown

### DIFF
--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -14,10 +14,10 @@
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "unstable-preview-types",
@@ -47,8 +47,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/graph/tsdown.config.mjs
+++ b/packages/graph/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 

--- a/packages/graph/typedoc.config.mjs
+++ b/packages/graph/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,12 +709,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/holodeck:
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `packages/graph` (`@ember-data/graph`) from vite/rollup to tsdown (rolldown-based), following the same pattern already applied across `warp-drive-packages/*` and `@ember-data/debug`.
- Renamed `vite.config.mjs` → `tsdown.config.mjs`, now importing `createConfig` from `@warp-drive/internal-config/tsdown/config.js`. The single `entryPoints` (`./src/-private.ts`) and empty `externals` are unchanged.
- Updated `typedoc.config.mjs` to import from the new `tsdown.config.mjs`.
- `package.json`: `build:pkg` is now `tsdown`, `start` is now `tsdown --watch`, and `vite` devDependency is swapped for `tsdown@^0.22.14`.

## Test plan
- [x] `pnpm install` (full, non-filtered)
- [x] `pnpm --filter @ember-data/graph run build:pkg` succeeds; verified `dist/-private.js` + `unstable-preview-types/-private.d.ts` output shape matches the previous vite build
- [x] Rebuilt the dependent `ember-data` meta-package (`packages/-ember-data`) successfully
- [x] `pnpm exec ember-tsc --noEmit` passes in `tests/ember-data__graph` and `tests/ember-data__model`
- [x] `tests/ember-data__graph` full diagnostic test suite passes (143/143)
- [x] `eslint . --quiet` and `prettier --check` pass on changed files