### PR TITLE
fix: exclude @embroider/config-meta-loader unstable build from trustPolicy no-downgrade

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,6 +66,15 @@ trustPolicyIgnoreAfter: 1051200
 ##
 trustPolicyExclude:
   - hosted-git-info@6.1.3
+  ## @embroider/config-meta-loader@1.0.1-unstable.f9c81e9 (2025-03-14) is
+  ## pinned exactly across several tests/* fixtures. It isn't old enough yet
+  ## to clear trustPolicyIgnoreAfter above (needs ~2027-03-14), but the
+  ## "downgrade" is pnpm comparing it against a *later, unrelated* 1.0.0
+  ## release (2025-04-03) that added provenance -- not a regression within
+  ## this "-unstable" prerelease line, which never had provenance to begin
+  ## with. Same pnpm/pnpm#10202 false positive as hosted-git-info@6.1.3
+  ## above.
+  - "@embroider/config-meta-loader@1.0.1-unstable.f9c81e9"
 
 packages:
   - "packages/*"


### PR DESCRIPTION
## Summary

Every currently open Renovate PR is failing `renovate/artifacts` with the same unrelated error:

```
ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for
"@embroider/config-meta-loader@1.0.1-unstable.f9c81e9" (possible package takeover)
```

This exact version is pinned (not a floating range) across several `tests/*` fixtures and is already in our committed lockfile — Renovate isn't introducing it. `trustPolicy: no-downgrade` only started flagging it because #10688 enabled the check for the first time; nothing about this dependency actually changed.

Confirmed directly against the npm registry:
- Our pinned build (`1.0.1-unstable.f9c81e9`, published 2025-03-14) has **no** provenance attestation.
- A later, unrelated `1.0.0` release (published 2025-04-03) **does** have provenance.

pnpm's downgrade check compares a version against *any* later-published release regardless of whether it's a comparable line — the exact same `pnpm/pnpm#10202` false positive already documented in this file for `hosted-git-info@6.1.3`. `trustPolicyIgnoreAfter` (2yr) doesn't cover this yet (needs ~2027-03-14), so this excludes it explicitly in the meantime, same pattern as the existing entry.

## Verification

- Confirmed via `npm view` that the pinned version lacks `dist.attestations` while the later `1.0.0` has it, matching the exact mechanism from the prior `hosted-git-info` fix.
- `pnpm install --frozen-lockfile` succeeds cleanly with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)