### PR TITLE
fix: verify build-config/utilities' CJS build outputs before allowing build:pkg to succeed

### DIFF
--- a/warp-drive-packages/build-config/package.json
+++ b/warp-drive-packages/build-config/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
-    "build:pkg": "node node_modules/tsdown/dist/run.mjs && node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs && node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs && test -s dist/addon-shim.cjs && test -s dist/cjs-set-config.cjs && test -s dist/babel-plugin-transform-asserts.cjs && test -s dist/babel-plugin-transform-deprecations.cjs && test -s dist/babel-plugin-transform-features.cjs && test -s dist/babel-plugin-transform-logging.cjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",

--- a/warp-drive-packages/utilities/package.json
+++ b/warp-drive-packages/utilities/package.json
@@ -13,7 +13,7 @@
     "directory": "warp-drive-packages/utilities"
   },
   "scripts": {
-    "build:pkg": "node node_modules/tsdown/dist/run.mjs && node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs",
+    "build:pkg": "node node_modules/tsdown/dist/run.mjs && node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs && test -s cjs-dist/string.cjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "check:types": "tsc --noEmit",


### PR DESCRIPTION
## Summary

The LTS/releases CI scenarios are still failing after #10729/#10730/#10731 with:
```
Cannot find module '.../@warp-drive/build-config/dist/addon-shim.cjs'
```
I confirmed by computing turbo's own hash locally (`turbo run build:pkg --filter=@warp-drive/build-config --dry=json`) that the exact hash CI reports as a "cache hit" (`a9b79cf33b4a83bc`) is the **current, correct** hash for today's code — not a stale one #10731's `globalDependencies` fix should have busted. The remote cache is being poisoned by an occasional bad build of the *current* script, not an old one.

#10731 already improved this significantly by chaining the two-step tsdown build with `&&` instead of `;`, so a non-zero exit from either step now fails the whole task instead of being silently swallowed. But `&&` only catches a step that *exits non-zero* — it can't catch a step that exits 0 without actually finishing writing its output (e.g. killed mid-write under CI's resource contention, or any other silent partial failure). Once turbo sees `build:pkg` exit 0 it caches the result as a permanent success, and remote cache entries are immutable — so a single bad write under a given input hash poisons every future read of that hash until the hash changes again.

This adds an explicit `test -s <file>` check for every real output file of each package's second (CJS) tsdown invocation, chained onto the same `&&`:
- `@warp-drive/build-config`: `dist/addon-shim.cjs` plus its other `cjs-src` entries
- `@warp-drive/utilities`: `cjs-dist/string.cjs`

If a step silently produces a missing or empty file, the whole `build:pkg` command now fails loudly instead of succeeding — so turbo can never cache (and thus never permanently poison) an incomplete artifact again, regardless of what causes the underlying occasional incompleteness. As a side effect this also gives both packages a fresh content hash, escaping the specific remote-cache entry already poisoned under the current one.

## Test plan
- [x] Happy-path build still succeeds and produces identical output for both packages
- [x] `test -s` confirmed to correctly fail (exit 1) on missing/empty files and pass (exit 0) on real ones
- [x] `rm -rf node_modules && pnpm install --frozen-lockfile` succeeds cleanly (35/35 build:pkg tasks)
- [x] Three repeated forced full rebuilds (`TURBO_FORCE=true turbo run build:pkg --concurrency=10`, matching CI's exact concurrency) all completed successfully with both files present each time