### PR TITLE
feat: migrate @ember-data/adapter's build to rolldown via tsdown

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -15,10 +15,10 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -63,7 +63,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/adapter/tsdown.config.mjs
+++ b/packages/adapter/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@ember/service', // inject the store to base Adapter

--- a/packages/adapter/typedoc.config.mjs
+++ b/packages/adapter/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,12 +442,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/codemods:
     dependencies:
@@ -20401,9 +20401,6 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20439,16 +20436,10 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Migrates `packages/adapter` (`@ember-data/adapter`) from vite/rollup to `tsdown` (rolldown-based), continuing the tsdown migration series already completed across `warp-drive-packages/*` and other `packages/*`.
- Replaced `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; same `entryPoints`/`externals` carried over unchanged.
- Updated `typedoc.config.mjs` to import `entryPoints` from the new config file.
- `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, `vite` devDependency swapped for `tsdown@^0.22.14` (matching the version already used elsewhere in the repo).

## Test plan
- [x] Full `pnpm install` succeeds
- [x] `pnpm --filter @ember-data/adapter run build:pkg` succeeds, producing the same shape as before: `dist/{index,error,json-api,rest,-private}.js` + `unstable-preview-types/{index,error,json-api,rest,-private}.d.ts`
- [x] Rebuilt the sibling `ember-data` meta package (`packages/-ember-data`, depends on `@ember-data/adapter` via `workspace:*`) — succeeds against the new adapter output
- [x] `pnpm exec ember-tsc --noEmit` passes in `tests/ember-data__adapter` and `tests/ember-data__model`
- [x] Full test suites pass with 0 failures: `tests/ember-data__adapter` `test` (52/52) and `test:production` (52/52); `tests/ember-data__model` `test` (2/2, after a one-off flaky browser-launch retry unrelated to this change)
- [x] `eslint . --quiet` clean in `packages/adapter`
- [x] `prettier --check` clean on changed files