### PR TITLE
dx: migrate main-test-app build from broccoli to @embroider/vite

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1469,6 +1469,9 @@ importers:
       '@babel/core':
         specifier: ^7.28.3
         version: 7.28.3
+      '@babel/plugin-transform-runtime':
+        specifier: ^7.28.3
+        version: 7.28.3(@babel/core@7.28.3)
       '@babel/plugin-transform-typescript':
         specifier: ^7.28.0
         version: 7.28.0(@babel/core@7.28.3)
@@ -1523,9 +1526,21 @@ importers:
       '@ember/test-waiters':
         specifier: ^4.1.1
         version: 4.1.1(f9dfbf4fac3dbc0e0370b14ce6056988)
+      '@embroider/compat':
+        specifier: 4.1.12
+        version: 4.1.12(173e1969377496bab025e09d453d4c81)
+      '@embroider/config-meta-loader':
+        specifier: 1.0.1-unstable.f9c81e9
+        version: 1.0.1-unstable.f9c81e9
+      '@embroider/core':
+        specifier: ^4.4.2
+        version: 4.4.2(@glint/template@1.6.1)
       '@embroider/macros':
         specifier: ^1.20.6
         version: 1.20.6(f9dfbf4fac3dbc0e0370b14ce6056988)
+      '@embroider/vite':
+        specifier: ^1.5.0
+        version: 1.5.0(7c696368c8feb05fe28c46713eebc1d8)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1535,6 +1550,12 @@ importers:
       '@glint/template':
         specifier: 1.6.1
         version: 1.6.1
+      '@rollup/plugin-babel':
+        specifier: ^6.0.4
+        version: 6.0.4(@babel/core@7.28.3)
+      '@tsconfig/ember':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/qunit':
         specifier: 2.19.13
         version: 2.19.13
@@ -1568,24 +1589,12 @@ importers:
       '@warp-drive/utilities':
         specifier: workspace:*
         version: file:warp-drive-packages/utilities(14783ff7abfecaf4a15600481cda861e)
-      broccoli-concat:
-        specifier: ^4.2.5
-        version: 4.2.5
-      broccoli-merge-trees:
-        specifier: ^4.2.0
-        version: 4.2.0
-      broccoli-stew:
-        specifier: ^3.0.0
-        version: 3.0.0
-      broccoli-string-replace:
-        specifier: ^0.1.2
-        version: 0.1.2
-      broccoli-test-helper:
-        specifier: ^2.0.0
-        version: 2.0.0
-      broccoli-uglify-sourcemap:
+      babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
+      decorator-transforms:
+        specifier: ^2.3.0
+        version: 2.4.0(@babel/core@7.28.3)
       ember-auto-import:
         specifier: ^2.13.1
         version: 2.13.1(@glint/template@1.6.1)
@@ -1676,9 +1685,9 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      webpack:
-        specifier: 5.101.3
-        version: 5.101.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1
 
   tests/ember-data__adapter:
     dependencies:
@@ -7440,9 +7449,6 @@ packages:
   '@types/through@0.0.33':
     resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
 
-  '@types/tmp@0.0.33':
-    resolution: {integrity: sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==}
-
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
 
@@ -8632,10 +8638,6 @@ packages:
   broccoli-node-api@1.7.0:
     resolution: {integrity: sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==}
 
-  broccoli-node-info@1.1.0:
-    resolution: {integrity: sha512-DUohSZCdfXli/3iN6SmxPbck1OVG8xCkrLx47R25his06xVc1ZmmrOsrThiM8BsCWirwyocODiYJqNP5W2Hg1A==}
-    engines: {node: '>= 0.10.0'}
-
   broccoli-node-info@2.2.0:
     resolution: {integrity: sha512-VabSGRpKIzpmC+r+tJueCE5h8k6vON7EIMMWu6d/FyPdtijwLQ7QvzShEw+m3mHoDzUaj/kiZsDYrS8X2adsBg==}
     engines: {node: 8.* || >= 10.*}
@@ -8643,9 +8645,6 @@ packages:
   broccoli-output-wrapper@3.2.5:
     resolution: {integrity: sha512-bQAtwjSrF4Nu0CK0JOy5OZqw9t5U0zzv2555EA/cF8/a8SLDTIetk9UgrtMVw7qKLKdSpOZ2liZNeZZDaKgayw==}
     engines: {node: 10.* || >= 12.*}
-
-  broccoli-persistent-filter@1.4.6:
-    resolution: {integrity: sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==}
 
   broccoli-persistent-filter@2.3.1:
     resolution: {integrity: sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==}
@@ -8672,9 +8671,6 @@ packages:
   broccoli-slow-trees@3.1.0:
     resolution: {integrity: sha512-FRI7mRTk2wjIDrdNJd6znS7Kmmne4VkAkl8Ix1R/VoePFMD0g0tEl671xswzFqaRjpT9Qu+CC4hdXDLDJBuzMw==}
 
