### PR TITLE
feat: migrate @ember-data/core-types's build to rolldown via tsdown

### DIFF
--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -14,10 +14,10 @@
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "files": [
     "dist",
@@ -46,8 +46,8 @@
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/core-types/tsdown.config.mjs
+++ b/packages/core-types/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 

--- a/packages/core-types/typedoc.config.mjs
+++ b/packages/core-types/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,12 +525,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/debug:
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `@warp-drive/core-types`'s (packages/core-types) build from vite/rollup to tsdown (rolldown-based), continuing the migration already completed across all `warp-drive-packages/*` and several `packages/*` packages.
- Renames `vite.config.mjs` to `tsdown.config.mjs`, switching the import to `@warp-drive/internal-config/tsdown/config.js` (same `entryPoints`/`externals`).
- Updates `package.json`: `build:pkg` → `tsdown`, `start` → `tsdown --watch`, replaces `vite` devDependency with `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs` (which imported `entryPoints` from `vite.config.mjs`) to import from `tsdown.config.mjs` instead.

## Test plan
- [x] `pnpm install` (full workspace install)
- [x] `pnpm --filter @warp-drive/core-types run build:pkg` succeeds, producing the same `dist/*.js` + `unstable-preview-types/*.d.ts` shape as before
- [x] Rebuilt dependent `packages/-ember-data` (`ember-data` package) via its existing vite build — unaffected
- [x] `pnpm exec ember-tsc --noEmit` in `tests/ember-data__model`, `tests/ember-data__adapter`, `tests/ember-data__request` — no errors
- [x] `pnpm run test` in `tests/ember-data__model` (2/2), `tests/ember-data__adapter` (52/52), `tests/ember-data__request` (63/63) — all passing
- [x] `pnpm exec eslint . --quiet` in `packages/core-types` — clean
- [x] `pnpm exec prettier --check` on changed files — clean