### PR TITLE
fix: exclude hosted-git-info@6.1.3 from trustPolicy no-downgrade check

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,18 @@ trustPolicy: no-downgrade
 ##
 trustPolicyIgnoreAfter: 1051200
 
+## hosted-git-info@6.1.3 (2024-11-21) is a transitive dependency of the
+## frozen ember-cli@4.12.3 fixture used by the ember-lts-3.28 ember-try
+## scenario. It isn't old enough yet to clear trustPolicyIgnoreAfter above
+## (needs ~2026-11-21), but it never had provenance to begin with -- the
+## "downgrade" is pnpm comparing it against a *later major* (7.x/8.x) that
+## added provenance, not an actual regression within the 6.x line. See
+## https://github.com/pnpm/pnpm/issues/10202. ember-cli@4.12.3 is a fixed,
+## never-changing version, so this pin is safe to carry indefinitely.
+##
+trustPolicyExclude:
+  - hosted-git-info@6.1.3
+
 packages:
   - "packages/*"
   - "tools/*"


### PR DESCRIPTION
## Summary

Follow-up to #10710. `trustPolicyIgnoreAfter: 1051200` (2 years) doesn't cover `hosted-git-info@6.1.3` yet — it was published 2024-11-21, so it needs until ~2026-11-21 to age out. This keeps `ember-lts-3.28`'s `Basic tests` job red (see e.g. https://github.com/warp-drive-data/warp-drive/actions/runs/32435767721/job/96637353204):

```
ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for "hosted-git-info@6.1.3" (possible package takeover)
This error happened while installing the dependencies of ember-cli@4.12.3
 at npm-package-arg@10.1.0
```

The "downgrade" pnpm detects here is a known false-positive pattern (see [pnpm/pnpm#10202](https://github.com/pnpm/pnpm/issues/10202)): pnpm compares trust evidence against *any* later-published version of the package regardless of major, so once `hosted-git-info@7.x`/`8.x` gained npm provenance, every subsequent `6.x` release reads as a "downgrade" even though the `6.x` line itself never had provenance to begin with. pnpm's maintainer explicitly recommends `trustPolicyExclude` for this case.

`hosted-git-info@6.1.3` only shows up here as a transitive dependency of the frozen `ember-cli@4.12.3` fixture used by the `ember-lts-3.28` `ember-try` scenario — a version that will never change — so excluding this exact pin is safe to carry indefinitely, without weakening the 2-year policy for anything else.

## Verification

Reproduced and confirmed the fix in an isolated scratch repo:
- `pnpm install` against a `package.json` depending on `npm-package-arg@10.1.0` (pulls `hosted-git-info@6.1.3`) fails with `ERR_PNPM_TRUST_DOWNGRADE` under the current config.
- Adding `trustPolicyExclude: [hosted-git-info@6.1.3]` resolves it cleanly.

## Test plan
- [ ] CI: `lts (ember-lts-3.28)` job goes green