### PR TITLE
feat: migrate @ember-data/json-api's build to rolldown via tsdown

### DIFF
--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -14,10 +14,10 @@
   "author": "",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -55,7 +55,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
     "expect-type": "^1.2.2",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "ember": {
     "edition": "octane"

--- a/packages/json-api/tsdown.config.mjs
+++ b/packages/json-api/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 

--- a/packages/json-api/typedoc.config.mjs
+++ b/packages/json-api/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,9 +792,9 @@ importers:
       expect-type:
         specifier: ^1.2.2
         version: 1.2.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14
 
   packages/legacy-compat:
     dependencies:
@@ -29175,6 +29175,18 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.3):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.3
+      yuku-ast: 0.8.4
+      yuku-codegen: 0.8.4
+      yuku-parser: 0.8.4
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.27.14(rolldown@1.2.3)(typescript@5.9.2):
     dependencies:
       dts-resolver: 3.0.0
@@ -30487,6 +30499,29 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.22.14:
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
 
   tsdown@0.22.14(2d08bf30f09f74acf5c22716525a3b86):
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `packages/json-api` (`@ember-data/json-api` — the older, still-published legacy JSON:API cache package, NOT `@warp-drive/json-api` in `warp-drive-packages/json-api`, which was already migrated separately) from vite/rollup to tsdown (rolldown-based).
- Renamed `vite.config.mjs` → `tsdown.config.mjs`, now importing `createConfig` from `@warp-drive/internal-config/tsdown/config.js`. `entryPoints` (`./src/index.ts`, `./src/request.ts`) and empty `externals` are unchanged.
- Updated `typedoc.config.mjs` to import from the new `tsdown.config.mjs`.
- `package.json`: `build:pkg` is now `tsdown`, `start` is now `tsdown --watch`, and `vite` devDependency is swapped for `tsdown@^0.22.14`.

## Test plan
- [x] `pnpm install` (full, non-filtered)
- [x] `pnpm --filter @ember-data/json-api run build:pkg` succeeds; verified `dist/*.js` + `unstable-preview-types/*.d.ts` output shape matches the previous vite build
- [x] Rebuilt the dependent `ember-data` meta-package (`packages/-ember-data`) successfully
- [x] `pnpm exec ember-tsc --noEmit` passes in `tests/ember-data__adapter` and `tests/ember-data__model`
- [x] `tests/ember-data__adapter` (52/52) and `tests/ember-data__model` (2/2) diagnostic test suites pass
- [x] `eslint . --quiet` and `prettier --check` pass on changed files