### PR TITLE
feat: migrate the warp-drive CLI's build to rolldown via tsdown

### DIFF
--- a/packages/-warp-drive/package.json
+++ b/packages/-warp-drive/package.json
@@ -24,11 +24,11 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "bin": {
     "warp-drive": "./dist/warp-drive.js",
@@ -60,8 +60,8 @@
     "@types/debug": "^4.1.12",
     "@types/node": "^24.3.0",
     "@warp-drive/internal-config": "workspace:*",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/-warp-drive/tsdown.config.mjs
+++ b/packages/-warp-drive/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = ['node:child_process', 'fs', 'chalk', 'path', 'semver', 'comment-json'];
 export const entryPoints = ['./src/warp-drive.ts'];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,12 +365,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(@types/node@24.3.0)
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.3.0)
 
   packages/active-record:
     dependencies:
@@ -20374,11 +20374,17 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20388,17 +20394,11 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20420,10 +20420,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Part of migrating the older `packages/*` tree to tsdown, following the same pattern already completed for all of `warp-drive-packages/*`.
- This is a plain Node CLI (`packages/-warp-drive`, published as `warp-drive`) with a single entry point and no Ember/decorator/JSX content, so the migration is a straightforward config swap with no source changes needed.

## Test plan
- [x] tsdown correctly grants execute permission to the built `dist/warp-drive.js` (needed for the `bin` entries to work when invoked directly) and preserves the shebang line.
- [x] Smoke-tested `warp-drive --help` and `warp-drive about` against the built output — both render correctly.
- [x] No workspace packages or `tests/*` packages depend on this one, and it has no test script of its own, so this manual smoke test is the available verification surface.
- [x] Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)