### PR TITLE
fix: WarpDriveConfig docs missing from @warp-drive/core, breaking docs build

### DIFF
--- a/warp-drive-packages/core/typedoc.config.mjs
+++ b/warp-drive-packages/core/typedoc.config.mjs
@@ -6,6 +6,13 @@ const config = {
   entryPoints: entryPoints.filter((entry) => !entry.includes('-private')),
   out: 'doc',
   readme: 'src/index.md',
+  // build-config.ts re-exports types (e.g. WarpDriveConfig) that are declared
+  // in @warp-drive/build-config. The docs-viewer root config sets
+  // excludeExternals: true so cross-package re-exports collapse into a link
+  // to their origin package instead of getting their own page -- but
+  // @warp-drive/core/build-config is the intended public surface for these,
+  // so document them here too.
+  excludeExternals: false,
 };
 
 export default config;


### PR DESCRIPTION
## Summary

The `canary.warp-drive.io deployment` workflow has failed on every push to `main` since 2026-08-22:

```
[vitepress] 1 dead link(s) found.
(!) Found dead link /api/@warp-drive/core/build-config/interfaces/WarpDriveConfig in file guides/configuration/index.md
```

#10737 fixed a separate TypeDoc entry-point bug in `@warp-drive/ember` the same day, but the deploy kept failing on every subsequent push — this is a second, unrelated problem.

**Root cause**: `WarpDriveConfig` is declared in `@warp-drive/build-config` and only re-exported (as a type) from `@warp-drive/core`'s `build-config.ts`. The shared `docs-viewer` typedoc config sets `excludeExternals: true`, so a symbol re-exported from another already-documented package collapses into a reference pointing at its *origin* project instead of getting its own page under the re-exporting package. `WarpDriveConfig` was therefore only ever documented under `@warp-drive/build-config`, never under `@warp-drive/core/build-config` — even though that's the guide's (correct, historical) link target and the actual public import path (`import { setConfig } from '@warp-drive/core/build-config'`).

**Fix**: override `excludeExternals: false` in `@warp-drive/core`'s own `typedoc.config.mjs`, scoped to just that package's project — not the shared root config — so it doesn't change how every other package's external re-exports are documented. This restores `@warp-drive/core/build-config/interfaces/WarpDriveConfig.md` as a real generated page, so the guide's original link needs no change at all.

## Verification

- Ran `pnpm exec typedoc` directly before/after the config change and confirmed `@warp-drive/core/build-config/interfaces/WarpDriveConfig.md` is now generated (it wasn't before).
- Diffed TypeDoc's warning output before/after: fixes 3 "resolved but not included in the documentation" warnings, introduces 4 new benign internal `{@link}`-resolution warnings (same non-fatal class as ~230 pre-existing warnings elsewhere in the docs) — net neutral, no new errors.
- Ran the full `pnpm run build` in `docs-viewer` (the same command `deploy.yml` uses) — completes cleanly with no dead-link error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)