### PR TITLE
fix: close the diagnostic/holodeck port race blocking test parallelization

### DIFF
--- a/packages/diagnostic/server/index.js
+++ b/packages/diagnostic/server/index.js
@@ -74,7 +74,14 @@ export async function launch(config) {
     const { checkPort } = await import('./bun/port.js');
     const hostname = config.hostname ?? 'localhost';
     const protocol = config.protocol ?? 'https';
-    const port = await getPort(config, checkPort);
+    let { port, release } = await getPort(config, checkPort);
+    // Belt-and-suspenders: if the process dies without running through
+    // state.safeCleanup (uncaught exception, hard kill, etc.), still release
+    // the port lock synchronously on exit so it doesn't leak as "stale" for
+    // longer than necessary (port-lock.js also self-heals via PID liveness
+    // checks, but there's no reason to wait on that when we can clean up
+    // eagerly).
+    process.on('exit', () => release());
 
     const serveOptions = {
       port,
@@ -130,6 +137,8 @@ export async function launch(config) {
     process.on('SIGTERM', () => void handleTerminationSignal('SIGTERM'));
     process.on('SIGQUIT', () => void handleTerminationSignal('SIGQUIT'));
 
+    addCloseHandler(state, () => release());
+
     if (protocol === 'https') {
       if (!config.key && !config.cert) {
         const info = await getCertInfo();
@@ -151,15 +160,36 @@ export async function launch(config) {
     }
 
     try {
-      state.server = Bun.serve({
-        ...serveOptions,
-        development: false,
-        exclusive: true,
-        fetch(req, server) {
-          return handleBunFetch(config, state, req, server);
-        },
-        websocket: buildHandler(config, state),
-      });
+      // The lock in port-lock.js prevents two of our own processes from
+      // racing for the same pair, but it can't account for a port held by
+      // something outside that convention (a leftover process from a prior
+      // run that hasn't exited yet, an unrelated local service, etc). Retry
+      // against a fresh, freshly-locked port pair a few times before giving
+      // up, rather than crashing on the first collision.
+      const MAX_BIND_ATTEMPTS = 5;
+      for (let attempt = 1; ; attempt++) {
+        try {
+          state.server = Bun.serve({
+            ...serveOptions,
+            development: false,
+            exclusive: true,
+            fetch(req, server) {
+              return handleBunFetch(config, state, req, server);
+            },
+            websocket: buildHandler(config, state),
+          });
+          break;
+        } catch (e) {
+          if (e?.code !== 'EADDRINUSE' || attempt >= MAX_BIND_ATTEMPTS) {
+            throw e;
+          }
+          debug(`Port ${port} became unavailable before bind, picking a new port pair (attempt ${attempt})`);
+          release();
+          ({ port, release } = await getPort({ ...config, port: 0, defaultPort: port + 2 }, checkPort));
+          state.port = port;
+          serveOptions.port = port;
+        }
+      }
 
       addCloseHandler(state, () => {
         state.browsers?.forEach((browser) => {

--- a/packages/diagnostic/server/utils/port-lock.js
+++ b/packages/diagnostic/server/utils/port-lock.js
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { debug } from './debug.js';
+
+// Every test app's client-side test-helper derives holodeck's URL as
+// `window.location.port + 1` (see e.g. tests/*/tests/test-helper.{js,ts}),
+// so a diagnostic server on port N always needs its holodeck companion on
+// port N + 1. A bare TCP check-then-bind for N is not enough to make that
+// pairing safe: many packages' test suites start concurrently (turbo running
+// multiple packages' `test` tasks at once), and the gap between diagnostic
+// binding N and holodeck binding N + 1 (which happens later, after cert
+// setup) is wide enough for a sibling process's own port discovery to see
+// "N + 1 is free" and claim it as *its* diagnostic port first.
+//
+// This lock closes that gap with a filesystem-based mutex: before any
+// process attempts to bind a port pair, it must atomically reserve both
+// ports here. Only one process can hold a given port's lock file at a time
+// (`fs.openSync(path, 'wx')` is atomic create-if-not-exists), so no two
+// concurrent processes can ever be handed overlapping port pairs.
+const LOCK_DIR = path.join(os.tmpdir(), 'warp-drive-diagnostic-port-locks');
+
+function lockPathFor(port) {
+  return path.join(LOCK_DIR, `${port}.lock`);
+}
+
+function isPidAlive(pid) {
+  if (!Number.isInteger(pid)) return false;
+  try {
+    // signal 0 does not kill the process, it just probes whether it exists
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Reclaim a lock file left behind by a process that died without cleanup. */
+function clearIfStale(lockPath) {
+  let heldBy;
+  try {
+    heldBy = Number(fs.readFileSync(lockPath, 'utf8').trim());
+  } catch {
+    // lock file vanished between our EEXIST and this read -- treat as cleared
+    return true;
+  }
+  if (isPidAlive(heldBy)) {
+    return false;
+  }
+  try {
+    fs.rmSync(lockPath, { force: true });
+    debug(`Reclaimed stale port lock at ${lockPath} (owning pid ${heldBy} is no longer running)`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tryAcquireOne(port) {
+  fs.mkdirSync(LOCK_DIR, { recursive: true });
+  const lockPath = lockPathFor(port);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.writeSync(fd, String(process.pid));
+      fs.closeSync(fd);
+      return true;
+    } catch (e) {
+      if (e.code !== 'EEXIST') throw e;
+      if (attempt === 0 && clearIfStale(lockPath)) {
+        continue; // stale lock cleared, try to claim it once more
+      }
+      return false;
+    }
+  }
+  return false;
+}
+
+function releaseOne(port) {
+  const lockPath = lockPathFor(port);
+  try {
+    const heldBy = Number(fs.readFileSync(lockPath, 'utf8').trim());
+    if (heldBy === process.pid) {
+      fs.rmSync(lockPath, { force: true });
+    }
+  } catch {
+    // already gone -- nothing to release
+  }
+}
+
+/**
+ * Attempts to atomically reserve the pair [port, port + 1] for this process.
+ * Returns true on success. On failure (either port already locked by a live
+ * process), releases any partial reservation and returns false so the caller
+ * can move on to the next candidate port.
+ */
+export function acquirePortPair(port) {
+  if (!tryAcquireOne(port)) {
+    return false;
+  }
+  if (!tryAcquireOne(port + 1)) {
+    releaseOne(port);
+    return false;
+  }
+  return true;
+}
+
+export function releasePortPair(port) {
+  releaseOne(port);
+  releaseOne(port + 1);
+}

--- a/packages/diagnostic/server/utils/port.js
+++ b/packages/diagnostic/server/utils/port.js
@@ -1,33 +1,63 @@
 import { DEFAULT_PORT, MAX_PORT_TRIES } from './const.js';
 import { debug } from './debug.js';
+import { acquirePortPair, releasePortPair } from './port-lock.js';
 
-async function discoverPort(defaultPort, checkPort) {
-  debug(`Discovering available port starting from default port of ${defaultPort}`);
+/**
+ * Verifies (via the supplied TCP-level `checkPort`) that both `port` and
+ * `port + 1` are free. This is a secondary, best-effort check on top of the
+ * filesystem lock in port-lock.js -- it catches ports held by processes that
+ * aren't participating in our lock convention (e.g. an unrelated local dev
+ * server), but on its own it is not race-free, since checking a port and
+ * binding to it are two separate operations. The lock is what actually
+ * prevents two of *our* concurrently-starting processes from colliding.
+ */
+async function pairIsFree(port, checkPort) {
+  return (await checkPort(port)) && (await checkPort(port + 1));
+}
+
+async function discoverPortPair(defaultPort, checkPort) {
+  debug(`Discovering an available port pair starting from default port of ${defaultPort}`);
   let port = defaultPort;
 
   for (let i = 0; i < MAX_PORT_TRIES; i++) {
-    if (await checkPort(port)) {
-      return port;
+    if (acquirePortPair(port)) {
+      if (await pairIsFree(port, checkPort)) {
+        return port;
+      }
+      // TCP-level check failed even though we hold the lock -- something
+      // outside our lock convention is using one of these ports. Release
+      // and keep searching.
+      releasePortPair(port);
     }
     port++;
   }
 
-  throw new Error(`Could not find an available port in the range ${defaultPort} to ${port}`);
+  throw new Error(`Could not find an available port pair in the range ${defaultPort} to ${port}`);
 }
 
+/**
+ * Resolves the port a diagnostic server should bind to, returning both the
+ * chosen port and a `release()` callback the caller must invoke once the
+ * server (and its holodeck companion on port + 1, if any) are done with it.
+ */
 export async function getPort(config, checkPort) {
   if (typeof config.port === 'number') {
     if (config.port < 0 || config.port > 65535) {
       throw new Error(`Invalid port number: ${config.port}`);
     } else if (config.port === 0) {
-      debug('Port is set to 0, discovering available port');
-      return await discoverPort(config.defaultPort || DEFAULT_PORT, checkPort);
+      debug('Port is set to 0, discovering available port pair');
+      const port = await discoverPortPair(config.defaultPort || DEFAULT_PORT, checkPort);
+      return { port, release: () => releasePortPair(port) };
     } else {
-      await checkPort(config.port);
-      return config.port;
+      if (!acquirePortPair(config.port) || !(await pairIsFree(config.port, checkPort))) {
+        releasePortPair(config.port);
+        throw new Error(`Port ${config.port} (or ${config.port + 1}) is not available`);
+      }
+      return { port: config.port, release: () => releasePortPair(config.port) };
     }
   } else {
-    debug(`Port is not set, discovering available port`);
-    return await discoverPort(config.defaultPort || DEFAULT_PORT, checkPort);
+    debug(`Port is not set, discovering available port pair`);
+    const port = await discoverPortPair(config.defaultPort || DEFAULT_PORT, checkPort);
+    return { port, release: () => releasePortPair(port) };
   }
 }

--- a/packages/holodeck/server/bun.js
+++ b/packages/holodeck/server/bun.js
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import path from 'path';
 import { Worker, threadId, parentPort } from 'node:worker_threads';
 import {
+  bindWithRetry,
   compress,
   createCloseHandler,
   DEFAULT_PORT,
@@ -307,15 +308,17 @@ async function _createServer(options) {
     hostname: options.hostname ?? 'localhost',
   };
 
-  const server = Bun.serve({
-    fetch: app.fetch,
-    tls: {
-      key: KEY,
-      cert: CERT,
-    },
-    port: location.port,
-    hostname: location.hostname,
-  });
+  const server = await bindWithRetry(() =>
+    Bun.serve({
+      fetch: app.fetch,
+      tls: {
+        key: KEY,
+        cert: CERT,
+      },
+      port: location.port,
+      hostname: location.hostname,
+    })
+  );
 
   console.log(
     `\tServing Holodeck HTTP Mocks from ${chalk.yellow('https://') + chalk.magenta(location.hostname + ':') + chalk.yellow(location.port)}\n`

--- a/packages/holodeck/server/node.js
+++ b/packages/holodeck/server/node.js
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import path from 'path';
 import { Worker, threadId, parentPort } from 'node:worker_threads';
 import {
+  bindWithRetry,
   compress,
   createCloseHandler,
   DEFAULT_PORT,
@@ -308,23 +309,25 @@ async function _createServer(options) {
     hostname: options.hostname ?? 'localhost',
   };
 
-  const server = serve({
-    overrideGlobalObjects: true,
-    fetch: app.fetch,
-    serverOptions: {
-      key: KEY,
-      cert: CERT,
-      // rejectUnauthorized: false,
-      // enableTrace: true,
-      // Allow HTTP/1.1 fallback for ALPN negotiation
-      // allowHTTP1: true,
-      // ALPNProtocols: ['h2', 'http/1.1', 'http/1.0'],
-      // origins: ['*'],
-    },
-    createServer: createSecureServer,
-    port: location.port,
-    hostname: location.hostname,
-  });
+  const server = await bindWithRetry(() =>
+    serve({
+      overrideGlobalObjects: true,
+      fetch: app.fetch,
+      serverOptions: {
+        key: KEY,
+        cert: CERT,
+        // rejectUnauthorized: false,
+        // enableTrace: true,
+        // Allow HTTP/1.1 fallback for ALPN negotiation
+        // allowHTTP1: true,
+        // ALPNProtocols: ['h2', 'http/1.1', 'http/1.0'],
+        // origins: ['*'],
+      },
+      createServer: createSecureServer,
+      port: location.port,
+      hostname: location.hostname,
+    })
+  );
 
   console.log(
     `\tServing Holodeck HTTP Mocks from ${chalk.yellow('https://') + chalk.magenta(location.hostname + ':') + chalk.yellow(location.port)}\n`

--- a/packages/holodeck/server/utils.js
+++ b/packages/holodeck/server/utils.js
@@ -127,3 +127,58 @@ export function createCloseHandler(cb) {
     cb();
   };
 }
+
+/**
+ * Binds a server created by `createServerFn()`, retrying on the same port if
+ * it's already in use.
+ *
+ * Holodeck's port is never renegotiated on conflict -- every test app's
+ * client-side test-helper derives holodeck's URL as `window.location.port +
+ * 1` (the diagnostic server's own port, plus one), so holodeck must bind
+ * exactly the port it was asked for or the browser can never find it.
+ * Instead, this retries the *same* port a few times with a short delay, to
+ * ride out the narrow window where a concurrently-starting sibling process's
+ * diagnostic server hasn't released this exact port yet (see
+ * packages/diagnostic/server/utils/port-lock.js for the reservation scheme
+ * that's supposed to prevent that from happening at all -- this is a
+ * defense-in-depth fallback for anything outside that convention).
+ *
+ * `createServerFn` must synchronously create the server and start binding,
+ * returning the server instance. Some implementations (Bun.serve) throw
+ * synchronously on a bind failure; others (Node's http/http2 `.listen()`,
+ * which is what @hono/node-server uses under the hood) bind asynchronously
+ * and emit an 'error' event on the returned server instead of throwing. This
+ * handles both.
+ */
+export async function bindWithRetry(createServerFn, { maxAttempts = 5, retryDelayMs = 150 } = {}) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const server = createServerFn();
+      if (typeof server?.on !== 'function') {
+        // no event emitter to observe an async bind failure on -- the
+        // synchronous creation above already succeeded, so assume the bind
+        // did too (this is the Bun.serve path, which throws synchronously
+        // instead)
+        return server;
+      }
+      const bindError = await new Promise((resolve) => {
+        const onError = (e) => resolve(e);
+        server.once('error', onError);
+        setTimeout(() => {
+          server.off('error', onError);
+          resolve(null);
+        }, retryDelayMs);
+      });
+      if (!bindError) {
+        return server;
+      }
+      throw bindError;
+    } catch (e) {
+      if (e?.code !== 'EADDRINUSE' || attempt >= maxAttempts) {
+        throw e;
+      }
+      console.log(`\tPort in use, retrying bind (attempt ${attempt}/${maxAttempts})...`);
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+}


### PR DESCRIPTION
## Context

Part of an effort to remove `--concurrency=1` from `pnpm turbo test`/`test:production`, which was linearized years ago for reasons that are no longer fully documented. Investigating why raising concurrency isn't safe today turned up two independent, reproducible races:

1. **This PR**: a port-allocation race between `@warp-drive/diagnostic`'s dev server and its `@warp-drive/holodeck` mock-server companion.
2. A separate race in pnpm's injected-workspace-package bin-linking during concurrent `build:pkg` (surfaces as intermittent `Cannot find module .../dist/addon-shim.cjs` / `tsdown: No such file or directory` errors) — being fixed in a separate effort. Both need to land before concurrency can safely go up.

## The bug

Every test app's client-side test-helper derives holodeck's mock-server URL as `window.location.port + 1` — the diagnostic server's own port, plus one (see e.g. `tests/json-api/tests/test-helper.js`). So a diagnostic server on port N always needs its holodeck companion on port N + 1.

The existing port allocation was a bare TCP check-then-bind: `checkPort` (`packages/diagnostic/server/bun/port.js`) binds a probe socket, releases it, and reports the port "free" — the *actual* bind happens later. That gap is wide enough to matter here specifically because diagnostic binds port N immediately, but holodeck doesn't attempt to bind N + 1 until seconds later (after cert setup completes inside `config.setup`). A sibling process's own port discovery can see "N + 1 is free" in that window and claim it as *its own* diagnostic port, so by the time holodeck tries to bind N + 1, it's gone.

Reproduced directly: `pnpm exec turbo run test --filter='!main-test-app' --concurrency=4 --force` reliably hit:
```
Error: listen EADDRINUSE: address already in use ::1:7358
```

## Fix

1. **`packages/diagnostic/server/utils/port-lock.js`** (new) — a filesystem-based mutex. Before any process attempts to bind a port pair, it atomically reserves both ports (`fs.openSync(path, 'wx')` is atomic create-if-not-exists), so no two concurrent processes can be handed overlapping pairs. Self-heals locks left behind by processes that died without cleanup, by checking whether the owning PID is still alive.
2. **Defense in depth**, for anything outside that lock convention (a leftover process from a prior run, a genuinely occupied port): both the diagnostic server and holodeck (via a new `bindWithRetry` helper) now retry on `EADDRINUSE` instead of crashing outright. Diagnostic can pick a fresh locked pair and retry; holodeck can't renegotiate its port (the browser already assumes `+ 1`), so it retries the *same* port a few times with a short backoff.

## Test plan

- [x] Reproduced the failure: 3 consecutive forced (`--force`, no cache) `--concurrency=4` runs of the non-`main-test-app` suite before this fix — hit `EADDRINUSE` within a run or two.
- [x] After this fix: 3 consecutive forced `--concurrency=4` runs — **0/3 hit `EADDRINUSE`** (61/61, 61/61, and 60/61 — the one failure was an unrelated Chrome-launch watchdog timeout on my local machine, not a port collision; no `EADDRINUSE` appeared in that run either).
- [x] `node --check` on all changed files.
- [x] `pnpm exec turbo run lint --filter=@warp-drive/diagnostic --filter=@warp-drive/holodeck` passes clean.
- [ ] CI green.

Note: this PR alone does not flip `test`/`test:production`'s `--concurrency=1` — that should wait until the injected-deps race is also fixed and both have been validated together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)