### PR TITLE
ci: share the turbo remote-cache proxy's disk cache across jobs/workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -82,6 +82,41 @@ runs:
         echo "restore-lint-caches = ${{ inputs.restore-lint-caches }}"
         echo "restore-broccoli-cache = ${{ inputs.restore-broccoli-cache }}"
 
+    # felixmosh/turborepo-gh-artifacts' local proxy server (below) serves a
+    # GET for artifact <id> straight from ${RUNNER_TEMP}/turbo-cache/<id>.gz
+    # on disk with zero network calls when that file already exists --  it
+    # only falls back to querying the GitHub Artifacts API when it's missing
+    # locally (see felixmosh/turborepo-gh-artifacts's turboServer.ts). That
+    # API-based fallback path is the one that's proven unreliable across
+    # separate jobs/workflow runs (see the note on `permissions` in
+    # .github/workflows/main.yml). Pre-seeding this directory from a shared
+    # actions/cache entry means most GETs hit the instant, reliable local
+    # path instead, for jobs both within this workflow run and in later ones.
+    #
+    # This must be placed *before* the felixmosh step: composite/JS action
+    # "post" cleanup steps run in the *reverse* order their main steps were
+    # registered, and felixmosh's own post step is what moves this run's
+    # newly-built artifacts from turbo-cache/new-artifacts/ into the flat
+    # turbo-cache/<id>.gz layout the GET handler reads from (see
+    # felixmosh/turborepo-gh-artifacts's uploadArtifacts.ts). Registering our
+    # restore first means our save (its own post step) runs *after*
+    # felixmosh's, capturing that final, fully-populated state rather than
+    # a snapshot from before this run's artifacts were moved into place.
+    #
+    # The key is unique per run (so a save always has something new to
+    # write -- actions/cache entries are immutable once created, an
+    # already-existing key is silently skipped) with a prefix-matched
+    # restore-key so every run still starts from the most recently saved
+    # state regardless of which prior run wrote it.
+    - name: 'Restore Turbo Remote-Cache Proxy Disk Cache'
+      if: ${{ inputs.repo-token }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/turbo-cache
+        key: turbo-remote-cache-${{ github.run_id }}
+        restore-keys: |
+          turbo-remote-cache-
+
     - name: 'Setup local TurboRepo server'
       if: ${{ inputs.repo-token }}
       uses: felixmosh/turborepo-gh-artifacts@118f869397261f74bc39cb8565f2d02c0ed4209f # 4.1.1

--- a/.github/workflows/blueprint-tests.yml
+++ b/.github/workflows/blueprint-tests.yml
@@ -11,12 +11,31 @@ env:
   TURBO_TOKEN: this-is-not-a-secret
   TURBO_TEAM: myself
 
+# See the matching note in .github/workflows/main.yml: without this, the
+# felixmosh/turborepo-gh-artifacts proxy can't look up artifacts it (or a
+# sibling job) already wrote, and re-uploads duplicates instead.
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: docs-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  # See the matching "install" job in .github/workflows/main.yml.
+  install:
+    timeout-minutes: 8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: ./.github/actions/setup
+        with:
+          install: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   test:
+    needs: [install]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/compat-tests.yml
+++ b/.github/workflows/compat-tests.yml
@@ -11,12 +11,34 @@ env:
   TURBO_TOKEN: this-is-not-a-secret
   TURBO_TEAM: myself
 
+# See the matching note in .github/workflows/main.yml: without this, the
+# felixmosh/turborepo-gh-artifacts proxy can't look up artifacts it (or a
+# sibling job) already wrote, and re-uploads duplicates instead.
+permissions:
+  contents: read
+  actions: read
+
 concurrency:
   group: compat-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  # See the matching "install" job in .github/workflows/main.yml -- every
+  # job below independently runs `pnpm install`, so this warms the shared
+  # build:pkg cache once up front instead of letting them all race to
+  # compute+write it concurrently.
+  install:
+    timeout-minutes: 8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: ./.github/actions/setup
+        with:
+          install: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
   vite:
+    needs: [install]
     timeout-minutes: 7
     runs-on: ubuntu-latest
     steps:
@@ -74,10 +96,9 @@ jobs:
 
   smoke-tests:
     name: Smoke ${{ matrix.scenario.name }} w/ ${{ matrix.packageManager }}
+    needs: [install]
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    # TODO:
-    # needs: [vite]
 
     strategy:
       matrix:


### PR DESCRIPTION
## Root cause, finally pinned down

Pulled the exact duplicate artifact pair that caused a real "Cannot find module .../cjs-dist/string.cjs" failure on #10730 (name `87305f56ee9e23f9`) and downloaded both copies directly. They came from **two different workflow files** (`Main` and `Compat`) triggered by the same push — and **both were byte-for-byte complete** (42/42 files, `cjs-dist/string.cjs` present in both). So the stored data was never actually corrupt. The failure has to be happening in `felixmosh/turborepo-gh-artifacts`' download/lookup path on whichever runner hit it, not in what got uploaded.

I traced the proxy's actual source:
- `GET /v8/artifacts/:id` serves straight from `${RUNNER_TEMP}/turbo-cache/<id>.gz` on disk with **zero network calls** when that file exists locally, only falling back to the GitHub Artifacts list+download API (the flaky path — see `main.yml`'s existing note on [felixmosh/turborepo-gh-artifacts#5](https://github.com/felixmosh/turborepo-gh-artifacts/issues/5)) when it's missing.
- After a successful (or already-uploaded/409) upload, this run's newly-built artifacts get moved from `turbo-cache/new-artifacts/` into that same flat `turbo-cache/<id>.gz` layout — during the action's `post` step, at the very end of the job.
- `@actions/artifact`'s `uploadArtifact()` only guards against duplicate names **within a single workflow run** (a 409 it treats as "already there, skip"). Across separate runs — e.g. `Main` and `Compat` both building the same commit — there's no such guard, which is exactly how two artifacts ended up sharing one name.

## Fix

Persist `${RUNNER_TEMP}/turbo-cache` itself via `actions/cache`, keyed per-run with a prefix-matched restore-key so every run starts from the most recently saved state. This is placed **before** the felixmosh setup step specifically because composite/JS action `post` steps run in **reverse** registration order — putting our restore first means our save (its own post step) runs *after* felixmosh's, capturing the fully-populated post-move state. Most `GET`s should now hit the instant, reliable local file path instead of the network fallback, for both same-run and cross-run/cross-workflow sharing — without giving up the GitHub Artifacts store, which keeps working as the fallback and cross-branch persistence layer underneath.

## Also fixed along the way

- `compat-tests.yml` and `blueprint-tests.yml` were both missing the `actions: read` permission `main.yml` already grants specifically so the proxy can look up existing artifacts before uploading. Without it, every job in those two files was unconditionally re-uploading duplicates. Added it to both.
- Neither file had a dedicated cache-warming job the way `main.yml`'s `lint`/`browser-tests`/etc. do — every job in them raced its own `pnpm install` independently. Added an `install` job to each, mirroring `main.yml`'s, with `needs: [install]` on `vite`/`smoke-tests`/`test`. Also resolves `smoke-tests`' pre-existing `# TODO: needs: [vite]` comment — it now correctly depends on the shared warm-up instead of the unrelated `vite` job.

## Test plan

- [x] All 4 touched YAML files parse cleanly.
- [x] Traced the felixmosh/turborepo-gh-artifacts source directly (`turboServer.ts`, `uploadArtifacts.ts`) to confirm the disk-cache-dir/post-step-ordering behavior this relies on, rather than guessing.
- [ ] Could not validate `actions/cache`'s post-step save ordering locally — that's GitHub Actions runtime behavior. Watching real CI runs on this PR (this one, plus a couple of follow-up pushes) to confirm the corruption pattern actually stops recurring and that `Compat`/`DX` jobs now correctly wait on their own `install` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)