### PR TITLE
ci: install mkcert directly instead of via Homebrew

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -88,18 +88,26 @@ runs:
       with:
         repo-token: ${{ inputs.repo-token }}
 
-    - name: Set Up Homebrew
-      if: ${{ inputs.with-cert == 'true' }}
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-
     - name: 'Setup SSL Cert Infra'
       if: ${{ inputs.with-cert == 'true' }}
       shell: bash
+      # We only need the mkcert binary itself, so we install it directly from
+      # its GitHub release instead of via Homebrew. The runner image ships
+      # Homebrew preinstalled, but the setup-homebrew action still ran a full
+      # `brew update` (git-fetching Homebrew/brew + refreshing the formula
+      # index) before `brew install mkcert` could run, costing ~20s per job
+      # for a stable, rarely-updated formula. Pinning the version + verifying
+      # its checksum keeps this at least as trustworthy as the Homebrew path.
       run: |
         sudo apt-get -y update
-        sudo apt install libnss3-tools
-        brew install mkcert
+        sudo apt-get -y install libnss3-tools
+
+        MKCERT_VERSION=v1.4.4
+        MKCERT_SHA256=6d31c65b03972c6dc4a14ab429f2928300518b26503f58723e532d1b0a3bbb52
+        curl -fsSL -o /tmp/mkcert "https://github.com/FiloSottile/mkcert/releases/download/${MKCERT_VERSION}/mkcert-${MKCERT_VERSION}-linux-amd64"
+        echo "${MKCERT_SHA256}  /tmp/mkcert" | sha256sum -c -
+        chmod +x /tmp/mkcert
+        sudo mv /tmp/mkcert /usr/local/bin/mkcert
 
     - name: 'Setup DBus for Chrome'
       shell: bash


### PR DESCRIPTION
## Summary

Profiled the "Test Chrome" job's setup step and found the SSL cert setup (needed for holodeck's mock HTTPS server) was spending ~20s on `Homebrew/actions/setup-homebrew` before installing `mkcert`. The runner image already ships Homebrew preinstalled — that action step was just running a full `brew update` (git-fetching `Homebrew/brew` + refreshing the formula index) for the sake of installing one stable, rarely-updated formula.

## Change

Install the `mkcert` binary directly from its GitHub release (pinned to v1.4.4, with a sha256 checksum check) instead of going through Homebrew. `packages/holodeck/server/ensure-cert.js` just shells out to the `mkcert` CLI directly, so nothing else needs Homebrew here.

This runs in every job that sets `with-cert: true`: `browser-tests`, `special-build-tests`, all 7 `lts` scenarios, and both `releases` scenarios — about 11 jobs per CI run, each saving ~20s.

## Test plan
- [x] Verified the pinned binary's sha256 matches what's checked into the script.
- [x] Verified the `sha256sum -c` verification command syntax against the actual downloaded binary.
- [x] Validated the composite action YAML still parses correctly.
- [ ] CI green on this PR (exercises the real `with-cert: true` path across `browser-tests`/`lts`/`releases`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)