### PR TITLE
feat: migrate @warp-drive/schema-record's build to rolldown via tsdown

### DIFF
--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -14,10 +14,10 @@
   "author": "",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -52,7 +52,7 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "ember": {
     "edition": "octane"

--- a/packages/schema-record/tsdown.config.mjs
+++ b/packages/schema-record/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [];
 

--- a/packages/schema-record/typedoc.config.mjs
+++ b/packages/schema-record/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,9 +1014,9 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14
 
   packages/serializer:
     dependencies:
@@ -20413,16 +20413,10 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -29175,6 +29169,18 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.3):
+    dependencies:
+      dts-resolver: 3.0.0
+      get-tsconfig: 5.0.0-beta.5
+      obug: 2.1.4
+      rolldown: 1.2.3
+      yuku-ast: 0.8.4
+      yuku-codegen: 0.8.4
+      yuku-parser: 0.8.4
+    transitivePeerDependencies:
+      - oxc-resolver
+
   rolldown-plugin-dts@0.27.14(rolldown@1.2.3)(typescript@5.9.2):
     dependencies:
       dts-resolver: 3.0.0
@@ -30487,6 +30493,29 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsdown@0.22.14:
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
 
   tsdown@0.22.14(2d08bf30f09f74acf5c22716525a3b86):
     dependencies:


### PR DESCRIPTION
## Summary
- Continues the tsdown (rolldown) build migration already completed across `warp-drive-packages/*`, now applied to `@warp-drive/schema-record` in the legacy `packages/*` tree.
- Replaces `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; `entryPoints`/`externals` are unchanged.
- Updates `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, `vite` devDependency swapped for `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs` to import `entryPoints` from `tsdown.config.mjs`.

## Test plan
- [x] Full `pnpm install` succeeds
- [x] `pnpm --filter @warp-drive/schema-record run build:pkg` succeeds, producing `dist/index.js` + `dist/-private.js` and matching `.d.ts` files in `unstable-preview-types` (same shape as before)
- [x] No other `packages/*` depend on `@warp-drive/schema-record` via `workspace:*`
- [x] `tests/dont-write-new-tests-here`: `pnpm exec ember-tsc --noEmit` passes; `pnpm run test` passes (5344/5349, 5 pre-existing skips); `pnpm run test:production` passes (5189/5349, pre-existing skips)
- [x] `tests/experiments`: `pnpm exec ember-tsc --noEmit` passes; `pnpm run test` passes (8/8); `pnpm run test:production` passes (8/8)
- [x] `eslint . --quiet` clean in `packages/schema-record`
- [x] `prettier --check` clean on changed files