### PR TITLE
fix: use strict singular type in ember-data__adapter's hasMany decorators

### DIFF
--- a/tests/ember-data__adapter/tests/integration/belongs-to-test.js
+++ b/tests/ember-data__adapter/tests/integration/belongs-to-test.js
@@ -74,7 +74,7 @@ class Post extends Model {
   @attr
   text;
 
-  @hasMany('comments', { async: true, inverse: 'post' })
+  @hasMany('comment', { async: true, inverse: 'post' })
   comments;
 }
 

--- a/tests/ember-data__adapter/tests/integration/has-many-test.js
+++ b/tests/ember-data__adapter/tests/integration/has-many-test.js
@@ -74,7 +74,7 @@ class Post extends Model {
   @attr
   text;
 
-  @hasMany('comments', { async: true, inverse: 'post' })
+  @hasMany('comment', { async: true, inverse: 'post' })
   comments;
 }
 


### PR DESCRIPTION
## Summary

"Remove All Deprecations" has been failing on every PR that touches `main` since #10725 (the native Vite migration) merged. 13 of 67 tests across `tests/ember-data__adapter/tests/integration/belongs-to-test.js` and `has-many-test.js` fail with:

```
No model was found for 'comments'
```

## Root cause

Nothing to do with the Vite migration. Both test files declare:

```js
class Post extends Model {
  @hasMany('comments', { async: true, inverse: 'post' })
  comments;
}
```

But only ever register `model:comment` (singular) with the owner, and the mock adapter's fetch responses use `type: 'comment'` too. This has always been inconsistent — it only worked because `DEPRECATE_NON_STRICT_TYPES` silently normalizes non-strict relationship type strings (dasherize + singularize) before they're used to look up a model factory (see `warp-drive-packages/legacy/src/model/-private/has-many.ts`'s `normalizeType`).

"Remove All Deprecations" builds with that flag off — simulating a future where the leniency is gone — so the raw `'comments'` string reaches `getModelFactory` unchanged and fails to find the singular-registered class.

## Fix

Use the singular model name (`'comment'`) as the `hasMany` type argument. The property name itself stays `comments;` — only the decorator's first argument, which must be the actual (singular) model name, changes.

## Verification

- `EMBER_DATA_FULL_COMPAT=true pnpm turbo test:production --filter=ember-data__adapter` now passes 65/67 (2 skipped, matching the existing DEBUG-ONLY skip pattern) — previously 13 failing.
- `pnpm turbo test --filter=ember-data__adapter` (normal, non-full-compat) still passes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
