### PR TITLE
fix: stop busting build:pkg cache for consuming-app env vars

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -60,7 +60,16 @@
       "dependsOn": ["^build:pkg"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only",
-      "env": ["NODE_ENV", "EMBER_DATA_FULL_COMPAT", "IS_UNPKG_BUILD", "BABEL_DISABLE_CACHE"]
+      // NODE_ENV, EMBER_DATA_FULL_COMPAT, and BABEL_DISABLE_CACHE are only read by
+      // the turbo-bypassing unpkg release script (tools/release/core/publish/steps/
+      // amend-for-unpkg.ts), which invokes tsdown directly rather than via `pnpm run
+      // build:pkg`, so they never affect a normal turbo-orchestrated build:pkg run.
+      // Hashing them here only busts the cache for env values (e.g. the ambient
+      // NODE_ENV set by the consuming test app) that don't change this task's output.
+      // IS_UNPKG_BUILD is kept because tsdown.config.mjs reads it unconditionally
+      // (`compileTypes: process.env.IS_UNPKG_BUILD !== 'true'`) and it genuinely
+      // changes build:pkg's output even outside the unpkg release path.
+      "env": ["IS_UNPKG_BUILD"]
     },
 
     /////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Audits `turbo.json`'s `build:pkg` task `env` array. It was hashing `NODE_ENV`, `EMBER_DATA_FULL_COMPAT`, and `BABEL_DISABLE_CACHE` into the cache key even though none of these affect a normal, turbo-orchestrated `build:pkg` invocation:

- All three are only read by `tools/release/core/publish/steps/amend-for-unpkg.ts`, which invokes `node node_modules/tsdown/dist/run.mjs` **directly**, bypassing `pnpm run build:pkg` (and therefore turbo) entirely.
- `NODE_ENV` in particular is typically set by the *consuming test app*, not the library build itself — so its ambient value could needlessly bust `build:pkg`'s cache for packages whose actual build output never changes based on it.

`IS_UNPKG_BUILD` is kept: `tsdown.config.mjs` reads it unconditionally in several packages (`compileTypes: process.env.IS_UNPKG_BUILD !== 'true'`), so it's a genuine, immediately-reachable behavioral gate even for a normal `pnpm run build:pkg` run.

## Verification

- `rm -rf node_modules && pnpm install --frozen-lockfile` — full fresh build, all 35 `build:pkg` tasks succeed.
- Second `turbo run build:pkg` — full cache hit (`FULL TURBO`, 35/35 cached).
- `NODE_ENV=production turbo run build:pkg --filter=@warp-drive/core` — still cache hits (confirms the fix: this env var no longer busts the key).
- `IS_UNPKG_BUILD=true turbo run build:pkg --filter=@warp-drive/core` — correctly triggers a rebuild (confirms this var is still properly cache-sensitive).

## Note

This overlaps with the still-open #10730 (parallelizes `build:pkg` via per-package task overrides, each of which currently duplicates this same `env` array). Whichever merges second will need a small rebase to carry this `env` change into #10730's per-package overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)