### PR TITLE
fix: cjs-dist missing from turbo build:pkg cache outputs, breaking lint on cache hit

### DIFF
--- a/tools/release/core/publish/steps/generate-tarballs.ts
+++ b/tools/release/core/publish/steps/generate-tarballs.ts
@@ -526,7 +526,9 @@ async function makeTypesStable(pkg: Package) {
     );
   }
 
-  const hasInlineTypes = value.includes('./dist/index.d.ts');
+  // co-located types live under dist/ now, either as a literal "." entry
+  // (./dist/index.d.ts) or a wildcard subpath entry (./dist/*.d.ts)
+  const hasInlineTypes = value.includes('./dist/index.d.ts') || value.includes('./dist/*.d.ts');
 
   // enforce that the correct types directory is present
   const present = new Set(pkg.pkgData.files);

--- a/turbo.json
+++ b/turbo.json
@@ -48,6 +48,8 @@
         "addon-test-support/**",
         // V2-Addon convention
         "dist/**",
+        // secondary CJS build for packages exposing `.cjs` subpath exports
+        "cjs-dist/**",
         "unstable-preview-types/**",
         "declarations/**",
         "tsconfig.tsbuildinfo"


### PR DESCRIPTION
## Summary
- Diagnosed the `lint`/`Test Chrome` failures currently red on `main`. Root cause: `turbo.json`'s `build:pkg` task never declared `cjs-dist/**` in its `outputs`. `@warp-drive/utilities` (and other packages producing a secondary CJS build) get a turbo cache hit that restores `dist/**` but silently skips `cjs-dist/**`. `eslint-plugin-warp-drive` does `require('@warp-drive/utilities/string.cjs')` directly, so `core-tests`/`ember-data`/`@warp-drive/legacy-tests` lint fails with `Cannot find module '.../cjs-dist/string.cjs'` on any cache hit for that package. Confirmed locally: deleted `cjs-dist`, ran `turbo run build:pkg` again, got a cache hit, `cjs-dist` stayed missing. After adding it to `outputs`, the same repro correctly restores the directory.
- Also widened `generate-tarballs.ts`'s `makeTypesStable` `hasInlineTypes` check to recognize the wildcard dist export shape (`./dist/*.d.ts`), not just the literal `.` entry (`./dist/index.d.ts`). Packages that only expose subpath exports (no `.` entry) were misdiagnosed as missing a `declarations` directory during release packaging.

## Test plan
- [x] Reproduced the cache-hit bug locally (delete `cjs-dist`, force cache restore, confirm it stays missing pre-fix / gets restored post-fix)
- [x] `npx tsc --noEmit -p tools/release/tsconfig.json` clean for the `generate-tarballs.ts` change
- [ ] CI green on this PR