### PR TITLE
fix: stop force-disabling turbo cache for build:pkg outside of releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "takeoff": "FORCE_COLOR=2 pnpm install --prefer-offline --reporter=append-only",
-    "prepare": "export TURBO_FORCE=true; turbo run build:pkg --log-order=stream --concurrency=23;",
+    "prepare": "turbo run build:pkg --log-order=stream --concurrency=23;",
     "release": "./tools/release/index.ts",
     "build": "turbo run build:pkg --log-order=stream --concurrency=10;",
     "sync": "pnpm --filter './packages/*' run --parallel --if-present sync",

--- a/tools/release/core/publish/steps/bump-versions.ts
+++ b/tools/release/core/publish/steps/bump-versions.ts
@@ -37,7 +37,11 @@ export async function bumpAllPackages(
   const nextVersion = strategy.get('root')?.toVersion;
   let commitCommand = `git commit -am "Release v${nextVersion}"`;
 
-  if (willPublish) commitCommand = `pnpm install --no-frozen-lockfile && ` + commitCommand;
+  // TURBO_FORCE=true is intentional here (and only here): package builds are
+  // otherwise allowed to use turbo's cache, but a real publish must never
+  // ship a package built from a stale/cached artifact, so we force a fresh
+  // `build:pkg` for every package as part of the release install.
+  if (willPublish) commitCommand = `TURBO_FORCE=true pnpm install --no-frozen-lockfile && ` + commitCommand;
   else commitCommand = `pnpm install && ` + commitCommand;
   commitCommand += ` && git tag v${nextVersion}`;
 

--- a/turbo.json
+++ b/turbo.json
@@ -81,14 +81,21 @@
     /////////////////////////////////////////////////
 
     "lint": {
-      "inputs": ["eslint.*", "tsconfig.json", "tsconfig.tsbuildinfo"],
+      // $TURBO_DEFAULT$ is required here or these `inputs` REPLACE (rather
+      // than add to) turbo's default file-hashing, which is every git-tracked
+      // file in the package. Without it, this task's hash was blind to any
+      // actual source-file edits (only eslint config / tsconfig / tsbuildinfo
+      // could bust the cache), so a cached "lint passed" could be served for
+      // code that was never actually linted.
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig.tsbuildinfo"],
       "dependsOn": ["^build:pkg"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only"
     },
 
     "check:types": {
-      "inputs": ["tsconfig.json", "tsconfig.tsbuildinfo"],
+      // See the $TURBO_DEFAULT$ note on `lint` above — same bug applied here.
+      "inputs": ["$TURBO_DEFAULT$", "tsconfig.tsbuildinfo"],
       "dependsOn": ["^build:pkg"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only"
@@ -100,6 +107,8 @@
         "src/**",
         "tests/**",
         "app/**",
+        "config/**",
+        "public/**",
         "ember-cli-build.js",
         "addon-main.*",
         "tsconfig.json",
@@ -137,6 +146,8 @@
         "src/**",
         "tests/**",
         "app/**",
+        "config/**",
+        "public/**",
         "ember-cli-build.js",
         "addon-main.*",
         "tsconfig.json",


### PR DESCRIPTION
## Summary

Follow-up to the CI throughput investigation: the biggest chunk of the "Test Chrome" job's setup step (~47s of ~87s) turned out to be `pnpm install`'s `prepare` script rebuilding all ~35 workspace packages via `turbo run build:pkg` — and it was **never able to use turbo's cache**, because the script hardcoded `TURBO_FORCE=true`, unconditionally, on every single install (local dev and CI alike).

## Changes

1. **Remove the blanket `TURBO_FORCE=true`** from the root `prepare` script. `build:pkg` now caches normally.
2. **Keep forcing fresh builds specifically for releases.** Since a real publish must never ship a stale/cached artifact, `TURBO_FORCE=true` is now set explicitly on the release flow's own install step (`tools/release/core/publish/steps/bump-versions.ts`, in the `willPublish` branch only).
3. **Audited `turbo.json` for other cache-busting gaps** while in there, and found two real ones:
   - `lint` and `check:types` declared explicit `inputs` without the `$TURBO_DEFAULT$` sentinel. Turbo's semantics: an explicit `inputs` array *replaces* the default file set (which is every git-tracked file in the package), it doesn't add to it. So these tasks' cache keys were only sensitive to `eslint.config.mjs`/`tsconfig.json`/`tsconfig.tsbuildinfo` — **never to the actual source files being linted or type-checked**. This is a correctness bug, not just a performance one: a stale "lint passed" result could be served for code that was never actually linted. Confirmed empirically (see test plan).
   - `build:tests`/`build:production` were missing `config/**` and `public/**` — every Ember test app here has a `config/` dir (environment.js, targets.js, optional-features.json) that affects the build, and some have `public/` fixtures bundled into output. Neither would have busted the cache.

## Test plan

All verified locally against a fresh worktree checkout:

- [x] Cold `pnpm install`: `build:pkg` → `35 successful, 35 total`, `0 cached, 35 total` (~18s for the build:pkg pass alone, ~47s including the rest of the composite setup action in CI).
- [x] Re-running `turbo run build:pkg` immediately after, no changes: `35 successful, 35 total`, **`35 cached, 35 total`, 587ms, FULL TURBO**.
- [x] `turbo run lint --filter=@ember-data/model --dry=json` before this fix: hash unchanged after editing `packages/model/src/index.ts`. After this fix: hash changes (`db4d8e54...` → `c1578ac7...`) as expected, and `src/**` files now appear in the task's resolved `inputs`.
- [x] `turbo run build:tests --filter=json-api --dry=json`: `config/environment.js`, `config/optional-features.json`, `config/targets.js` now appear in resolved inputs (previously absent).
- [x] Ran the real `pnpm exec turbo run lint --filter=@ember-data/model` (not just `--dry`) to confirm it still executes correctly end-to-end.
- [ ] CI green on this PR (its own `lint`/`Test Chrome`/etc. jobs exercise the changed `prepare` script directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)