### PR TITLE
fix: docs publishing — update ember typedoc.tsconfig.json to reference dist

### DIFF
--- a/warp-drive-packages/ember/typedoc.tsconfig.json
+++ b/warp-drive-packages/ember/typedoc.tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["./declarations/**/*", "./src/**/*.md"],
+  "include": ["./dist/**/*", "./src/**/*.md"],
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
@@ -28,7 +28,7 @@
     "experimentalDecorators": true,
     "composite": false,
     "incremental": false,
-    "rootDir": "declarations",
+    "rootDir": "dist",
     "declaration": true,
     "declarationMap": true,
     "inlineSourceMap": true,
@@ -37,8 +37,6 @@
     "types": ["@glint/ember-tsc/types", "ember-source/types"],
     "allowImportingTsExtensions": true,
     "paths": {
-      "@warp-drive/core": ["../core/declarations"],
-      "@warp-drive/core/*": ["../core/declarations/*"],
       "@glimmer/validator": ["../../@types/@glimmer/validator.d.ts"]
     },
     "erasableSyntaxOnly": true,


### PR DESCRIPTION
## Summary
- The \"canary.warp-drive.io deployment\" workflow has been failing on `main` since the dist co-location / paths-removal work merged: TypeDoc for `@warp-drive/ember` errors with `Unable to find any entry points`.
- `warp-drive-packages/ember/typedoc.tsconfig.json` was a separate config file (used only for the typedoc pass, not the regular build) that was missed during that migration — it still pointed at the old `declarations/` layout (`include`, `rootDir`, and `paths` mapping `@warp-drive/core` to `../core/declarations`).
- Updated `include`/`rootDir` to point at `dist` (matching `typedoc.config.mjs`'s entry-point rewrite of `./src` → `./dist`), and dropped the stale `@warp-drive/core` paths mapping since `@warp-drive/core` now resolves via its own package `exports` to `dist` (consistent with the paths-removal already applied to the regular `tsconfig.json` files).

## Test plan
- [x] Ran `typedoc --tsconfig ./typedoc.tsconfig.json --options typedoc.config.mjs --emit none` directly against the built `warp-drive-packages/ember` package: 0 errors (previously: 2 errors, "Unable to find any entry points").
- [ ] Confirm the "canary.warp-drive.io deployment" workflow goes green on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)