### PR TITLE
fix: exempt aged packages from trustPolicy downgrade check

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,19 @@ blockExoticSubdeps: true
 ##
 trustPolicy: no-downgrade
 
+## Trust-downgrade checks are only meaningful for *recently* published
+## versions, where a drop in provenance is a real signal of a hijacked
+## account. For a version published long enough ago that the community
+## would have already flagged an actual incident, a missing/weaker trust
+## signal is far more likely to be inconsistent publish tooling (common
+## for native-binary packages that ship per-platform builds, e.g.
+## @oxc-parser's platform binaries) than an active compromise.
+##
+## Matches minimumReleaseAge (10080 minutes = 7 days) so we're not
+## flagging anything we'd already consider "aged past the danger window".
+##
+trustPolicyIgnoreAfter: 10080
+
 packages:
   - "packages/*"
   - "tools/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,10 +47,13 @@ trustPolicy: no-downgrade
 ## for native-binary packages that ship per-platform builds, e.g.
 ## @oxc-parser's platform binaries) than an active compromise.
 ##
-## Matches minimumReleaseAge (10080 minutes = 7 days) so we're not
-## flagging anything we'd already consider "aged past the danger window".
+## 1051200 minutes = 2 years -- long enough that "published a while ago"
+## reliably means "aged past the danger window", rather than tying this to
+## the much shorter minimumReleaseAge above, which is about delaying
+## brand-new releases rather than judging whether a trust regression is
+## still a meaningful signal.
 ##
-trustPolicyIgnoreAfter: 10080
+trustPolicyIgnoreAfter: 1051200
 
 packages:
   - "packages/*"


### PR DESCRIPTION
## Summary

`trustPolicy: no-downgrade`, added in #10688, is currently breaking every `lts`/`releases` job on `main` (and on any open PR) with:

```
ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for "@oxc-parser/binding-win32-x64-msvc@0.82.3" (possible package takeover)
This error happened while installing the dependencies of unplugin-isolated-decl@0.15.1
```

This is a false positive. pnpm's trust check compares by publish-date ordering across a package's entire history, not by the version actually being resolved — so any long-stable, widely-used package that predates npm provenance adoption (e.g. `semver@6.3.1`, also observed failing an `ember-lts-5.4` run) looks like a "downgrade" the moment some unrelated later release of it adopts provenance. Native multi-platform packages like `@oxc-parser`'s per-platform binaries make this worse, since provenance coverage across platform builds/releases is often inconsistent to begin with.

## Fix

Add `trustPolicyIgnoreAfter: 1051200` (2 years) so the downgrade check only applies to packages published within that window — where a regression is actually a meaningful signal — instead of flagging already-aged, widely-used releases. (Originally landed as 7 days to match `minimumReleaseAge`, but that setting answers a different question — how long to wait before trusting a *brand-new* release — not how old a release needs to be before a trust regression stops being meaningful. 2 years gives a much wider margin while still catching anything actually recent.)

## Test plan
- [x] Reproduced the failure locally: `pnpm exec ember try:one ember-lts-3.28 --skip-cleanup` failed with the same `ERR_PNPM_TRUST_DOWNGRADE` before this change.
- [x] Reproduced the `semver@6.3.1` variant too: `pnpm exec ember try:one ember-lts-5.4 --skip-cleanup` failed the same way before the fix, succeeded after.
- [x] `pnpm config get trustPolicyIgnoreAfter` confirms the setting parses (`1051200`).
- [ ] CI green on this PR's own `lts`/`releases` jobs (this PR is itself a live test of the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)