### PR TITLE
fix: invoke tsdown directly via node to avoid racy bin-shim resolution

### DIFF
--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -16,10 +16,10 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/-warp-drive/package.json
+++ b/packages/-warp-drive/package.json
@@ -24,11 +24,11 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "tsdown --watch",
+    "start": "node node_modules/tsdown/dist/run.mjs --watch",
     "check:types": "tsc --noEmit"
   },
   "bin": {

--- a/packages/active-record/package.json
+++ b/packages/active-record/package.json
@@ -31,10 +31,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -15,10 +15,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "addon-main.cjs",

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -67,10 +67,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "build:tests": "rm -rf dist-test && cp -R test dist-test && mkdir -p dist-test/@warp-drive && cp -R dist dist-test/@warp-drive/diagnostic",
-    "build:pkg": "NODE_ENV=production tsdown",
+    "build:pkg": "NODE_ENV=production node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "peerDependencies": {
     "@ember/test-helpers": "5.2.0",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -15,10 +15,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "addon-main.cjs",

--- a/packages/holodeck/package.json
+++ b/packages/holodeck/package.json
@@ -39,11 +39,11 @@
   },
   "scripts": {
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "peerDependencies": {
     "@warp-drive/utilities": "workspace:*",

--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -15,10 +15,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/legacy-compat/package.json
+++ b/packages/legacy-compat/package.json
@@ -37,10 +37,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -38,10 +38,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -17,10 +17,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "addon-main.cjs",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -39,10 +39,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -15,10 +15,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -16,10 +16,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,10 +32,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "dependencies": {
     "@embroider/macros": "^1.20.6",

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -42,10 +42,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -36,7 +36,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "check:types": "tsc --noEmit"

--- a/specs/package.json
+++ b/specs/package.json
@@ -12,11 +12,11 @@
   "license": "MIT",
   "author": "",
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/tools/release/core/publish/steps/amend-for-unpkg.ts
+++ b/tools/release/core/publish/steps/amend-for-unpkg.ts
@@ -11,7 +11,9 @@ import { Package } from '../../../utils/package.ts';
  */
 function buildCommandFor(pkg: Package, outDir: string): string {
   const usesTsdown = fs.existsSync(path.join(pkg.projectPath, 'tsdown.config.mjs'));
-  return usesTsdown ? `pnpm exec tsdown --out-dir ${outDir}` : `pnpm exec vite build --outDir ${outDir}`;
+  return usesTsdown
+    ? `node node_modules/tsdown/dist/run.mjs --out-dir ${outDir}`
+    : `pnpm exec vite build --outDir ${outDir}`;
 }
 
 function extractValuePath(value: string): string {

--- a/warp-drive-packages/build-config/package.json
+++ b/warp-drive-packages/build-config/package.json
@@ -14,11 +14,11 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "build:pkg": "tsdown; tsdown -c ./tsdown.config-cjs.mjs;",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs; node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs;",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "tsdown --watch",
+    "start": "node node_modules/tsdown/dist/run.mjs --watch",
     "check:types": "tsc --noEmit"
   },
   "type": "module",

--- a/warp-drive-packages/core/package.json
+++ b/warp-drive-packages/core/package.json
@@ -13,12 +13,12 @@
     "directory": "warp-drive-packages/core"
   },
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/warp-drive-packages/ember/package.json
+++ b/warp-drive-packages/ember/package.json
@@ -15,11 +15,11 @@
     "ember-addon"
   ],
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
-    "start": "tsdown --watch",
+    "start": "node node_modules/tsdown/dist/run.mjs --watch",
     "check:types": "ember-tsc --noEmit"
   },
   "files": [

--- a/warp-drive-packages/experiments/package.json
+++ b/warp-drive-packages/experiments/package.json
@@ -44,10 +44,10 @@
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "peerDependencies": {
     "@sqlite.org/sqlite-wasm": "3.46.0-build2",

--- a/warp-drive-packages/json-api/package.json
+++ b/warp-drive-packages/json-api/package.json
@@ -13,12 +13,12 @@
     "directory": "warp-drive-packages/json-api"
   },
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/warp-drive-packages/legacy/package.json
+++ b/warp-drive-packages/legacy/package.json
@@ -13,12 +13,12 @@
     "directory": "warp-drive-packages/legacy"
   },
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/warp-drive-packages/react/package.json
+++ b/warp-drive-packages/react/package.json
@@ -18,12 +18,12 @@
     "warp-drive"
   ],
   "scripts": {
-    "build:pkg": "NODE_ENV=production tsdown",
+    "build:pkg": "NODE_ENV=production node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "addon-main.cjs",

--- a/warp-drive-packages/schema-dsl/package.json
+++ b/warp-drive-packages/schema-dsl/package.json
@@ -13,12 +13,12 @@
   "homepage": "https://github.com/warp-drive-data/warp-drive",
   "bugs": "https://github.com/warp-drive-data/warp-drive/issues",
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/warp-drive-packages/tc39-proposal-signals/package.json
+++ b/warp-drive-packages/tc39-proposal-signals/package.json
@@ -13,12 +13,12 @@
   "bugs": "https://github.com/warp-drive-data/warp-drive/issues",
   "keywords": [],
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "addon-main.cjs",

--- a/warp-drive-packages/utilities/package.json
+++ b/warp-drive-packages/utilities/package.json
@@ -13,12 +13,12 @@
     "directory": "warp-drive-packages/utilities"
   },
   "scripts": {
-    "build:pkg": "tsdown; tsdown -c ./tsdown.config-cjs.mjs;",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs; node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs;",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
     "sync": "echo \"syncing\"",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "dist",

--- a/warp-drive-packages/vue/package.json
+++ b/warp-drive-packages/vue/package.json
@@ -19,12 +19,12 @@
     "warpdrive"
   ],
   "scripts": {
-    "build:pkg": "tsdown",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",
-    "start": "tsdown --watch"
+    "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
     "addon-main.cjs",


### PR DESCRIPTION
## Summary

CI has been intermittently failing package `build:pkg` tasks with:
```
sh: 1: tsdown: not found
```
or
```
sh: 1: tsdown: Permission denied
```
Always for a task turbo picked as a genuine cache miss (e.g. `ember-data#build:pkg` in the LTS/releases job matrix), and never consistently the same package across runs — pointing to a race in pnpm's bin-shim generation (the small wrapper script it writes to `node_modules/.bin/<name>`) under the high parallelism turbo uses for `build:pkg`, rather than anything specific to any one package.

pnpm's generated `.bin/tsdown` shim does nothing but:
```sh
exec node "$basedir/../tsdown/dist/run.mjs" "$@"
```
— i.e. it just runs `node_modules/tsdown/dist/run.mjs`, the same file every package already gets a stable symlink to via normal dependency linking (not the racy step; `tsdown.config.mjs`'s own `import ... from 'tsdown'` already depends on that symlink existing).

This PR switches every package's `build:pkg`/`start` script (and the analogous `pnpm exec tsdown` call in `tools/release`'s unpkg-build step, used during publishing) to invoke `node node_modules/tsdown/dist/run.mjs` directly, bypassing the racy PATH-based bin-shim lookup entirely rather than trying to detect-and-recover from it with a sync/retry script. Since this is the exact same file the shim itself invokes, behavior is unchanged — only the lookup mechanism differs.

## Test plan
- [x] `rm -rf node_modules && pnpm install --frozen-lockfile` succeeds cleanly
- [x] `TURBO_FORCE=true turbo run build:pkg` succeeds across all 35 buildable packages with 0 cache hits (genuine fresh builds), including `ember-data` — the package that raced in the CI logs this fix was diagnosed from
- [x] Verified the multi-invocation (`warp-drive-packages/build-config`, `warp-drive-packages/utilities`) and `NODE_ENV=production`-prefixed (`packages/diagnostic`, `warp-drive-packages/react`) script variants all build correctly
- [x] All 33 modified `package.json` files parse as valid JSON and pass `prettier --check`
- [x] `tsc --noEmit` on `tools/release` shows no new errors introduced by the `amend-for-unpkg.ts` change (pre-existing unrelated errors in sibling files are untouched)