### PR TITLE
feat: migrate @warp-drive/diagnostic's build to rolldown via tsdown

### DIFF
--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -68,10 +68,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "build:tests": "rm -rf dist-test && cp -R test dist-test && mkdir -p dist-test/@warp-drive && cp -R dist dist-test/@warp-drive/diagnostic",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "peerDependencies": {
     "@ember/test-helpers": "5.2.0",
@@ -118,8 +118,8 @@
     "bun-types": "^1.4.0",
     "ember-cli-test-loader": "^3.1.0",
     "ember-source": "~6.12.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "build:tests": "rm -rf dist-test && cp -R test dist-test && mkdir -p dist-test/@warp-drive && cp -R dist dist-test/@warp-drive/diagnostic",
-    "build:pkg": "tsdown",
+    "build:pkg": "NODE_ENV=production tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "start": "tsdown --watch"

--- a/packages/diagnostic/src/-types.ts
+++ b/packages/diagnostic/src/-types.ts
@@ -1,3 +1,5 @@
+import type { Assert } from 'qunit-dom';
+
 import type { SuiteReport } from './-types/report';
 
 export type CompatTestReport = {
@@ -79,6 +81,15 @@ export type GlobalConfig<TC extends TestContext = TestContext> = {
 };
 
 export interface Diagnostic {
+  /**
+   * DOM assertion helpers from `qunit-dom`. Declared here (rather than via
+   * per-entry-point `declare module` augmentation, as `ember.ts`/`react.tsx`/
+   * `spec.ts` each used to do identically) because rolldown-plugin-dts's
+   * entry-based declaration bundling doesn't reliably preserve relative-path
+   * `declare module` augmentations once the augmented module is shared across
+   * 2+ curated entry points.
+   */
+  dom: Assert['dom'];
   equal<T>(actual: T, expected: T, message?: string): void;
   notEqual<T>(actual: T, expected: T, message?: string): void;
   deepEqual<T>(actual: T, expected: T, message?: string): void;

--- a/packages/diagnostic/src/ember.ts
+++ b/packages/diagnostic/src/ember.ts
@@ -11,7 +11,7 @@ import {
 } from '@ember/test-helpers';
 import type { Owner } from '@ember/test-helpers/build-owner';
 
-import { type Assert as DomAssert, setup } from 'qunit-dom';
+import { setup } from 'qunit-dom';
 
 import { module as _module, skip as _skip, test as _test, todo as _todo } from './-define';
 import isComponent from './-ember/is-component';
@@ -113,12 +113,6 @@ function upgradeContext(context: TestContext): asserts context is RenderingTestC
 }
 
 function upgradeOwner(owner: Owner): asserts owner is FullOwner {}
-
-declare module './-types' {
-  interface Diagnostic {
-    dom: DomAssert['dom'];
-  }
-}
 
 export function setupRenderingTest<TC extends TestContext>(hooks: Hooks<TC>, options: SetupContextOptions = {}): void {
   const _options = { waitForSettled: false, ...options } as unknown as SetupContextOptions & {

--- a/packages/diagnostic/src/react.tsx
+++ b/packages/diagnostic/src/react.tsx
@@ -57,12 +57,6 @@ export interface SetupContextOptions {
   strictMode?: boolean;
 }
 
-declare module "./-types" {
-  interface Diagnostic {
-    dom: Assert["dom"];
-  }
-}
-
 // we do not use act because React incorrectly thinks updates can only come from internal
 // to itself when using it. TL;DR react never expects to be embedded or for external
 // reactive updates to occur.

--- a/packages/diagnostic/src/spec.ts
+++ b/packages/diagnostic/src/spec.ts
@@ -1,14 +1,6 @@
-import type { Assert } from 'qunit-dom';
-
 import { module, skip, test, todo } from './-define';
 import type { Diagnostic as TestAssert, Hooks, TestContext } from './-types';
 import type { TestHelpers } from './helpers/install';
-
-declare module './-types' {
-  interface Diagnostic {
-    dom: Assert['dom'];
-  }
-}
 
 /**
  * Supported Frameworks for Spec Tests

--- a/packages/diagnostic/tsdown.config.mjs
+++ b/packages/diagnostic/tsdown.config.mjs
@@ -1,5 +1,5 @@
-import { keepAssets } from '@warp-drive/internal-config/vite/keep-assets';
-import { createConfig } from '@warp-drive/internal-config/vite/config';
+import { keepAssets } from '@warp-drive/internal-config/tsdown/keep-assets.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@ember/runloop',
@@ -25,6 +25,7 @@ export default createConfig(
   {
     entryPoints,
     externals,
+    jsx: true,
     plugins: [keepAssets({ from: 'src', include: ['./styles/**/*.css'], dist: 'dist' })],
   },
   import.meta.resolve

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -644,12 +644,12 @@ importers:
       ember-source:
         specifier: ~6.12.0
         version: 6.12.0(@glimmer/component@2.0.0)
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/eslint-plugin-warp-drive:
     dependencies:
@@ -20393,9 +20393,6 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
@@ -20439,9 +20436,6 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:

--- a/tools/internal-config/tsdown/keep-assets.js
+++ b/tools/internal-config/tsdown/keep-assets.js
@@ -1,0 +1,22 @@
+import { join } from 'path';
+import { copyFileSync, mkdirSync } from 'fs';
+import { globSync } from '../utils/glob.js';
+
+export function keepAssets({ from, include, dist }) {
+  return {
+    name: 'copy-assets',
+
+    // the assets go into the output directory in the same relative locations as
+    // in the input directory
+    async closeBundle() {
+      const files = globSync(include, { cwd: join(process.cwd(), from) });
+      for (let name of files) {
+        const fromPath = join(process.cwd(), from, name);
+        const toPath = join(process.cwd(), dist, name);
+
+        mkdirSync(join(toPath, '..'), { recursive: true });
+        copyFileSync(fromPath, toPath);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Part of migrating the older `packages/*` tree (still-published `@ember-data/*`-adjacent packages) to tsdown, following the same pattern already completed for all of `warp-drive-packages/*`.
- Ported `tools/internal-config/vite/keep-assets.js` (copies non-TS assets like the DOM reporter's CSS into `dist/` after bundling) to `tools/internal-config/tsdown/keep-assets.js` unchanged — it's a plain rollup-style `closeBundle` hook with no Vite-specific dependency, so it works identically under tsdown/rolldown.
- Enabled `jsx: true` for `src/react.tsx`, same fix as `@warp-drive/react`'s migration (#10656).
- **Fixed a real bug surfaced by rebuilding**: `Diagnostic.dom` was declared identically in three separate files (`ember.ts`, `react.tsx`, `spec.ts`) via `declare module './-types' { interface Diagnostic { dom ... } }` — cross-file relative-path module augmentation, the same pattern already known to not survive rolldown-plugin-dts's entry-based declaration bundling (confirmed by a "will be kept as-is in the output" warning during the build, and by `tests/framework-react` failing to type-check with `Property 'dom' does not exist on type 'Diagnostic'`). All three augmentations were identical (same `Assert` type from `qunit-dom`), so moved `dom` directly into `-types.ts`'s own `Diagnostic` interface (same-module, immune to the bundling issue) and deleted the three now-redundant augmentations.

## Test plan
- [x] Build succeeds with no "kept as-is" warning (previously present).
- [x] `tests/core`, `tests/framework-react`, `tests/framework-ember`, `tests/framework-vue`, and `tests/ember-data__adapter` all type-check cleanly (`framework-react` was failing before the `Diagnostic.dom` fix).
- [x] Diagnostic suites pass at baseline: `tests/core` 187/189, `tests/framework-react` 39/39, `tests/framework-ember` 48/48, `tests/framework-vue` 1/1.
- [x] ESLint and Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)