### PR TITLE
fix: align Renovate's minimumReleaseAge with pnpm, unblock all Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
     }
   ],
   "npm": {
-    "minimumReleaseAge": "3 days"
+    "minimumReleaseAge": "7 days"
   },
   "rangeStrategy": "bump",
   "prHourlyLimit": 10,

--- a/package.json
+++ b/package.json
@@ -166,7 +166,9 @@
       "qunit": "2.19.4",
       "ember-compatibility-helpers": "^1.2.7",
       "testem": "~3.11.0",
-      "typescript": "5.9.2"
+      "typescript": "5.9.2",
+      "@types/bun": "1.3.14",
+      "bun-types": "1.3.14"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,8 @@ overrides:
   ember-compatibility-helpers: ^1.2.7
   testem: ~3.11.0
   typescript: 5.9.2
+  '@types/bun': 1.3.14
+  bun-types: 1.3.14
 
 packageExtensionsChecksum: sha256-kOXFGnaIQmS0tU8c6OEyLwyV08fMRA903uqzK0zObCA=
 
@@ -82,8 +84,8 @@ importers:
         specifier: 5.0.2
         version: 5.0.2
       bun-types:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -157,8 +159,8 @@ importers:
         specifier: 1000.1.2
         version: 1000.1.2
       '@types/bun':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -489,8 +491,8 @@ importers:
         version: 3.17.0
     devDependencies:
       '@types/bun':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/inquirer':
         specifier: ^9.0.0
         version: 9.0.9
@@ -639,8 +641,8 @@ importers:
         specifier: workspace:*
         version: file:tools/internal-config
       bun-types:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       ember-cli-test-loader:
         specifier: ^3.1.0
         version: 3.1.0(@babel/core@7.28.3)
@@ -990,8 +992,8 @@ importers:
   packages/schema:
     devDependencies:
       bun-types:
-        specifier: 1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
 
   packages/schema-record:
     dependencies:
@@ -1344,8 +1346,8 @@ importers:
         specifier: workspace:*
         version: file:packages/codemods
       '@types/bun':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/ember-data__model':
         specifier: ^4.0.5
         version: 4.0.5
@@ -2916,8 +2918,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       bun-types:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       decorator-transforms:
         specifier: ^2.3.0
         version: 2.3.0(@babel/core@7.28.3)
@@ -3404,8 +3406,8 @@ importers:
         specifier: 1001.0.0
         version: 1001.0.0
       '@types/bun':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
@@ -3425,14 +3427,14 @@ importers:
   tools/release:
     dependencies:
       '@types/bun':
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
       bun-types:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: 1.3.14
+        version: 1.3.14
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -6921,8 +6923,8 @@ packages:
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
 
-  '@types/bun@1.4.0':
-    resolution: {integrity: sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ==}
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
 
   '@types/chai-as-promised@7.1.8':
     resolution: {integrity: sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==}
@@ -8405,8 +8407,8 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  bun-types@1.4.0:
-    resolution: {integrity: sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q==}
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   byte-size@9.0.1:
     resolution: {integrity: sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw==}
@@ -20326,9 +20328,9 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 24.3.0
 
-  '@types/bun@1.4.0':
+  '@types/bun@1.3.14':
     dependencies:
-      bun-types: 1.4.0
+      bun-types: 1.3.14
 
   '@types/chai-as-promised@7.1.8':
     dependencies:
@@ -20481,9 +20483,6 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -21583,7 +21582,7 @@ snapshots:
     dependencies:
       '@mdit/plugin-footnote': 0.22.2
       '@pnpm/find-workspace-dir': 1000.1.2
-      '@types/bun': 1.4.0
+      '@types/bun': 1.3.14
       '@types/debug': 4.1.12
       '@vite-pwa/vitepress': 1.0.0(vite-plugin-pwa@1.0.3(vite@7.3.1))
       chalk: 5.6.0
@@ -21648,7 +21647,7 @@ snapshots:
       '@pnpm/find-workspace-dir': 1000.1.2
       '@pnpm/find-workspace-packages': 6.0.9(@pnpm/logger@1001.0.0)
       '@pnpm/logger': 1001.0.0
-      '@types/bun': 1.4.0
+      '@types/bun': 1.3.14
       '@types/debug': 4.1.12
       chalk: 5.4.1
       comment-json: 4.2.5
@@ -22952,7 +22951,7 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bun-types@1.4.0:
+  bun-types@1.3.14:
     dependencies:
       '@types/node': 24.3.0
 


### PR DESCRIPTION
## Summary

Two related fixes to the pnpm supply-chain hardening (#10688) / Renovate interaction:

1. **Config mismatch**: Renovate's `npm.minimumReleaseAge` was `"3 days"` while `pnpm-workspace.yaml`'s `minimumReleaseAge` is `10080` minutes (7 days). Renovate could propose an update pnpm would then refuse to install until it aged further. Bumped to `"7 days"` to match.

2. **Active, repo-wide breakage** (the more urgent one): every currently open Renovate PR was failing its `renovate/artifacts` check with an identical, unrelated error:
   ```
   ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 1.4.0 (released 23 hours ago) of @types/bun does not meet the minimumReleaseAge constraint
   ```
   Confirmed on both the webpack ([#10709](https://github.com/warp-drive-data/warp-drive/pull/10709)) and turbo ([#10708](https://github.com/warp-drive-data/warp-drive/pull/10708)) security-update PRs, neither of which touches `@types/bun` at all. Since pnpm re-resolves the *entire* lockfile on any change, a floating `^1.4.0` range on `@types/bun`/`bun-types` resolving to a build published within the last day blocks **every** Renovate PR, not just ones that touch those packages.

   **Fix: pinned both to `1.3.14` (exact) via `pnpm.overrides`**, the same pattern already used for `typescript`. An earlier version of this PR excluded them from `minimumReleaseAgeExclude` instead, on the reasoning that they're type-only (no runtime code). That doesn't hold up: a compromised publisher account/token can ship anything under a package name regardless of its past contents, and the age gate exists specifically to catch that scenario. `bun-types` in particular publishes near-daily canary builds — exactly the high-velocity pattern the gate should apply *more* scrutiny to, not less. Pinning avoids the recurring lockfile-resolution failure without weakening the check going forward; bumping the override itself will still need to clear the normal 7-day age requirement.

## Verification

- `pnpm install --lockfile-only` succeeds cleanly; lockfile now resolves both packages to the pinned `1.3.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)