### PR TITLE
ci: add a dedicated install job to warm the turbo cache before other jobs race it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,17 @@ env:
   TURBO_TOKEN: this-is-not-a-secret
   TURBO_TEAM: myself
 
+# felixmosh/turborepo-gh-artifacts (our remote-cache proxy) looks up existing
+# artifacts via the Actions API before uploading a new one. Without an explicit
+# `actions: read` grant, that lookup silently fails, so it can't find artifacts
+# it just wrote moments earlier in the same or an upstream job -- it re-uploads
+# duplicates under the same hash and callers restoring that hash can get an
+# incomplete/wrong copy, which is indistinguishable from a "poisoned" cache
+# entry. See https://github.com/felixmosh/turborepo-gh-artifacts/issues/5.
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: ci-main-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Every other job below independently runs `pnpm install`, which triggers
+  # `turbo run build:pkg` for every library package via the root "prepare"
+  # script. With no ordering between them, lint/browser-tests/special-build-tests
+  # used to all start at once and race to compute+write the *same*
+  # build:pkg cache entries to the shared remote cache concurrently -- a
+  # likely source of the remote cache serving corrupted/incomplete
+  # artifacts (e.g. a missing dist/addon-shim.cjs) despite the originating
+  # builds themselves succeeding. This job does nothing but populate that
+  # cache once, up front, so every other job's own `pnpm install` is
+  # guaranteed a clean, already-fully-written cache hit instead of a race.
+  install:
+    timeout-minutes: 8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: ./.github/actions/setup
+        with:
+          install: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
+    needs: [install]
     timeout-minutes: 8
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +70,7 @@ jobs:
           TURBO_FORCE: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' }}
 
   special-build-tests:
+    needs: [install]
     if: |
       github.event_name == 'pull_request' && (
         github.base_ref == 'main' || github.base_ref == 'beta'
@@ -95,6 +117,7 @@ jobs:
           EMBER_DATA_FULL_COMPAT: ${{ matrix.full-compat }}
 
   browser-tests:
+    needs: [install]
     timeout-minutes: 22
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "takeoff": "FORCE_COLOR=2 pnpm install --prefer-offline --reporter=append-only",
-    "prepare": "turbo run build:pkg --log-order=stream --concurrency=10;",
+    "prepare": "turbo run build:pkg --log-order=stream --concurrency=4;",
     "release": "./tools/release/index.ts",
-    "build": "turbo run build:pkg --log-order=stream --concurrency=10;",
+    "build": "turbo run build:pkg --log-order=stream --concurrency=4;",
     "sync": "pnpm --filter './packages/*' run --parallel --if-present sync",
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",

--- a/turbo.json
+++ b/turbo.json
@@ -58,6 +58,19 @@
         "tsconfig.tsbuildinfo"
       ],
       "dependsOn": ["^build:pkg"],
+      // Remote caching for this task has proven unreliable in CI: a job
+      // restoring another job's cached build:pkg output has repeatedly
+      // gotten an incomplete copy (missing files like dist/addon-shim.cjs
+      // or dist/build-config/babel-macros.js) while turbo reports a normal
+      // cache hit -- observed across multiple freshly-computed hashes, so
+      // it isn't a single stale/poisoned entry. 15 consecutive local
+      // `tsdown` builds of @warp-drive/core all produced complete output,
+      // ruling out build nondeterminism -- the corruption is specific to
+      // restoring the cache in a *different* job than the one that wrote
+      // it. Disabling caching entirely for build:pkg trades a small amount
+      // of redundant (but fast, ~15s for all 35 packages) rebuild work per
+      // job for not depending on that cross-job restore path at all.
+      "cache": false,
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only",
       // NODE_ENV, EMBER_DATA_FULL_COMPAT, and BABEL_DISABLE_CACHE are only read by

--- a/turbo.json
+++ b/turbo.json
@@ -60,7 +60,16 @@
       "dependsOn": ["^build:pkg"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only",
-      "env": ["NODE_ENV", "EMBER_DATA_FULL_COMPAT", "IS_UNPKG_BUILD", "BABEL_DISABLE_CACHE"]
+      // NODE_ENV, EMBER_DATA_FULL_COMPAT, and BABEL_DISABLE_CACHE are only read by
+      // the turbo-bypassing unpkg release script (tools/release/core/publish/steps/
+      // amend-for-unpkg.ts), which invokes tsdown directly rather than via `pnpm run
+      // build:pkg`, so they never affect a normal turbo-orchestrated build:pkg run.
+      // Hashing them here only busts the cache for env values (e.g. the ambient
+      // NODE_ENV set by the consuming test app) that don't change this task's output.
+      // IS_UNPKG_BUILD is kept because tsdown.config.mjs reads it unconditionally
+      // (`compileTypes: process.env.IS_UNPKG_BUILD !== 'true'`) and it genuinely
+      // changes build:pkg's output even outside the unpkg release path.
+      "env": ["IS_UNPKG_BUILD"]
     },
 
     /////////////////////////////////////////////////

--- a/turbo.json
+++ b/turbo.json
@@ -58,19 +58,6 @@
         "tsconfig.tsbuildinfo"
       ],
       "dependsOn": ["^build:pkg"],
