### PR TITLE
feat: migrate ember-data's build to rolldown via tsdown

### DIFF
--- a/packages/-ember-data/eslint.config.mjs
+++ b/packages/-ember-data/eslint.config.mjs
@@ -3,7 +3,7 @@ import { globalIgnores } from '@warp-drive/internal-config/eslint/ignore.js';
 import * as node from '@warp-drive/internal-config/eslint/node.js';
 import * as typescript from '@warp-drive/internal-config/eslint/typescript.js';
 import * as qunit from '@warp-drive/internal-config/eslint/qunit.js';
-import { externals } from './vite.config.mjs';
+import { externals } from './tsdown.config.mjs';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -16,10 +16,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "vite build",
+    "build:pkg": "tsdown",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "vite"
+    "start": "tsdown --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",
@@ -112,8 +112,8 @@
     "ember-source": "~6.12.0",
     "eslint": "^9.34.0",
     "qunit": "^2.18.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "tsdown": "^0.22.14",
+    "typescript": "^5.9.3"
   },
   "ember": {
     "edition": "octane"

--- a/packages/-ember-data/src/version.ts
+++ b/packages/-ember-data/src/version.ts
@@ -1,1 +1,9 @@
-export { version as default } from '../package.json';
+import { version } from '../package.json';
+
+// The `as string` here is redundant for full-program type-checking (which is
+// why the lint rule flags it), but isolatedDeclarations' per-file analysis
+// can't resolve the value's type from a re-exported `../package.json` import
+// without it -- omitting it makes tsdown/rolldown-plugin-dts's oxc generator
+// try to parse package.json itself as TS source and fail.
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+export default version as string;

--- a/packages/-ember-data/tsdown.config.mjs
+++ b/packages/-ember-data/tsdown.config.mjs
@@ -1,4 +1,4 @@
-import { createConfig } from '@warp-drive/internal-config/vite/config.js';
+import { createConfig } from '@warp-drive/internal-config/tsdown/config.js';
 
 export const externals = [
   '@ember/application/namespace',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,12 +316,12 @@ importers:
       qunit:
         specifier: 2.19.4
         version: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
+      tsdown:
+        specifier: ^0.22.14
+        version: 0.22.14(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1
 
   packages/-warp-drive:
     dependencies:
@@ -20374,11 +20374,17 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20388,17 +20394,11 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20420,10 +20420,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:


### PR DESCRIPTION
## Summary
- Part of migrating the older `packages/*` tree to tsdown, following the same pattern already completed for all of `warp-drive-packages/*`.
- This is the umbrella `ember-data` meta-package, built from a single glob entry point (`./src/**/*.ts`, ~20 files) matching the old vite config's uncurated per-file declaration approach exactly.
- **Fixed a real build failure**: `src/version.ts` did `export { version as default } from '../package.json';` — a direct re-export from a JSON module. tsdown/rolldown-plugin-dts's oxc (`isolatedDeclarations`) generator tries to resolve the re-exported binding's type by parsing the target module as TS source, and JSON isn't valid TS syntax, so it failed with an "expected a semicolon" parse error pointing at `package.json`'s opening brace. Rewrote it as an explicit import + `export default version as string` — confirmed by testing that removing the `as string` reproduces the exact same failure, so `isolatedDeclarations` genuinely needs the explicit annotation to avoid inferring through the JSON import. Full-program type-checking sees the assertion as redundant (a real, understood tension between `isolatedDeclarations`' narrower per-file analysis and the full checker), so added a scoped `eslint-disable` with a comment explaining why, rather than fighting the two tools against each other.

## Test plan
- [x] Build succeeds (confirmed the fix is necessary, not just defensive, by reverting it and reproducing the failure).
- [x] Runtime value matches `package.json`'s version exactly.
- [x] `tests/dont-write-new-tests-here` and `tests/vite-basic-compat` (the only two `tests/*` consumers of this package) both type-check cleanly.
- [x] `tests/vite-basic-compat`'s full ember-cli test run passes 2/2.
- [x] ESLint and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)