### PR TITLE
feat: migrate @ember-data/request-utils's build to rolldown via tsdown

### DIFF
--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -38,10 +38,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -69,8 +69,8 @@
     "@warp-drive/internal-config": "workspace:*",
     "ember-inflector": "6.0.0",
     "ember-source": "~6.12.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "ember": {
     "edition": "octane"

--- a/packages/request-utils/src/index.ts
+++ b/packages/request-utils/src/index.ts
@@ -47,7 +47,6 @@ import {
 } from '@warp-drive/core/store';
 
 export * from '@warp-drive/utilities';
-export type * from '@warp-drive/utilities';
 
 export { DefaultCachePolicy as CachePolicy, type PolicyConfig, type CacheControlValue, parseCacheControl };
 

--- a/packages/request-utils/tsdown.config.mjs
+++ b/packages/request-utils/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['@ember/debug', 'ember-inflector'];
 export const entryPoints = ['src/index.ts', 'src/string.ts', 'src/deprecation-support.ts', 'src/handlers.ts'];

--- a/packages/request-utils/typedoc.config.mjs
+++ b/packages/request-utils/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,12 +946,12 @@ importers:
       ember-source:
         specifier: ~6.12.0
         version: 6.12.0
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/rest:
     dependencies:
@@ -20374,11 +20374,17 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20388,17 +20394,11 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20420,10 +20420,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Continues the tsdown (rolldown-based) build migration already completed for all `warp-drive-packages/*` packages, now applied to `@ember-data/request-utils`.
- Replaces `vite.config.mjs` with `tsdown.config.mjs`, using the shared `@warp-drive/internal-config/tsdown/config.js` helper with the same `entryPoints`/`externals` unchanged.
- Updates `package.json`: `build:pkg` -> `tsdown`, `start` -> `tsdown --watch`, devDependencies swap `vite` for `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs`'s import of `entryPoints` from `./vite.config.mjs` to `./tsdown.config.mjs`.
- Fixes a real regression surfaced by the switch: `src/index.ts` had both `export * from '@warp-drive/utilities'` and a redundant `export type * from '@warp-drive/utilities'`. tsdown's dts bundler (rolldown-plugin-dts) collapses those two into just the type-only form when they target the same specifier in one file, silently dropping value exports (e.g. `setBuildURLConfig`) from the emitted `.d.ts`. Removing the redundant line fixes this without any runtime behavior change (`export *` already re-exports both values and types).
- No tsconfig changes needed (`isolatedDeclarations`/`isolatedModules` already enabled).

## Test plan
- [x] `pnpm install` (full, non-filtered)
- [x] `pnpm --filter @ember-data/request-utils run build:pkg` succeeds, producing the same `dist/*.js` + `unstable-preview-types/*.d.ts` shape as before, and the emitted `index.d.ts` correctly re-exports both values and types from `@warp-drive/utilities`
- [x] Rebuilt dependent `ember-data` (packages/-ember-data) via `build:pkg` — succeeds
- [x] `tests/utilities`: `check:types` (tsc --noEmit) — caught the export-type regression before the fix, clean after; `build:tests`, `test` — all pass (75/75)
- [x] `tests/ember-data__model`: `check:types` (tsc --noEmit), `build:tests`, `test` — all pass (2/2)
- [x] `pnpm exec eslint . --quiet` in packages/request-utils — clean
- [x] `pnpm exec prettier --check` on changed files — clean