-  broccoli-source@1.1.0:
-    resolution: {integrity: sha512-ahvqmwF6Yvh6l+sTJJdey4o4ynwSH8swSSBSGmUXGSPPCqBWvquWB/4rWN65ZArKilBFq/29O0yQnZNIf//sTg==}
-
   broccoli-source@3.0.1:
     resolution: {integrity: sha512-ZbGVQjivWi0k220fEeIUioN6Y68xjMy0xiLAc0LdieHI99gw+tafU8w0CggBDYVNsJMKUr006AZaM7gNEwCxEg==}
     engines: {node: 8.* || 10.* || >= 12.*}
@@ -8686,24 +8682,9 @@ packages:
     resolution: {integrity: sha512-NXfi+Vas24n3Ivo21GvENTI55qxKu7OwKRnCLWXld8MiLiQKQlWIq28eoARaFj0lTUFwUa4jKZeA7fW9PiWQeg==}
     engines: {node: 8.* || >= 10.*}
 
-  broccoli-string-replace@0.1.2:
-    resolution: {integrity: sha512-QHESTrrrPlKuXQNWsvXawSQbV2g34wCZ5oKgd6bntdOuN8VHxbg1BCBHqVY5HxXJhWelimgGxj3vI7ECkyij8g==}
-
   broccoli-terser-sourcemap@4.1.1:
     resolution: {integrity: sha512-8sbpRf0/+XeszBJQM7vph2UNj4Kal0lCI/yubcrBIzb2NvYj5gjTHJABXOdxx5mKNmlCMu2hx2kvOtMpQsxrfg==}
     engines: {node: ^10.12.0 || 12.* || >= 14}
-
-  broccoli-test-helper@2.0.0:
-    resolution: {integrity: sha512-TKwh8dBT+RcxKEG+vAoaRRhZsCMwZIHPZbCzBNCA0nUi1aoFB/LVosqwMC6H9Ipe06FxY5hpQxDLFbnBMdUPsA==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
-  broccoli-uglify-sourcemap@4.0.0:
-    resolution: {integrity: sha512-46yB4gw1Q3ALtBROY5QfKXNXxYK5uPSvER1OGjjh2t3piaipqBfuRXTzQZvmZ+Odr6/McY+J8XmxON4+lE1ukg==}
-    engines: {node: ^10.12.0 || 12.* || >= 14}
-
-  broccoli@2.3.0:
-    resolution: {integrity: sha512-TeYMYlCGFK8EGk4Wce1G1uU3i52+YxRqP3WPOVDojC1zUk+Gi40wHBzUT2fncQZDl26dmCQMNugtHKjvUpcGQg==}
-    engines: {node: '>= 6'}
 
   broccoli@3.5.2:
     resolution: {integrity: sha512-sWi3b3fTUSVPDsz5KsQ5eCQNVAtLgkIE/HYFkEZXR/07clqmd4E/gFiuwSaqa9b+QTXc1Uemfb7TVWbEIURWDg==}
@@ -10608,10 +10589,6 @@ packages:
   find-yarn-workspace-root@2.0.0:
     resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
-  findup-sync@2.0.0:
-    resolution: {integrity: sha512-vs+3unmJT45eczmcAZ6zMJtxN3l/QXeccaXQx5cu/MeJMhewVfoWZqibRkOxPnmoR59+Zy5hjabfQc6JLSah4g==}
-    engines: {node: '>= 0.10'}
-
   findup-sync@4.0.0:
     resolution: {integrity: sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==}
     engines: {node: '>= 8'}
@@ -10622,9 +10599,6 @@ packages:
 
   fireworm@0.7.2:
     resolution: {integrity: sha512-GjebTzq+NKKhfmDxjKq3RXwQcN9xRmZWhnnuC9L+/x5wBQtR0aaQM50HsjrzJ2wc28v1vSdfOpELok0TKR4ddg==}
-
-  fixturify@0.3.4:
-    resolution: {integrity: sha512-Gx+KSB25b6gMc4bf7UFRTA85uE0iZR+RYur0JHh6dg4AGBh0EksOv4FCHyM7XpGmiJO7Bc7oV7vxENQBT+2WEQ==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -11406,10 +11380,6 @@ packages:
   is-git-url@1.0.0:
     resolution: {integrity: sha512-UCFta9F9rWFSavp9H3zHEHrARUfZbdJvmHKeEpds4BK3v7W2LdXoNypMtXXi5w5YBDEBCTYmbI+vsSwI8LYJaQ==}
     engines: {node: '>=0.8'}
-
-  is-glob@3.1.0:
-    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==}
-    engines: {node: '>=0.10.0'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -13114,10 +13084,6 @@ packages:
   promise.hash.helper@1.0.8:
     resolution: {integrity: sha512-KYcnXctWUWyVD3W3Ye0ZDuA1N8Szrh85cVCxpG6xYrOk/0CttRtYCmU30nWsUch0NuExQQ63QXvzRE6FLimZmg==}
     engines: {node: 10.* || >= 12.*}
-
-  promise.prototype.finally@3.1.8:
-    resolution: {integrity: sha512-aVDtsXOml9iuMJzUco9J1je/UrIT3oMYfWkCTiUhkt+AvZw72q4dUZnR/R/eB3h5GeAagQVXvM1ApoYniJiwoA==}
-    engines: {node: '>= 0.4'}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -15127,10 +15093,6 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
-
-  watch-detector@0.1.0:
-    resolution: {integrity: sha512-vfzMMfpjQc88xjETwl2HuE6PjEuxCBeyC4bQmqrHrofdfYWi/4mEJklYbNgSzpqM9PxubsiPIrE5SZ1FDyiQ2w==}
-    engines: {node: '>= 4'}
 
   watch-detector@1.0.2:
     resolution: {integrity: sha512-MrJK9z7kD5Gl3jHBnnBVHvr1saVGAfmkyyrvuNzV/oe0Gr1nwZTy5VSA0Gw2j2Or0Mu8HcjUa44qlBvC2Ofnpg==}
@@ -17930,6 +17892,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@embroider/compat@4.1.12(173e1969377496bab025e09d453d4c81)':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.28.3
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.3)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.3)
+      '@babel/plugin-transform-runtime': 7.28.3(@babel/core@7.28.3)
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
+      '@babel/runtime': 7.28.3
+      '@babel/traverse': 7.28.4
+      '@embroider/core': 4.4.2(@glint/template@1.6.1)
+      '@embroider/macros': 1.20.6(f9dfbf4fac3dbc0e0370b14ce6056988)
+      '@types/babel__code-frame': 7.0.6
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      babel-plugin-debug-macros: 2.0.0(@babel/core@7.28.3)
+      babel-plugin-ember-template-compilation: 3.0.0
+      babel-plugin-ember-template-compilation-2: babel-plugin-ember-template-compilation@2.4.1
+      babel-plugin-syntax-dynamic-import: 6.18.0
+      babylon: 6.18.0
+      bind-decorator: 1.0.11
+      broccoli: 3.5.2
+      broccoli-concat: 4.2.5
+      broccoli-file-creator: 2.1.1
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-persistent-filter: 3.1.3
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      chalk: 4.1.2
+      debug: 4.4.1
+      fast-sourcemap-concat: 2.1.1
+      fs-extra: 9.1.0
+      fs-tree-diff: 2.0.1
+      jsdom: 26.1.0
+      lodash: 4.17.21
+      pkg-up: 3.1.0
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
+      semver: 7.7.2
+      symlink-or-copy: 1.3.1
+      tree-sync: 2.1.0
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
   '@embroider/compat@4.1.12(@embroider/core@4.4.2)':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -20396,11 +20411,17 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20410,17 +20431,11 @@ snapshots:
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__engine@4.0.11':
     dependencies:
       '@types/ember__object': 4.0.12
       '@types/ember__owner': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__error@4.0.6': {}
 
@@ -20442,10 +20457,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -20618,8 +20639,6 @@ snapshots:
   '@types/through@0.0.33':
     dependencies:
       '@types/node': 24.3.0
-
-  '@types/tmp@0.0.33': {}
 
   '@types/triple-beam@1.3.5': {}
 
@@ -23054,8 +23073,6 @@ snapshots:
 
   broccoli-node-api@1.7.0: {}
 
-  broccoli-node-info@1.1.0: {}
-
   broccoli-node-info@2.2.0: {}
 
   broccoli-output-wrapper@3.2.5:
@@ -23063,24 +23080,6 @@ snapshots:
       fs-extra: 8.1.0
       heimdalljs-logger: 0.1.10
       symlink-or-copy: 1.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  broccoli-persistent-filter@1.4.6:
-    dependencies:
-      async-disk-cache: 1.3.5
-      async-promise-queue: 1.0.5
-      broccoli-plugin: 1.3.1
-      fs-tree-diff: 0.5.9
-      hash-for-dep: 1.5.1
-      heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
-      mkdirp: 0.5.6
-      promise-map-series: 0.2.3
-      rimraf: 2.7.1
-      rsvp: 3.6.2
-      symlink-or-copy: 1.3.1
-      walk-sync: 0.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -23156,8 +23155,6 @@ snapshots:
     dependencies:
       heimdalljs: 0.2.6
 
-  broccoli-source@1.1.0: {}
-
   broccoli-source@3.0.1:
     dependencies:
       broccoli-node-api: 1.7.0
@@ -23191,13 +23188,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-string-replace@0.1.2:
-    dependencies:
-      broccoli-persistent-filter: 1.4.6
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   broccoli-terser-sourcemap@4.1.1:
     dependencies:
       async-promise-queue: 1.0.5
@@ -23210,56 +23200,6 @@ snapshots:
       terser: 5.43.1
       walk-sync: 2.2.0
       workerpool: 6.5.1
-    transitivePeerDependencies:
-      - supports-color
-
-  broccoli-test-helper@2.0.0:
-    dependencies:
-      '@types/tmp': 0.0.33
-      broccoli: 2.3.0
-      fixturify: 0.3.4
-      fs-tree-diff: 0.5.9
-      tmp: 0.0.33
-      walk-sync: 0.3.4
-    transitivePeerDependencies:
-      - supports-color
-
-  broccoli-uglify-sourcemap@4.0.0:
-    dependencies:
-      async-promise-queue: 1.0.5
-      broccoli-plugin: 4.0.7
-      debug: 4.4.1
-      lodash.defaultsdeep: 4.6.1
-      matcher-collection: 2.0.1
-      source-map-url: 0.4.1
-      symlink-or-copy: 1.3.1
-      terser: 5.43.1
-      walk-sync: 2.2.0
-      workerpool: 6.5.1
-    transitivePeerDependencies:
-      - supports-color
-
-  broccoli@2.3.0:
-    dependencies:
-      broccoli-node-info: 1.1.0
-      broccoli-slow-trees: 3.1.0
-      broccoli-source: 1.1.0
-      commander: 2.20.3
-      connect: 3.7.0
-      esm: 3.2.25
-      findup-sync: 2.0.0
-      handlebars: 4.7.8
-      heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
-      mime-types: 2.1.35
-      promise.prototype.finally: 3.1.8
-      resolve-path: 1.4.0
-      rimraf: 2.7.1
-      sane: 4.1.0
-      tmp: 0.0.33
-      tree-sync: 1.4.0
-      underscore.string: 3.3.6
-      watch-detector: 0.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -24041,6 +23981,11 @@ snapshots:
       babel-import-util: 3.0.1
     transitivePeerDependencies:
       - '@babel/core'
+
+  decorator-transforms@2.4.0(@babel/core@7.28.3):
+    dependencies:
+      '@babel/core': 7.28.3
+      babel-import-util: 3.0.1
 
   decorator-transforms@2.4.0(@babel/core@7.29.7):
     dependencies:
@@ -24868,7 +24813,7 @@ snapshots:
   ember-modifier@4.2.2(@babel/core@7.28.3):
     dependencies:
       '@embroider/addon-shim': 1.10.0
-      decorator-transforms: 2.3.0(@babel/core@7.28.3)
+      decorator-transforms: 2.4.0(@babel/core@7.28.3)
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
     transitivePeerDependencies:
@@ -26063,15 +26008,6 @@ snapshots:
     dependencies:
       micromatch: 4.0.8
 
-  findup-sync@2.0.0:
-    dependencies:
-      detect-file: 1.0.0
-      is-glob: 3.1.0
-      micromatch: 3.1.10
-      resolve-dir: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   findup-sync@4.0.0:
     dependencies:
       detect-file: 1.0.0
@@ -26093,11 +26029,6 @@ snapshots:
       lodash.debounce: 3.1.1
       lodash.flatten: 3.0.2
       minimatch: 3.1.5
-
-  fixturify@0.3.4:
-    dependencies:
-      fs-extra: 0.30.0
-      matcher-collection: 1.1.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -27004,10 +26935,6 @@ snapshots:
       safe-regex-test: 1.1.0
 
   is-git-url@1.0.0: {}
-
-  is-glob@3.1.0:
-    dependencies:
-      is-extglob: 2.1.1
 
   is-glob@4.0.3:
     dependencies:
@@ -28812,14 +28739,6 @@ snapshots:
 
   promise.hash.helper@1.0.8: {}
 
-  promise.prototype.finally@3.1.8:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-errors: 1.3.0
-      set-function-name: 2.0.2
-
   property-information@7.1.0: {}
 
   proto-list@1.2.4: {}
@@ -30508,7 +30427,7 @@ snapshots:
   tracked-built-ins@4.0.0(7c1eb33138e746229cea5e7e565a34fb):
     dependencies:
       '@embroider/addon-shim': 1.10.0
-      decorator-transforms: 2.3.0(@babel/core@7.28.3)
+      decorator-transforms: 2.4.0(@babel/core@7.28.3)
       ember-tracked-storage-polyfill: 1.0.0(7c1eb33138e746229cea5e7e565a34fb)
     transitivePeerDependencies:
       - '@babel/core'
@@ -31375,16 +31294,6 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
-
-  watch-detector@0.1.0:
-    dependencies:
-      heimdalljs-logger: 0.1.10
-      quick-temp: 0.1.8
-      rsvp: 4.8.5
-      semver: 5.7.2
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   watch-detector@1.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1632,8 +1632,8 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       ember-exam:
-        specifier: ^9.1.0
-        version: 9.1.0(7cf7a9df3b05ff4ce5f91492e5ef954e)
+        specifier: ^10.1.3
+        version: 10.1.3(7cf7a9df3b05ff4ce5f91492e5ef954e)
       ember-inflector:
         specifier: 6.0.0
         version: 6.0.0(@babel/core@7.28.3)
@@ -9895,8 +9895,8 @@ packages:
   ember-estree@0.6.11:
     resolution: {integrity: sha512-aZyheQGUXyHu8GARPd1YyjbDMGkvqBYKzPj6RVp8qqMqA1L1MbkWKsljWE3K1CwiJcHwTPgm/O3oxS0TY1AX9Q==}
 
-  ember-exam@9.1.0:
-    resolution: {integrity: sha512-POqCgZ1jjQEvIARnDVDFoag3KZaNRU7XTGIzL/enVsilzPA0xTomOlCpc2lZNh/hXOZSfB69fHwygYshxMf3+A==}
+  ember-exam@10.1.3:
+    resolution: {integrity: sha512-SoofgdajDsytTFVch9ahtlTb2DmV6Rn+HkhUCnTDr1opcLyvQLuFFco8ABwJeD/zBq3Svp6cvzyNOheXB6kcWA==}
     engines: {node: '>= 18'}
     peerDependencies:
       ember-cli: '*'
@@ -10685,10 +10685,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.3.0:
-    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
-    engines: {node: '>=14.14'}
 
   fs-extra@11.3.3:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
@@ -15705,7 +15701,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.1':
@@ -15761,6 +15757,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.1
+      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.4
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.28.3':
     dependencies:
       '@babel/helper-annotate-as-pure': 7.27.3
@@ -15780,6 +15789,19 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.3)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.28.4
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.28.4
       semver: 6.3.1