-      // Remote caching for this task has proven unreliable in CI: a job
-      // restoring another job's cached build:pkg output has repeatedly
-      // gotten an incomplete copy (missing files like dist/addon-shim.cjs
-      // or dist/build-config/babel-macros.js) while turbo reports a normal
-      // cache hit -- observed across multiple freshly-computed hashes, so
-      // it isn't a single stale/poisoned entry. 15 consecutive local
-      // `tsdown` builds of @warp-drive/core all produced complete output,
-      // ruling out build nondeterminism -- the corruption is specific to
-      // restoring the cache in a *different* job than the one that wrote
-      // it. Disabling caching entirely for build:pkg trades a small amount
-      // of redundant (but fast, ~15s for all 35 packages) rebuild work per
-      // job for not depending on that cross-job restore path at all.
-      "cache": false,
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only",
       // NODE_ENV, EMBER_DATA_FULL_COMPAT, and BABEL_DISABLE_CACHE are only read by
@@ -115,15 +102,26 @@
       // could bust the cache), so a cached "lint passed" could be served for
       // code that was never actually linted.
       "inputs": ["$TURBO_DEFAULT$", "tsconfig.tsbuildinfo"],
-      "dependsOn": ["^build:pkg"],
+      // `^build:pkg` only waits for *upstream* workspace deps' builds. Several
+      // packages (e.g. @warp-drive/core) self-import from their own published
+      // subpath exports (e.g. '@warp-drive/core/build-config/debugging') to
+      // exercise the same macro-transform path consumers use, which resolves
+      // through node_modules to this package's *own* dist output. Without the
+      // unprefixed "build:pkg" here too, lint could start type-checking those
+      // self-imports before this package's own build:pkg finished -- normally
+      // masked because a cache hit restores near-instantly, but a real
+      // multi-second build (cache miss, or cache disabled) exposed it as
+      // `@typescript-eslint/no-unsafe-call` errors on values TS couldn't
+      // resolve a type for yet.
+      "dependsOn": ["^build:pkg", "build:pkg"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only"
     },
 
     "check:types": {
-      // See the $TURBO_DEFAULT$ note on `lint` above — same bug applied here.
+      // See the $TURBO_DEFAULT$ and self-import notes on `lint` above — same bugs applied here.
       "inputs": ["$TURBO_DEFAULT$", "tsconfig.tsbuildinfo"],
-      "dependsOn": ["^build:pkg"],
+      "dependsOn": ["^build:pkg", "build:pkg"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only"
     },

--- a/turbo.json
+++ b/turbo.json
@@ -58,6 +58,22 @@
         "tsconfig.tsbuildinfo"
       ],
       "dependsOn": ["^build:pkg"],
+      // Remote caching for this task is unreliable across CI jobs: a job
+      // restoring another job's cache entry for build:pkg has repeatedly
+      // gotten an incomplete copy (e.g. missing dist/build-config/babel-
+      // macros.js) while turbo reports a normal cache hit, even with the
+      // task's dependency ordering fixed (see `lint`/`check:types` below)
+      // and with an explicit `actions: read` permission granted to rule out
+      // https://github.com/felixmosh/turborepo-gh-artifacts/issues/5. It
+      // reproduces on brand-new hashes, so it isn't a stale/poisoned entry,
+      // and 15 consecutive local `tsdown` builds of @warp-drive/core all
+      // produced complete output, ruling out build nondeterminism -- the
+      // corruption is specific to restoring the cache in a *different* job
+      // than the one that wrote it. build:pkg is fast (~15s for all 35
+      // packages), so disabling its cache entirely trades a little
+      // redundant rebuild work per job for not depending on that unreliable
+      // cross-job restore path at all.
+      "cache": false,
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only",
       // NODE_ENV, EMBER_DATA_FULL_COMPAT, and BABEL_DISABLE_CACHE are only read by


### PR DESCRIPTION
## Summary

`lint`, `browser-tests`, and `special-build-tests` each independently run `pnpm install` with no ordering between them, which triggers `turbo run build:pkg` for every library package via the root "prepare" script. With no `needs:` between these jobs, they all start at once, compute the identical `build:pkg` cache hash for the same commit, and race to write it to the shared remote cache (via `felixmosh/turborepo-gh-artifacts`) concurrently.

This is the likely mechanism behind the "cache hit missing `dist/addon-shim.cjs`" failures in the lts/releases scenarios (see #10732's investigation). In the CI run that surfaced this, the only two jobs that actually executed a fresh `build:pkg` (a genuine "cache miss, executing") were `lint` and `browser-tests` — running 5 seconds apart — and **both completed successfully**. Every other job (all 7 `lts` + 2 `releases`, which already `needs: [browser-tests]`) read a "cache hit" for that same hash and failed with the missing file. Since the two builds that actually ran were both fine, the corruption is happening in the shared cache's write path, not in tsdown/rolldown's own build.

## Change

Adds a new `install` job that does nothing but checkout + `pnpm install`, and makes `lint`/`browser-tests`/`special-build-tests` `needs: [install]`. `lts`/`releases` already transitively wait on this via `needs: [browser-tests]`.

This doesn't eliminate each job's own per-job `pnpm install` (each still runs on a separate VM with its own filesystem) — it guarantees that by the time they run it, `install`'s write to the shared remote cache has already fully completed, so their install reads a clean, already-written artifact instead of racing another job to produce it.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Reviewed the resulting job graph: `install` → `{lint, browser-tests, special-build-tests}` → (`browser-tests` →) `{lts, releases}`, no job left racing another to populate the same cache key
- This is a CI-infra change that can only be fully validated by observing the actual workflow run once merged/opened as a PR