### PR TITLE
feat: migrate @ember-data/active-record's build to rolldown via tsdown

### DIFF
--- a/packages/active-record/package.json
+++ b/packages/active-record/package.json
@@ -31,10 +31,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -52,7 +52,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "ember": {
     "edition": "octane"

--- a/packages/active-record/tsdown.config.mjs
+++ b/packages/active-record/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 export const entryPoints = ['./src/request.ts', './src/index.ts'];

--- a/packages/active-record/typedoc.config.mjs
+++ b/packages/active-record/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,12 +396,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/adapter:
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `packages/active-record` (`@ember-data/active-record`) from vite/rollup to `tsdown` (rolldown-based), continuing the tsdown migration series already completed across `warp-drive-packages/*` and other `packages/*`.
- Replaced `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; same `entryPoints`/`externals` carried over unchanged.
- Updated `typedoc.config.mjs` to import `entryPoints` from the new config file.
- `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, `vite` devDependency swapped for `tsdown@^0.22.14` (matching the version already used elsewhere in the repo).

## Test plan
- [x] Full `pnpm install` succeeds
- [x] `pnpm --filter @ember-data/active-record run build:pkg` succeeds, producing the same shape as before: `dist/{index,request}.js` + `unstable-preview-types/{index,request}.d.ts` (declarations dir matches `declarationDir` in `tsconfig.json`, unaffected by this change)
- [x] No other `packages/*` depend on active-record via `workspace:*`; `tests/utilities` is the only consumer
- [x] `pnpm exec ember-tsc --noEmit` passes in `tests/utilities`
- [x] Full test suites pass with 0 failures: `tests/utilities` `test` (75/75) and `test:production` (75/75)
- [x] `eslint . --quiet` clean in `packages/active-record`
- [x] `prettier --check` clean on changed files