@@ -15812,6 +15834,13 @@ snapshots:
       regexpu-core: 6.2.0
       semver: 6.3.1
 
+  '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      regexpu-core: 6.2.0
+      semver: 6.3.1
+
   '@babel/helper-define-polyfill-provider@0.6.5':
     dependencies:
       '@babel/helper-compilation-targets': 7.27.2
@@ -15825,6 +15854,17 @@ snapshots:
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      debug: 4.4.1
+      lodash.debounce: 4.0.8
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       debug: 4.4.1
@@ -15882,6 +15922,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -15920,6 +15969,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-wrap-function': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@7.27.1':
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.27.1
@@ -15931,6 +15989,15 @@ snapshots:
   '@babel/helper-replace-supers@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-member-expression-to-functions': 7.27.1
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-replace-supers@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.28.4
@@ -16023,6 +16090,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16032,6 +16107,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16039,6 +16119,11 @@ snapshots:
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1':
@@ -16058,6 +16143,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16068,6 +16162,14 @@ snapshots:
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.28.4
     transitivePeerDependencies:
@@ -16084,6 +16186,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -16105,6 +16215,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-decorators@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-private-methods@7.18.6':
     dependencies:
       '@babel/helper-create-class-features-plugin': 7.28.3
@@ -16120,11 +16239,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2': {}
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
 
   '@babel/plugin-proposal-private-property-in-object@7.21.11':
     dependencies:
