### PR TITLE
fix: stop tools/release/** from globally invalidating turbo's cache

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,8 +15,15 @@
     ".pnpm-workspace.yaml",
     "patches/*",
     ".github/**",
-    "./tools/release/**",
     "./tools/internal-config/**"
+    // NOTE: tools/release/** is intentionally NOT a global dependency.
+    // No package's build/test code imports anything from it, so it had no
+    // business invalidating every task's cache in the entire monorepo --
+    // it just meant any PR touching release tooling forced a full,
+    // unrelated rebuild for everyone. Release correctness against stale
+    // caches is instead guaranteed at the source: the release publish
+    // flow's own install step now sets TURBO_FORCE=true explicitly
+    // (see tools/release/core/publish/steps/bump-versions.ts).
   ],
 
   "envMode": "loose",


### PR DESCRIPTION
## Summary

Explains and fixes the "Test Chrome" job's timing variance (~4min to ~9min on runs that appeared not to be hitting cache at all).

`turbo.json`'s `globalDependencies` included `./tools/release/**`. Any change under `tools/release/` — including a completely unrelated one-line edit — invalidates turbo's cache hash for **every task in the entire monorepo**, not just release-related ones. This is exactly what happened in #10712 (the previous turbo-cache-fixes PR): it touched `tools/release/core/publish/steps/bump-versions.ts` as part of scoping `TURBO_FORCE=true` to releases, which reset the shared cache baseline for everyone — hence that PR's own CI run (and everyone else's until the cache re-warmed) saw a much lower hit rate and correspondingly longer `Test Chrome` runtime, since `pnpm turbo test --concurrency=1` runs everything serially and every miss adds directly to wall-clock time.

## Fix

Remove `./tools/release/**` from `globalDependencies`. Confirmed no package's build or test code imports anything from `tools/release/`, so it never needed this protection. Release correctness against stale caches is already guaranteed at the right layer: the release publish flow's own install step explicitly sets `TURBO_FORCE=true` (added in #10712), independent of this global-dependency list.

## Test plan
- [x] Before this fix: reverting one line in `tools/release/core/publish/steps/bump-versions.ts` changed the hash of a totally unrelated task (`@ember-data/store#build:pkg`).
- [x] After this fix: editing that same file leaves the unrelated task's hash unchanged, and it no longer appears in turbo's `globalCacheInputs.files` list.
- [x] `pnpm exec turbo run build:pkg` still gets a full `35 cached, 35 total, FULL TURBO` cache hit after install.
- [ ] CI green (this PR's own `Test Chrome` job should now run at the fast end of the range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)