### PR TITLE
chore: harden pnpm supply-chain settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,13 +70,13 @@
     "node": ">= 25.5.0",
     "yarn": "use pnpm",
     "npm": "use pnpm",
-    "pnpm": "10.15.0"
+    "pnpm": "10.34.5"
   },
   "volta": {
     "node": "25.5.0",
-    "pnpm": "10.15.0"
+    "pnpm": "10.34.5"
   },
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@10.34.5",
   "changelog": {
     "cacheDir": ".changelog-cache",
     "labels": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,42 @@
 # enableGlobalVirtualStore: true
+
+## Supply-chain hardening
+##
+## Newly published versions are not installable until they have existed
+## for at least this many minutes. This gives the ecosystem time to detect
+## and unpublish/deprecate compromised releases (e.g. from a hijacked
+## maintainer account or leaked publish token) before we can pull them in,
+## including as transitive dependencies.
+##
+## 10080 minutes = 7 days.
+##
+minimumReleaseAge: 10080
+
+## Our own packages are published by our own release automation and are
+## never installed from a public attacker's account, so there's no reason
+## to delay picking up our own just-published releases (e.g. when the
+## release tooling itself depends on a package it just published, or when
+## verifying a release in CI immediately after publish).
+##
+minimumReleaseAgeExclude:
+  - "@warp-drive/*"
+  - "@ember-data/*"
+
+## Prevents transitive (sub-)dependencies from being resolved via git,
+## git+ssh, or raw tarball URLs. Only our own direct dependencies may use
+## those protocols (none currently do); anything pulled in transitively
+## must come from the registry, where it is subject to the release-age
+## delay above and standard registry integrity checks.
+##
+blockExoticSubdeps: true
+
+## Refuses to install a package version whose trust signals (e.g. npm
+## provenance) have regressed compared to a version we've previously seen
+## for it. A sudden drop in trust is a strong signal that a maintainer
+## account or publish token has been compromised.
+##
+trustPolicy: no-downgrade
+
 packages:
   - "packages/*"
   - "tools/*"


### PR DESCRIPTION
## Summary
- Adds `minimumReleaseAge: 10080` (7 days) so newly published package versions — including transitive deps — aren't installable until the ecosystem has had time to catch a compromised release.
- Excludes our own `@warp-drive/*` and `@ember-data/*` scopes from that delay via `minimumReleaseAgeExclude`, since those are published by our own release automation.
- Adds `blockExoticSubdeps: true` to stop transitive dependencies from resolving via git/tarball URLs instead of the registry.
- Adds `trustPolicy: no-downgrade` to refuse installing a version whose provenance/trust signal has regressed from a previously seen version (a signal of a hijacked maintainer account or leaked token).
- Bumps pnpm from `10.15.0` → `10.34.5` (in `packageManager`, `engines`, and `volta`), since these settings require pnpm ≥ 10.16 (`minimumReleaseAge`) / ≥ 10.26 (`blockExoticSubdeps`).

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds against the existing lockfile with pnpm 10.34.5 and the new settings active (no lockfile drift, no resolution errors).
- [x] `pnpm config list` confirms all four new settings parse as expected.
- [ ] CI green (pnpm/action-setup reads the version from `packageManager`, no workflow changes needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)