@@ -16145,6 +16276,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-syntax-decorators@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16152,6 +16293,11 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.3)':
@@ -16173,6 +16319,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-import-attributes@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16180,6 +16331,11 @@ snapshots:
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.3)':
@@ -16196,6 +16352,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-typescript@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16203,6 +16364,11 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
@@ -16221,6 +16387,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-arrow-functions@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16228,6 +16400,11 @@ snapshots:
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-async-generator-functions@7.28.0':
@@ -16243,6 +16420,15 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.3)
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
       '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
@@ -16264,6 +16450,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-block-scoped-functions@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16273,6 +16468,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-block-scoping@7.28.0':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16280,6 +16480,11 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-class-properties@7.27.1':
@@ -16297,6 +16502,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-class-static-block@7.28.3':
     dependencies:
       '@babel/helper-create-class-features-plugin': 7.28.3
@@ -16308,6 +16521,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-class-static-block@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -16335,6 +16556,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-classes@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-globals': 7.28.0
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.7)
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-computed-properties@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16343,6 +16576,12 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/template': 7.27.2
+
+  '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.27.2
 
@@ -16361,6 +16600,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-dotall-regex@7.27.1':
     dependencies:
       '@babel/helper-create-regexp-features-plugin': 7.27.1
@@ -16372,6 +16619,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-duplicate-keys@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16379,6 +16632,11 @@ snapshots:
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1':
@@ -16392,6 +16650,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-dynamic-import@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16399,6 +16663,11 @@ snapshots:
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-explicit-resource-management@7.28.0':
@@ -16416,6 +16685,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-exponentiation-operator@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16425,6 +16702,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-export-namespace-from@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16432,6 +16714,11 @@ snapshots:
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.3)':
@@ -16455,6 +16742,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-function-name@7.27.1':
     dependencies:
       '@babel/helper-compilation-targets': 7.27.2
@@ -16472,6 +16767,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-json-strings@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16479,6 +16783,11 @@ snapshots:
   '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-literals@7.27.1':
@@ -16490,6 +16799,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-logical-assignment-operators@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16499,6 +16813,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-member-expression-literals@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16506,6 +16825,11 @@ snapshots:
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-modules-amd@7.27.1':
@@ -16523,6 +16847,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-commonjs@7.27.1':
     dependencies:
       '@babel/helper-module-transforms': 7.28.3
@@ -16534,6 +16866,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -16557,6 +16897,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-umd@7.27.1':
     dependencies:
       '@babel/helper-module-transforms': 7.28.3
@@ -16572,6 +16922,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1':
     dependencies:
       '@babel/helper-create-regexp-features-plugin': 7.27.1
@@ -16583,6 +16941,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-new-target@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16590,6 +16954,11 @@ snapshots:
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.27.1':
@@ -16601,6 +16970,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-numeric-separator@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16608,6 +16982,11 @@ snapshots:
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-object-rest-spread@7.28.0':
@@ -16631,6 +17010,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-object-super@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16646,6 +17036,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-optional-catch-binding@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16653,6 +17051,11 @@ snapshots:
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-optional-chaining@7.27.1':
@@ -16670,6 +17073,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-parameters@7.27.7':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16677,6 +17088,11 @@ snapshots:
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-private-methods@7.27.1':
@@ -16690,6 +17106,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.28.3)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -16711,6 +17135,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-property-in-object@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-property-literals@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16718,6 +17151,11 @@ snapshots:
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.3)':
@@ -16758,6 +17196,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-regenerator@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-regexp-modifiers@7.27.1':
     dependencies:
       '@babel/helper-create-regexp-features-plugin': 7.27.1
@@ -16769,6 +17212,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-reserved-words@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16776,6 +17225,11 @@ snapshots:
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-runtime@7.28.3':
@@ -16801,6 +17255,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-runtime@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-shorthand-properties@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16808,6 +17274,11 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-spread@7.27.1':
@@ -16825,6 +17296,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-spread@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-sticky-regex@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16832,6 +17311,11 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-template-literals@7.27.1':
@@ -16843,6 +17327,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-typeof-symbol@7.27.1':
     dependencies:
       '@babel/helper-plugin-utils': 7.27.1
