### PR TITLE
feat: migrate @ember-data/serializer's build to rolldown via tsdown

### DIFF
--- a/packages/serializer/eslint.config.mjs
+++ b/packages/serializer/eslint.config.mjs
@@ -4,7 +4,7 @@ import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 import * as js from '@warp-drive/internal-config/eslint/browser.js';
 
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -15,10 +15,10 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -63,8 +63,8 @@
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-typescript": "^7.27.1",
     "@warp-drive/internal-config": "workspace:*",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/serializer/tsdown.config.mjs
+++ b/packages/serializer/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@ember/service',

--- a/packages/serializer/typedoc.config.mjs
+++ b/packages/serializer/typedoc.config.mjs
@@ -1,4 +1,4 @@
-import { entryPoints } from './vite.config.mjs';
+import { entryPoints } from './tsdown.config.mjs';
 
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,12 +1060,12 @@ importers:
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/store:
     dependencies:
@@ -20379,6 +20379,9 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20388,17 +20391,11 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20424,6 +20421,9 @@ snapshots:
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Continues the tsdown (rolldown) build migration already completed across `warp-drive-packages/*`, now applied to `@ember-data/serializer` in the legacy `packages/*` tree.
- Replaces `vite.config.mjs` with `tsdown.config.mjs` using the shared `@warp-drive/internal-config/tsdown/config.js` helper; `entryPoints`/`externals` are unchanged.
- Updates `package.json`: `build:pkg` now runs `tsdown`, `start` runs `tsdown --watch`, `vite` devDependency swapped for `tsdown@^0.22.14`.
- Updates `typedoc.config.mjs` and `eslint.config.mjs` (which reads the `externals` list for the allowed-imports lint rule) to import from `tsdown.config.mjs`.

## Test plan
- [x] Full `pnpm install` succeeds
- [x] `pnpm --filter @ember-data/serializer run build:pkg` succeeds, producing `dist/{index,json,json-api,rest,transform}.js` + matching `.d.ts` files in `unstable-preview-types` (same shape as before)
- [x] `ember-data` (the one `packages/*` package depending on `@ember-data/serializer` via `workspace:*`) rebuilds successfully
- [x] `tests/dont-write-new-tests-here`: `ember-tsc --noEmit` passes; `test` passes (5344/5349, 5 pre-existing skips); `test:production` passes (5189/5349, pre-existing skips)
- [x] `tests/ember-data__adapter`: `ember-tsc --noEmit` passes; `test` passes (52/52); `test:production` passes (52/52)
- [x] `tests/ember-data__model`: `ember-tsc --noEmit` passes; `test` passes (2/2)
- [x] `tests/blueprints`: `test:blueprints` passes (38 passing, 3 pending)
- [x] `tests/vite-basic-compat`: `test:vite` passes (2/2)
- [x] `eslint . --quiet` clean in `packages/serializer`
- [x] `prettier --check` clean on changed files