### PR TITLE
fix: update stale DT-types smoke test assertions after tsdown migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ concat-stats-for
 dist
 dist-*
 cjs-dist
+# transient release-packaging output synthesized from dist/ for alpha/beta
+# types-strategy packages (see tools/release/core/publish/steps/generate-tarballs.ts)
+unstable-preview-types
+preview-types
 tmp
 packages/*/addon
 .svelte-kit/

--- a/tests/smoke-tests/dt-types/app/type-tests.ts
+++ b/tests/smoke-tests/dt-types/app/type-tests.ts
@@ -15,18 +15,11 @@ import Adapter from '@ember-data/adapter/-private/build-url-mixin';
 expectTypeOf<typeof StoreX>().not.toBeAny();
 
 import Store from '@ember-data/store';
-// @ts-expect-error this exists in the real package, but not DT Types
 import RequestManager from '@ember-data/request';
 import { BuildURLMixin } from '@ember-data/adapter';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
 import jsonapi from '@ember-data/json-api';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
 import { adapterFor } from '@ember-data/legacy-compat';
 import Model from '@ember-data/model';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
 import { setBuildURLConfig } from '@ember-data/request-utils';
 import Serializer from '@ember-data/serializer';
 
@@ -37,12 +30,12 @@ expectTypeOf<typeof Store>().not.toBeAny();
 expectTypeOf<typeof Model>().not.toBeAny();
 expectTypeOf<typeof Model>().toHaveProperty('reopen');
 expectTypeOf<typeof Serializer>().not.toBeAny();
-// @ts-expect-error no DT Types
 expectTypeOf<typeof RequestManager>().not.toBeAny();
+// @ts-expect-error @ember/object/mixin's DT types declare `Mixin<T, Base>` with
+// no default for `T`, but this package's own `BuildURLMixin: Mixin` annotation
+// is written against ember-source/types' non-generic `Mixin` -- the two ambient
+// declarations have incompatible arity and can't both be satisfied at once.
 expectTypeOf<typeof BuildURLMixin>().not.toBeAny();
-// @ts-expect-error no DT Types
 expectTypeOf<typeof jsonapi>().not.toBeAny();
-// @ts-expect-error no DT Types
 expectTypeOf<typeof setBuildURLConfig>().not.toBeAny();
-// @ts-expect-error no DT Types
 expectTypeOf<typeof adapterFor>().not.toBeAny();


### PR DESCRIPTION
## Summary
Diagnosed the remaining Smoke DT/Native Types failures on #10696 (unrelated to that PR -- reproduced independently on a fresh branch off `main`, and confirmed via `gh pr checks` on unrelated PR #10699 that this predates Phase A/B/C entirely).

- `tests/smoke-tests/dt-types/app/type-tests.ts` had `@ts-expect-error` directives asserting several imports (`@ember-data/request`, `json-api`, `legacy-compat`, `request-utils`) resolve to `any` under classic DefinitelyTyped-style consumption. They no longer do -- their published types got more complete, most likely as a side effect of the recent tsdown migration of these packages. TS flagged the directives as unused; removed them.
- `expectTypeOf<typeof BuildURLMixin>().not.toBeAny()` fails for a separate, unrelated, unfixable-from-our-side reason: `@ember/object/mixin`'s classic DT types declare `Mixin<T, Base>` requiring an explicit `T` with no default, but `warp-drive-packages/legacy`'s own `BuildURLMixin: Mixin` annotation is written against `ember-source/types`' non-generic `Mixin` -- the two ambient declarations have incompatible arity, so no single annotation on our side can satisfy both type systems at once. Added a `@ts-expect-error` with rationale, matching the file's existing pattern.
- Restored `unstable-preview-types`/`preview-types` to `.gitignore`. Phase C (#10715) dropped these entries assuming dist-colocation made the directories disappear entirely, but `generate-tarballs.ts`'s alpha/beta path still synthesizes them transiently inside each package during release packaging (and while running these smoke tests locally), leaving untracked cruft without the ignore entry.

## Test plan
- [x] `bun tests/smoke-tests/run.ts dt-types pnpm --reuse-tars` passes locally
- [x] `bun tests/smoke-tests/run.ts native-types pnpm --reuse-tars` passes locally
- [ ] CI green on this PR