@@ -16850,6 +17339,11 @@ snapshots:
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-typescript@7.28.0':
@@ -16873,6 +17367,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.3(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -16893,6 +17398,11 @@ snapshots:
       '@babel/core': 7.28.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-unicode-property-regex@7.27.1':
     dependencies:
       '@babel/helper-create-regexp-features-plugin': 7.27.1
@@ -16902,6 +17412,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-unicode-regex@7.27.1':
@@ -16915,6 +17431,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-unicode-sets-regex@7.27.1':
     dependencies:
       '@babel/helper-create-regexp-features-plugin': 7.27.1
@@ -16924,6 +17446,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.3)
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/preset-env@7.28.3':
@@ -17077,6 +17605,82 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-env@7.28.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/compat-data': 7.28.0
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.3(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-generator-functions': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-async-to-generator': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-block-scoping': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-classes': 7.28.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-computed-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-dotall-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-json-strings': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-systemjs': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-rest-spread': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-methods': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-private-property-in-object': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-regenerator': 7.28.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-regexp-modifiers': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-spread': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.27.1(@babel/core@7.29.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.7)
+      core-js-compat: 3.45.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-flow@7.27.1(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
@@ -17093,6 +17697,13 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/types': 7.28.4
+      esutils: 2.0.3
+
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/types': 7.28.4
       esutils: 2.0.3
@@ -19355,7 +19966,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.3
+      semver: 7.8.5
 
   '@npmcli/move-file@1.1.2':
     dependencies:
@@ -19742,7 +20353,7 @@ snapshots:
       ramda: '@pnpm/ramda@0.28.1'
       right-pad: 1.1.1
       rxjs: 7.8.2
-      semver: 7.7.3
+      semver: 7.8.5
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -19847,7 +20458,7 @@ snapshots:
       detect-libc: 2.0.4
       execa: safe-execa@0.1.2
       mem: 8.1.1
-      semver: 7.7.3
+      semver: 7.8.5
 
   '@pnpm/pnpmfile@5.0.7(@pnpm/logger@1001.0.0)':
     dependencies:
@@ -20419,9 +21030,6 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -20457,16 +21065,10 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -20486,9 +21088,6 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -22663,6 +23262,11 @@ snapshots:
       '@babel/core': 7.28.3
       semver: 5.7.2
 
+  babel-plugin-debug-macros@0.3.4(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      semver: 5.7.2
+
   babel-plugin-debug-macros@2.0.0:
     dependencies:
       babel-import-util: 2.1.1
@@ -22732,6 +23336,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.7):
+    dependencies:
+      '@babel/compat-data': 7.28.0
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.13.0:
     dependencies:
       '@babel/helper-define-polyfill-provider': 0.6.5
@@ -22747,6 +23360,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
+      core-js-compat: 3.45.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-regenerator@0.6.5:
     dependencies:
       '@babel/helper-define-polyfill-provider': 0.6.5
@@ -22757,6 +23378,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -22953,6 +23581,20 @@ snapshots:
   broccoli-babel-transpiler@8.0.2(@babel/core@7.28.3):
     dependencies:
       '@babel/core': 7.28.3
+      broccoli-persistent-filter: 3.1.3
+      clone: 2.1.2
+      hash-for-dep: 1.5.1
+      heimdalljs: 0.2.6
+      heimdalljs-logger: 0.1.10
+      json-stable-stringify: 1.3.0
+      rsvp: 4.8.5
+      workerpool: 6.5.1
+    transitivePeerDependencies:
+      - supports-color
+
+  broccoli-babel-transpiler@8.0.2(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
       broccoli-persistent-filter: 3.1.3
       clone: 2.1.2
       hash-for-dep: 1.5.1
@@ -24327,6 +24969,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-cli-babel@8.2.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-static-block': 7.28.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-runtime': 7.28.3(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.29.7)
+      '@babel/preset-env': 7.28.3(@babel/core@7.29.7)
+      '@babel/runtime': 7.12.18
+      amd-name-resolver: 1.3.1
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.7)
+      babel-plugin-ember-data-packages-polyfill: 0.1.2
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-module-resolver: 5.0.2
+      broccoli-babel-transpiler: 8.0.2(@babel/core@7.29.7)
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-source: 3.0.1
+      calculate-cache-key-for-tree: 2.0.0
+      clone: 2.1.2
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-cli-version-checker: 5.1.2
+      ensure-posix-path: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   ember-cli-blueprint-test-helpers@0.19.2(ember-cli@6.12.0):
     dependencies:
       chai: 4.5.0
@@ -24444,7 +25119,7 @@ snapshots:
     dependencies:
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
-      debug: 4.4.3
+      debug: 4.4.1
       execa: 4.1.0
       fs-extra: 9.1.0
       resolve: 1.22.10
@@ -24761,24 +25436,24 @@ snapshots:
       content-tag: 4.2.0
       oxc-parser: 0.130.0
 
-  ember-exam@9.1.0(7cf7a9df3b05ff4ce5f91492e5ef954e):
+  ember-exam@10.1.3(7cf7a9df3b05ff4ce5f91492e5ef954e):
     dependencies:
-      '@babel/core': 7.28.3
+      '@babel/core': 7.29.7
       chalk: 5.6.0
       cli-table3: 0.6.5
       debug: 4.4.1
       ember-auto-import: 2.13.1(@glint/template@1.6.1)
       ember-cli: 6.12.0
-      ember-cli-babel: 8.2.0(@babel/core@7.28.3)
+      ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       ember-qunit: 9.0.4(08f20db85383b70d241d2436b7cf0aef)
       ember-source: 6.12.0(@glimmer/component@2.0.0)
       execa: 8.0.1
-      fs-extra: 11.3.0
+      fs-extra: 11.3.3
       js-yaml: 4.1.0
       npmlog: 7.0.1
       qunit: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
       rimraf: 5.0.10
-      semver: 7.7.2
+      semver: 7.8.5
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@glint/template'
@@ -25346,7 +26021,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.34.0):
     dependencies:
       eslint: 9.34.0
-      semver: 7.7.3
+      semver: 7.8.5
 
   eslint-config-prettier@10.1.8(eslint@9.34.0):
     dependencies:
@@ -26108,12 +26783,6 @@ snapshots:
       rimraf: 2.7.1
 
   fs-extra@10.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-
-  fs-extra@11.3.0:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
@@ -29714,7 +30383,7 @@ snapshots:
       get-stdin: 9.0.0
       git-hooks-list: 3.2.0
       is-plain-obj: 4.1.0
-      semver: 7.7.3
+      semver: 7.8.5
       sort-object-keys: 1.1.3
       tinyglobby: 0.2.17
 
@@ -29796,7 +30465,7 @@ snapshots:
 
   stagehand@1.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -30689,7 +31358,7 @@ snapshots:
 
   typescript-auto-import-cache@0.3.5:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   typescript-eslint@8.41.0(eslint@9.34.0)(typescript@5.9.2):
     dependencies:

--- a/tests/dont-write-new-tests-here/.ember-cli
+++ b/tests/dont-write-new-tests-here/.ember-cli
@@ -1,0 +1,7 @@
+{
+  /**
+    Setting `isTypeScriptProject` to true will force the blueprint generators to generate TypeScript
+    rather than JavaScript by default, when a TypeScript version of a given blueprint is available.
+  */
+  "isTypeScriptProject": true
+}

--- a/tests/dont-write-new-tests-here/app/app.ts
+++ b/tests/dont-write-new-tests-here/app/app.ts
@@ -4,6 +4,8 @@ import '@warp-drive/ember/install';
 // import { Registry } from '@ember/-internals/container';
 import Application from '@ember/application';
 
+// eslint-disable-next-line import/no-unresolved
+import compatModules from '@embroider/virtual/compat-modules';
 import loadInitializers from 'ember-load-initializers';
 
 import config from './config/environment';
@@ -43,10 +45,10 @@ const EventConfig = {
 class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
-  override Resolver = Resolver;
+  override Resolver = Resolver.withModules(compatModules);
   override customEvents = EventConfig;
 }
 
-loadInitializers(App, config.modulePrefix);
+loadInitializers(App, config.modulePrefix, compatModules);
 
 export default App;

--- a/tests/dont-write-new-tests-here/app/app.ts
+++ b/tests/dont-write-new-tests-here/app/app.ts
@@ -4,8 +4,8 @@ import '@warp-drive/ember/install';
 // import { Registry } from '@ember/-internals/container';
 import Application from '@ember/application';
 
-// eslint-disable-next-line import/no-unresolved
 import compatModules from '@embroider/virtual/compat-modules';
+
 import loadInitializers from 'ember-load-initializers';
 
 import config from './config/environment';

--- a/tests/dont-write-new-tests-here/app/config/environment.js
+++ b/tests/dont-write-new-tests-here/app/config/environment.js
@@ -1,0 +1,3 @@
+import loadConfigFromMeta from '@embroider/config-meta-loader';
+
+export default loadConfigFromMeta('main-test-app');

--- a/tests/dont-write-new-tests-here/babel.config.mjs
+++ b/tests/dont-write-new-tests-here/babel.config.mjs
@@ -1,0 +1,58 @@
+import { createRequire } from 'node:module';
+
+import { babelCompatSupport, templateCompatSupport } from '@embroider/compat/babel';
+
+const require = createRequire(import.meta.url);
+
+export default {
+  plugins: [
+    // NOTE: we do NOT also spread `macros()` (from
+    // `@warp-drive/build-config/babel-macros`) here. `ember-cli-build.js`
+    // already registers those same plugins on the classic `EmberApp` via
+    // `babel: { plugins: [...macros()] }`, and `compatBuild`'s addon-widening
+    // step captures that registration. `babelCompatSupport()` below already
+    // re-surfaces it (via `pluginsFromV1Addons()`) for vite's babel pass, so
+    // adding it again here would register the same plugins twice and trip
+    // Babel's duplicate-plugin detection.
+    [
+      '@babel/plugin-transform-typescript',
+      {
+        allExtensions: true,
+        onlyRemoveTypeImports: true,
+        allowDeclareFields: true,
+      },
+    ],
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        enableLegacyModules: [
+          'ember-cli-htmlbars',
+          'ember-cli-htmlbars-inline-precompile',
+          'htmlbars-inline-precompile',
+        ],
+        transforms: [...templateCompatSupport()],
+      },
+    ],
+    [
+      'module:decorator-transforms',
+      {
+        runtime: {
+          import: require.resolve('decorator-transforms/runtime-esm'),
+        },
+      },
+    ],
+    [
+      '@babel/plugin-transform-runtime',
+      {
+        absoluteRuntime: import.meta.dirname,
+        useESModules: true,
+        regenerator: false,
+      },
+    ],
+    ...babelCompatSupport(),
+  ],
+
+  generatorOpts: {
+    compact: false,
+  },
+};

