### PR TITLE
feat: migrate @ember-data/request's build to rolldown via tsdown

### DIFF
--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -16,10 +16,10 @@
   ],
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "unstable-preview-types",
@@ -49,7 +49,7 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/request/tsdown.config.mjs
+++ b/packages/request/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['@ember/test-waiters'];
 export const entryPoints = ['src/index.ts', 'src/fetch.ts'];

--- a/packages/request/typedoc.config.mjs
+++ b/packages/request/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -909,9 +909,9 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14
 
   packages/request-utils:
     dependencies:
@@ -20367,9 +20367,6 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
@@ -20413,16 +20410,10 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -29175,6 +29166,18 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.3):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.3
+      yuku-ast: 0.8.4
+      yuku-codegen: 0.8.4
+      yuku-parser: 0.8.4
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.27.14(rolldown@1.2.3)(typescript@5.9.2):
     dependencies:
       dts-resolver: 3.0.0
@@ -30487,6 +30490,29 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.22.14:
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
 
   tsdown@0.22.14(2d08bf30f09f74acf5c22716525a3b86):
     dependencies:


### PR DESCRIPTION
## Summary
- Continues the tsdown (rolldown-based) build migration already completed for all `warp-drive-packages/*` packages, now applied to `@ember-data/request`.
- Replaces `vite.config.mjs` with `tsdown.config.mjs`, using the shared `@warp-drive/internal-config/tsdown/config.js` helper with the same `entryPoints`/`externals` unchanged.
- Updates `package.json`: `build:pkg` -> `tsdown`, `start` -> `tsdown --watch`, devDependencies swap `vite` for `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs`'s import of `entryPoints` from `./vite.config.mjs` to `./tsdown.config.mjs`.
- No tsconfig changes needed (`isolatedDeclarations`/`isolatedModules` already enabled).

## Test plan
- [x] `pnpm install` (full, non-filtered)
- [x] `pnpm --filter @ember-data/request run build:pkg` succeeds, producing the same `dist/*.js` + `unstable-preview-types/*.d.ts` shape as before
- [x] Rebuilt dependent `ember-data` (packages/-ember-data) via `build:pkg` — succeeds
- [x] `tests/ember-data__request`: `check:types` (tsc --noEmit), `build:tests`, `test` — all pass (63/63)
- [x] `tests/ember-data__model`: `check:types` (tsc --noEmit), `build:tests`, `test` — all pass (2/2)
- [x] `pnpm exec eslint . --quiet` in packages/request — clean
- [x] `pnpm exec prettier --check` on changed files — clean