### PR TITLE
fix: exclude undici-types@6.21.0 from trustPolicy no-downgrade

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,6 +79,16 @@ trustPolicyExclude:
   ## with. Same pnpm/pnpm#10202 false positive as hosted-git-info@6.1.3
   ## above.
   - "@embroider/config-meta-loader@1.0.1-unstable.f9c81e9"
+  ## undici-types@6.21.0 (2024-11-13) is a transitive dependency of
+  ## @types/node -- effectively unpinnable directly, since it's whatever
+  ## @types/node@<major> happens to require. It never had provenance; the
+  ## 6.x line resumed publishing after a ~14 month gap (6.23.0, 2026-01-05)
+  ## and added provenance then. Same pnpm/pnpm#10202 false positive as the
+  ## entries above: pnpm compares against later releases (here, even later
+  ## releases within the *same* 6.x line) regardless of whether provenance
+  ## was ever a realistic expectation for the version actually being
+  ## installed.
+  - undici-types@6.21.0
 
 packages:
   - "packages/*"


### PR DESCRIPTION
## Summary

Auditing all currently open Renovate PRs (per request) turned up a new trustPolicy false positive blocking artifact updates on at least the turbo (#10708) and svelte (#10707) security-update PRs:

```
ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for "undici-types@6.21.0" (possible package takeover)

This error happened while installing the dependencies of @types/node@22.15.3
```

Same `pnpm/pnpm#10202` false positive as the two entries already in this file:

- `undici-types@6.21.0` was published 2024-11-13 with no provenance attestation.
- The 6.x line went quiet for ~14 months and resumed at `6.23.0` (2026-01-05), which added provenance attestation.
- pnpm's downgrade check compares `6.21.0` against that later release (or the newer 7.x/8.x lines) regardless of whether provenance was a realistic expectation for a package published in late 2024.

Unlike the previous two entries, this one is **transitive** via `@types/node` rather than something we declare directly — it can recur for any `@types/node` version whose dependency range happens to resolve to this exact `undici-types` release.

## Other PRs audited, no action needed

- Several PRs (hono, glob, @sveltejs/kit, vite, rollup) were blocked on `ember-exam@10.1.3` hitting `minimumReleaseAge` — that's the age gate working as intended on a real, recent bump we made ourselves (#10697), not a false positive. It crossed the 7-day mark today and should self-resolve on Renovate's next pass.
- Two PRs (typescript-eslint, qunit) still show the already-fixed `@embroider/config-meta-loader` error from #10739 — their branches just haven't been rebased by Renovate's bot since that merged (last commit predates it). Expected to clear once Renovate cycles through them; no new fix needed.

## Verification

- `pnpm install --no-frozen-lockfile` succeeds cleanly with the exclusion in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)