--- a/tests/dont-write-new-tests-here/ember-cli-build.js
+++ b/tests/dont-write-new-tests-here/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const { compatBuild } = require('@embroider/compat');
 
 function isEnabled(flag) {
   return flag === true || flag === 'true' || flag === '1';
@@ -45,6 +46,7 @@ module.exports = async function (defaults) {
   logSystem();
   const { setConfig } = await import('@warp-drive/build-config');
   const { macros } = await import('@warp-drive/build-config/babel-macros');
+  const { buildOnce } = await import('@embroider/vite');
 
   const isTest = process.env.EMBER_CLI_TEST_COMMAND;
   const isProd = process.env.EMBER_ENV === 'production';
@@ -112,5 +114,31 @@ module.exports = async function (defaults) {
     },
   });
 
-  return app.toTree();
+  return compatBuild(app, buildOnce, {
+    // several tests dynamically `owner.register('component:some-name', ...)`
+    // and then invoke that name from a `hbs` template (see e.g.
+    // tests/acceptance/relationships/has-many-test.js). These components
+    // have no on-disk module for embroider's static resolver to find. By
+    // default embroider optimistically assumes any unrecognized PascalCase
+    // tag is a local app component and emits a static import for it, which
+    // then fails at bundle time since no such file exists. Marking them
+    // `safeToIgnore` here tells the resolver to leave the invocation alone
+    // so it falls back to the classic runtime resolver instead, without
+    // having to disable static resolution for the whole app (which would
+    // also break normal `service:`/`transform:`/etc runtime container
+    // lookups elsewhere in the suite).
+    allowUnsafeDynamicComponents: true,
+    packageRules: [
+      {
+        package: 'main-test-app',
+        components: {
+          '<PersonOverview />': { safeToIgnore: true },
+          '<ChildrenList />': { safeToIgnore: true },
+          '<WidgetCreator />': { safeToIgnore: true },
+          '<WidgetList />': { safeToIgnore: true },
+          '<PeopleList />': { safeToIgnore: true },
+        },
+      },
+    ],
+  });
 };

--- a/tests/dont-write-new-tests-here/index.html
+++ b/tests/dont-write-new-tests-here/index.html
@@ -9,16 +9,21 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/main-test-app.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/virtual/vendor.css">
+    <link rel="stylesheet" href="/assets/main-test-app.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/main-test-app.js"></script>
+    <script src="/@embroider/virtual/vendor.js"></script>
+    <script type="module">
+      import Application from './app/app';
+      import environment from './app/config/environment';
+
+      Application.create(environment.APP);
+    </script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dont-write-new-tests-here/package.json
+++ b/tests/dont-write-new-tests-here/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.28.3",
+    "@babel/plugin-transform-runtime": "^7.28.3",
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/runtime": "^7.28.3",
     "@ember-data/adapter": "workspace:*",
@@ -46,10 +47,16 @@
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "5.2.0",
     "@ember/test-waiters": "^4.1.1",
+    "@embroider/compat": "4.1.12",
+    "@embroider/config-meta-loader": "1.0.1-unstable.f9c81e9",
+    "@embroider/core": "^4.4.2",
     "@embroider/macros": "^1.20.6",
+    "@embroider/vite": "^1.5.0",
     "@glimmer/component": "^2.0.0",
     "@glint/ember-tsc": "^1.0.9",
     "@glint/template": "^1.7.3",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^3.0.11",
     "@types/qunit": "2.19.13",
     "@warp-drive/build-config": "workspace:*",
     "@warp-drive/core": "workspace:*",
@@ -61,12 +68,8 @@
     "@warp-drive/legacy": "workspace:*",
     "@warp-drive/schema-record": "workspace:*",
     "@warp-drive/utilities": "workspace:*",
-    "broccoli-concat": "^4.2.5",
-    "broccoli-merge-trees": "^4.2.0",
-    "broccoli-stew": "^3.0.0",
-    "broccoli-string-replace": "^0.1.2",
-    "broccoli-test-helper": "^2.0.0",
-    "broccoli-uglify-sourcemap": "^4.0.0",
+    "babel-plugin-ember-template-compilation": "^4.0.0",
+    "decorator-transforms": "^2.3.0",
     "ember-auto-import": "^2.13.1",
     "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli": "~6.12.0",
@@ -97,12 +100,16 @@
     "qunit-dom": "^3.5.0",
     "testem": "^3.12.0",
     "typescript": "^5.9.3",
-    "webpack": "^5.101.3"
+    "vite": "^7.3.1"
   },
   "ember": {
     "edition": "octane"
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "exports": {
+    "./tests/*": "./tests/*",
+    "./*": "./app/*"
   }
 }

--- a/tests/dont-write-new-tests-here/package.json
+++ b/tests/dont-write-new-tests-here/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build:tests": "IS_TESTING=true EMBER_CLI_TEST_COMMAND=true ember build --output-path=dist-test --suppress-sizes",
-    "build:production": "bun run build:tests -e production",
+    "build:production": "FORCE_BUILD_TESTS=true bun run build:tests -e production",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "ember-tsc --noEmit",
     "examine": "export EXAM_PARALLEL_COUNT=$(./bin/calculate-test-jobs); ember exam --test-port=0 --path=dist-test --parallel=$EXAM_PARALLEL_COUNT --load-balance",
@@ -82,7 +82,7 @@
     "ember-data": "workspace:*",
     "ember-decorators-polyfill": "^1.1.5",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-exam": "^9.1.0",
+    "ember-exam": "^10.1.3",
     "ember-inflector": "6.0.0",
     "ember-load-initializers": "^3.0.1",
     "ember-maybe-import-regenerator": "^1.0.0",

--- a/tests/dont-write-new-tests-here/tests/index.html
+++ b/tests/dont-write-new-tests-here/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/main-test-app.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+    <link rel="stylesheet" href="/@embroider/virtual/vendor.css">
+    <link rel="stylesheet" href="/assets/main-test-app.css">
+    <link rel="stylesheet" href="/@embroider/virtual/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -45,7 +45,7 @@
       </div>
     </div>
 
-    <script src="/testem.js" integrity=""></script>
+    <script src="/testem.js" integrity="" data-embroider-ignore></script>
     <script type="text/javascript">
 			// enable debugging memory over time
 			window.MEMORY_DATA = Object.create(null);
@@ -79,13 +79,15 @@
 				};
 			}
 		</script>
-    <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="/@embroider/virtual/vendor.js"></script>
+    <script src="/@embroider/virtual/test-support.js"></script>
+    <script type="module">import "ember-testing";</script>
 
-    <script src="{{rootURL}}assets/main-test-app.js"></script>
-    <script src="{{rootURL}}assets/tests.js"></script>
+    <script type="module">
+      import './test-helper';
+      import.meta.glob("./**/*.{js,ts,gjs,gts}", { eager: true });
+    </script>
 
     {{content-for "body-footer"}}
-    {{content-for "test-body-footer"}}
   </body>
 </html>

--- a/tests/dont-write-new-tests-here/tests/index.html
+++ b/tests/dont-write-new-tests-here/tests/index.html
@@ -84,8 +84,21 @@
     <script type="module">import "ember-testing";</script>
 
     <script type="module">
-      import './test-helper';
-      import.meta.glob("./**/*.{js,ts,gjs,gts}", { eager: true });
+      import { start } from './test-helper';
+
+      // ember-exam's vite support needs an explicit map of
+      // { modulePath: () => import(modulePath) } so its load-balanced test
+      // loader can lazily `import()` only the modules assigned to this
+      // worker, instead of relying on the classic AMD `requirejs.entries`
+      // registry (which nothing under vite populates). Do NOT pass
+      // `{ eager: true }` here - that would import (and thus execute/
+      // register) every test module up front on every worker, defeating
+      // `--load-balance`/`--parallel`.
+      const availableModules = {
+        ...import.meta.glob('./**/*-test.{js,ts,gjs,gts}'),
+      };
+
+      start({ availableModules });
     </script>
 
     {{content-for "body-footer"}}

--- a/tests/dont-write-new-tests-here/tests/test-helper.js
+++ b/tests/dont-write-new-tests-here/tests/test-helper.js
@@ -16,8 +16,8 @@ import { setConfig, setTestId } from '@warp-drive/holodeck';
 import { Model, restoreDeprecatedModelRequestBehaviors } from '@warp-drive/legacy/model';
 import { restoreDeprecatedStoreBehaviors } from '@warp-drive/legacy/store';
 
-import Application from '../app';
-import config from '../config/environment';
+import Application from '../app/app';
+import config from '../app/config/environment';
 
 restoreDeprecatedStoreBehaviors(Store);
 restoreDeprecatedModelRequestBehaviors(Model);

--- a/tests/dont-write-new-tests-here/tests/test-helper.js
+++ b/tests/dont-write-new-tests-here/tests/test-helper.js
@@ -7,7 +7,7 @@ import { getPendingWaiterState } from '@ember/test-waiters';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
 
-import start from 'ember-exam/test-support/start';
+import { start as startEmberExam } from 'ember-exam/addon-test-support';
 
 import { setBuildURLConfig } from '@ember-data/request-utils';
 import configureAsserts from '@ember-data/unpublished-test-infra/test-support/asserts/index';
@@ -192,4 +192,16 @@ QUnit.hooks.afterEach(function (assert) {
 
 setup(QUnit.assert);
 setApplication(Application.create(config.APP));
-start({ setupEmberOnerrorValidation: false, setupTestIsolationValidation: true });
+
+// under vite, ember-exam's test loader needs an explicit map of
+// { modulePath: () => import(modulePath) } (built from `import.meta.glob`
+// in tests/index.html and passed in here as `availableModules`) instead of
+// relying on the classic AMD `requirejs.entries` registry to discover and
+// lazily load test modules for `--load-balance`/`--parallel` support.
+export async function start(options) {
+  await startEmberExam({
+    setupEmberOnerrorValidation: false,
+    setupTestIsolationValidation: true,
+    ...options,
+  });
+}

--- a/tests/dont-write-new-tests-here/tsconfig.json
+++ b/tests/dont-write-new-tests-here/tsconfig.json
@@ -20,7 +20,7 @@
     "experimentalDecorators": true,
     "incremental": true,
     "declaration": true,
-    "types": ["@glint/ember-tsc/types", "ember-source/types"],
+    "types": ["@glint/ember-tsc/types", "ember-source/types", "@embroider/core/virtual"],
     "paths": {
       "main-test-app/*": ["./app/*"],
       "@ember-data/adapter": ["../../packages/adapter/unstable-preview-types"],

--- a/tests/dont-write-new-tests-here/types/index.d.ts
+++ b/tests/dont-write-new-tests-here/types/index.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@embroider/core/virtual" />

--- a/tests/dont-write-new-tests-here/vite.config.mjs
+++ b/tests/dont-write-new-tests-here/vite.config.mjs
@@ -5,6 +5,13 @@ import { babel } from '@rollup/plugin-babel';
 export default defineConfig({
   build: {
     outDir: 'dist-test',
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to
+    // `'terser'` for production builds unless something else is
+    // configured, which would require adding `terser` as a devDependency
+    // just for this test app. Use esbuild's (already-bundled, faster)
+    // minifier instead - exact minification output doesn't matter here
+    // since main-test-app is never published/shipped.
+    minify: 'esbuild',
   },
   plugins: [
     classicEmberSupport(),

--- a/tests/dont-write-new-tests-here/vite.config.mjs
+++ b/tests/dont-write-new-tests-here/vite.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import { extensions, classicEmberSupport, ember } from '@embroider/vite';
+import { babel } from '@rollup/plugin-babel';
+
+export default defineConfig({
+  build: {
+    outDir: 'dist-test',
+  },
+  plugins: [
+    classicEmberSupport(),
+    ember(),
+    // extra plugins here
+    babel({
+      babelHelpers: 'runtime',
+      extensions,
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

CI profiling showed `browser-tests` (Test Chrome) spends ~90% of its ~9min runtime on the ember-cli/broccoli build itself (Development ~3m10s + Production ~3m46s), while actual QUnit execution for the 5,349 tests is only ~1 minute ("Avg Duration of all 5349 tests: 39ms"). This same suite also runs 3 more times in `special-build-tests`, so the build-tool bottleneck compounds across ~5 CI runs.

This PR swaps the broccoli build for `tests/dont-write-new-tests-here` (`main-test-app`) for a vite-based build via `@embroider/vite` + `@embroider/compat`'s `compatBuild`, following the pattern already proven in this repo by `tests/vite-basic-compat` and `tests/performance`. **Test execution itself (QUnit/ember-qunit/testem/ember-exam) is unchanged.**

Naming approach: **in-place script replacement**. `build:tests`/`build:production`/`test`/`test:production` script names in `package.json` are kept exactly as-is — `ember build --output-path=dist-test` still works because `compatBuild(app, buildOnce)`'s returned broccoli tree internally spawns `vite build` via `buildOnce`. No changes to `.github/workflows/main.yml` or `turbo.json` were needed.

## Key fixes made along the way

- **`app/app.ts`**: added `Resolver.withModules(compatModules)` (from `@embroider/virtual/compat-modules`), required under `@embroider/vite` for classic `owner.lookup('service:...')`/`owner.lookup('transform:...')` etc. to resolve at all (mirrors `tests/performance/app/app.js`). Without it, virtually every test touching the store failed with `undefined` lookups.
- **`package.json`**: added an `exports` self-reference map (`"./*": "./app/*"`), required for classic modulePrefix-based container lookups to resolve at all under vite.
- **`ember-cli-build.js`**: added `packageRules` with `safeToIgnore` component rules for a few tests that dynamically `owner.register('component:...')` and invoke it via angle-bracket hbs (`has-many-test.js` and a few others), since embroider's static resolver otherwise emits an unresolvable `@embroider/virtual/components/*` import for them.
- **`package.json build:production`**: added `FORCE_BUILD_TESTS=true` — without it, `@embroider/vite` only includes `tests/index.html` in the build for non-production modes, so the production build was silently missing the entire tests page.
- **`vite.config.mjs`**: explicitly set `build.minify: 'esbuild'` — `@embroider/vite`'s `ember()` plugin defaults to `'terser'` for production builds, which isn't installed; esbuild is bundled with vite already, faster, and fine for a test app that's never published.
- Upgraded `ember-exam` 9.1.0 → 10.1.3 and reworked `tests/test-helper.js` + `tests/index.html` to use ember-exam's new vite-aware `start()` API (`ember-exam/addon-test-support`, passing an `availableModules` map built from a non-eager `import.meta.glob`), per ember-exam's own "How to use with Vite" docs. The previous eager `import.meta.glob(..., { eager: true })` approach executed/registered every test module up front on every worker, defeating `--load-balance`/`--parallel` (each of the 4 workers ran the full 5349-test suite instead of a ~1/4 slice).

## Validation

Local:
- `build:tests` / `build:production` both succeed, including `tests/index.html` in the production build.
- Full dev suite (`pnpm run test`, 4-way `--load-balance`): **5344 passed / 0 failed / 5 skipped** (Total 5349, matching the pre-migration baseline count and the same "39ms avg" duration).
- Full production suite (`pnpm run test:production`): **5189 passed / 0 failed / 160 skipped**.
- `WARP_DRIVE_FEATURE_OVERRIDE=ENABLE_ALL_OPTIONAL`: **5344 passed / 0 failed / 5 skipped**.
- `WARP_DRIVE_FEATURE_OVERRIDE=DISABLE_ALL`: **5344 passed / 0 failed / 5 skipped**.
- `EMBER_DATA_FULL_COMPAT=true` (production): **5174 passed / 0 failed / 171 skipped**.
- Removed now-dead broccoli-only devDependencies (`broccoli-concat`, `broccoli-merge-trees`, `broccoli-stew`, `broccoli-string-replace`, `broccoli-test-helper`, `broccoli-uglify-sourcemap`, `webpack`) after grepping for direct usage (none found).

CI (this PR, after the fixes above):
- ✅ `Test Chrome` (the primary target job) — pass, 8m21s
- ✅ `Enable All In-progress Features` / `Disable All In-progress Features` / `Remove All Deprecations` (the three `special-build-tests` scenarios) — all pass
- ✅ `lint`, `test`, `vite`, all four `Smoke *Types*` jobs — pass
- ❌ `lts (ember-lts-*)` / `releases (ember-canary/beta)` — fail, but due to an unrelated `ERR_PNPM_TRUST_DOWNGRADE` supply-chain trust-check error on `@oxc-parser/binding-linux-arm-gnueabihf` encountered during `ember try:one`'s own dependency install step, not anything related to this change. These jobs run `ember try:one <scenario> --skip-cleanup; pnpm build:tests; pnpm run test` directly and are worth re-checking after this lands, but the failure is external/environmental.

Two earlier CI failures (`Test Chrome` and the `Smoke *Types*` jobs, on the first push) were also unrelated: the pre-existing `ember-data:build:pkg` (`tsdown: not found`/`Permission denied`) flake during the shared setup step, which is exactly the flake called out as pre-existing/known — a rerun cleared it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)