### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
     - name: Restore ${{ inputs.name }}
       id: restore-ref-artifact
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ./${{ inputs.package }}/dist-${{ inputs.ref }}${{ inputs.ext }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -64,13 +64,13 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         registry-url: 'https://registry.npmjs.org'
         node-version: 25.5
         cache: 'pnpm'
 
-    - uses: oven-sh/setup-bun@v2
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: latest
 
@@ -187,7 +187,7 @@ runs:
 
     - name: Restore Broccoli Cache
       if: ${{ inputs.restore-broccoli-cache == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           ${{ github.workspace }}/.broccoli-cache
@@ -201,7 +201,7 @@ runs:
 
     - name: Restore Lint Caches
       if: ${{ inputs.restore-lint-caches == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         # Type-check (tsconfig.tsbuildinfo) and lint (.eslintcache) artifacts are
         # produced per-package by turbo rather than at the repo root, so these

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -110,7 +110,7 @@ runs:
     # state regardless of which prior run wrote it.
     - name: 'Restore Turbo Remote-Cache Proxy Disk Cache'
       if: ${{ inputs.repo-token }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ runner.temp }}/turbo-cache
         key: turbo-remote-cache-${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           ACTIONS_RUNNER_DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' }}
           DISABLE_TURBO_CACHE: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' }}
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Generate Artifact
         run: pnpm run build
         working-directory: docs-viewer
@@ -52,7 +52,7 @@ jobs:
           BASE: ''
           HOSTNAME: 'https://canary.warp-drive.io'
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs-viewer/docs.warp-drive.io/.vitepress/dist
 
@@ -67,4 +67,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/deprecations-check.yml
+++ b/.github/workflows/deprecations-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 25.5
           cache: 'pnpm'
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 25.5
           cache: 'pnpm'

--- a/.github/workflows/enforce-pr-labels-beta.yml
+++ b/.github/workflows/enforce-pr-labels-beta.yml
@@ -14,21 +14,21 @@ jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':label: breaking,:label: feat,:label: bug,:label: perf,:label: cleanup,:label: deprecation,:label: doc,:label: test,:label: chore'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for changelog generation. [':label: breaking', ':label: feat', ':label: bug', ':label: perf', ':label: cleanup', ':label: deprecation', ':label: doc', ':label: test', ':label: chore']"
   ban-target-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: ':dart: canary,:dart: beta,:dart: release,:dart: lts,:dart: lts-prev,:label: dependencies'
           BANNED_LABELS_DESCRIPTION: "These labels should only be used for PRs targeting the main branch, remove them. [':dart: canary', ':dart: beta', ':dart: release', ':dart: lts', ':dart: lts-prev',':label: dependencies']"
   ban-other-release-branch-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: 'backport-release,backport-lts,backport-lts-prev,backport-old-release'
           BANNED_LABELS_DESCRIPTION: "The following labels should only be applied to PRs targeting other release channel branches, remove them.['backport-release', 'backport-lts', 'backport-lts-prev', 'backport-old-release']"

--- a/.github/workflows/enforce-pr-labels-beta.yml
+++ b/.github/workflows/enforce-pr-labels-beta.yml
@@ -35,6 +35,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: backport-beta

--- a/.github/workflows/enforce-pr-labels-canary.yml
+++ b/.github/workflows/enforce-pr-labels-canary.yml
@@ -15,21 +15,21 @@ jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':label: breaking,:label: feat,:label: bug,:label: perf,:label: cleanup,:label: deprecation,:label: doc,:label: test,:label: chore,:label: dependencies'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for changelog generation. [':label: breaking', ':label: feat', ':label: bug', ':label: perf', ':label: cleanup', ':label: deprecation', ':label: doc', ':label: test', ':label: chore', ':label: dependencies']"
   enforce-target-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':dart: canary,:dart: beta,:dart: release,:dart: lts,:dart: lts-prev,:label: dependencies'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for what release channels to target. Use the labels `:dart: canary` or `:label: dependencies` and none of the others in the list if this PR should not be backported. [':dart: canary', ':dart: beta', ':dart: release', ':dart: lts', ':dart: lts-prev']"
   ban-release-branch-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: 'backport-beta,backport-release,backport-lts,backport-lts-prev,backport-old-release'
           BANNED_LABELS_DESCRIPTION: "The following labels should only be applied to PRs targeting release channel branches that backport a change already on the main branch, remove them.['backport-beta', 'backport-release', 'backport-lts', 'backport-lts-prev', 'backport-old-release']"

--- a/.github/workflows/enforce-pr-labels-lts-prev.yml
+++ b/.github/workflows/enforce-pr-labels-lts-prev.yml
@@ -36,6 +36,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: backport-lts-prev

--- a/.github/workflows/enforce-pr-labels-lts-prev.yml
+++ b/.github/workflows/enforce-pr-labels-lts-prev.yml
@@ -15,21 +15,21 @@ jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':label: breaking,:label: feat,:label: bug,:label: perf,:label: cleanup,:label: deprecation,:label: doc,:label: test,:label: chore'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for changelog generation. [':label: breaking', ':label: feat', ':label: bug', ':label: perf', ':label: cleanup', ':label: deprecation', ':label: doc', ':label: test', ':label: chore']"
   ban-target-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: ':dart: canary,:dart: beta,:dart: release,:dart: lts,:dart: lts-prev,:label: dependencies'
           BANNED_LABELS_DESCRIPTION: "These labels should only be used for PRs targeting the main branch, remove them. [':dart: canary', ':dart: beta', ':dart: release', ':dart: lts', ':dart: lts-prev',':label: dependencies']"
   ban-other-release-branch-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: 'backport-beta,backport-old-release,backport-lts,backport-release'
           BANNED_LABELS_DESCRIPTION: "The following labels should only be applied to PRs targeting other release channel branches, remove them.['backport-beta', 'backport-old-release', 'backport-lts', 'backport-release']"

--- a/.github/workflows/enforce-pr-labels-lts.yml
+++ b/.github/workflows/enforce-pr-labels-lts.yml
@@ -36,6 +36,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: backport-lts

--- a/.github/workflows/enforce-pr-labels-lts.yml
+++ b/.github/workflows/enforce-pr-labels-lts.yml
@@ -15,21 +15,21 @@ jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':label: breaking,:label: feat,:label: bug,:label: perf,:label: cleanup,:label: deprecation,:label: doc,:label: test,:label: chore'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for changelog generation. [':label: breaking', ':label: feat', ':label: bug', ':label: perf', ':label: cleanup', ':label: deprecation', ':label: doc', ':label: test', ':label: chore']"
   ban-target-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: ':dart: canary,:dart: beta,:dart: release,:dart: lts,:dart: lts-prev,:label: dependencies'
           BANNED_LABELS_DESCRIPTION: "These labels should only be used for PRs targeting the main branch, remove them. [':dart: canary', ':dart: beta', ':dart: release', ':dart: lts', ':dart: lts-prev', ':label: dependencies']"
   ban-other-release-branch-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: 'backport-beta,backport-old-release,backport-lts-prev,backport-release'
           BANNED_LABELS_DESCRIPTION: "The following labels should only be applied to PRs targeting other release channel branches, remove them.['backport-beta', 'backport-old-release', 'backport-lts-prev', 'backport-release']"

--- a/.github/workflows/enforce-pr-labels-old-release.yml
+++ b/.github/workflows/enforce-pr-labels-old-release.yml
@@ -14,21 +14,21 @@ jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':label: breaking,:label: feat,:label: bug,:label: perf,:label: cleanup,:label: deprecation,:label: doc,:label: test,:label: chore'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for changelog generation. [':label: breaking', ':label: feat', ':label: bug', ':label: perf', ':label: cleanup', ':label: deprecation', ':label: doc', ':label: test', ':label: chore']"
   ban-target-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: ':dart: canary,:dart: beta,:dart: release,:dart: lts,:dart: lts-prev,:label: dependencies'
           BANNED_LABELS_DESCRIPTION: "These labels should only be used for PRs targeting the main branch, remove them. [':dart: canary', ':dart: beta', ':dart: release', ':dart: lts', ':dart: lts-prev', ':label: dependencies']"
   ban-other-release-branch-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: 'backport-beta,backport-lts,backport-lts-prev,backport-release'
           BANNED_LABELS_DESCRIPTION: "The following labels should only be applied to PRs targeting other release channel branches, remove them.['backport-beta', 'backport-lts', 'backport-lts-prev', 'backport-release']"

--- a/.github/workflows/enforce-pr-labels-old-release.yml
+++ b/.github/workflows/enforce-pr-labels-old-release.yml
@@ -35,6 +35,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: backport-old-release

--- a/.github/workflows/enforce-pr-labels-release.yml
+++ b/.github/workflows/enforce-pr-labels-release.yml
@@ -14,21 +14,21 @@ jobs:
   enforce-changelog-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           REQUIRED_LABELS_ANY: ':label: breaking,:label: feat,:label: bug,:label: perf,:label: cleanup,:label: deprecation,:label: doc,:label: test,:label: chore'
           REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label for changelog generation. [':label: breaking', ':label: feat', ':label: bug', ':label: perf', ':label: cleanup', ':label: deprecation', ':label: doc', ':label: test', ':label: chore']"
   ban-target-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: ':dart: canary,:dart: beta,:dart: release,:dart: lts,:dart: lts-prev,:label: dependencies'
           BANNED_LABELS_DESCRIPTION: "These labels should only be used for PRs targeting the main branch, remove them. [':dart: canary', ':dart: beta', ':dart: release', ':dart: lts', ':dart: lts-prev', ':label: dependencies']"
   ban-other-release-branch-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
+      - uses: yogevbd/enforce-label-action@a3c219da6b8fa73f6ba62b68ff09c469b3a1c024 # 2.2.2
         with:
           BANNED_LABELS: 'backport-beta,backport-lts,backport-lts-prev,backport-old-release'
           BANNED_LABELS_DESCRIPTION: "The following labels should only be applied to PRs targeting other release channel branches, remove them.['backport-beta', 'backport-lts', 'backport-lts-prev', 'backport-old-release']"

--- a/.github/workflows/enforce-pr-labels-release.yml
+++ b/.github/workflows/enforce-pr-labels-release.yml
@@ -35,6 +35,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1.1.3
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: backport-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Check for Test Failure Retry
         id: retry-test-failures
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: failed-test-log.txt
           key: failed-test-log_${{ github.sha }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload testem logs
         if: ${{ always() && steps.run-tests-production.conclusion != 'skipped' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: client-testem-logs
           path: './tests/dont-write-new-tests-here/testem.log'
@@ -185,13 +185,13 @@ jobs:
 
       - name: Maybe Cache Failures
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: failed-test-log.txt
           key: failed-test-log_${{ github.sha }}
 
       - name: Archive Tests Execution File
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: (success() || failure()) && steps.retry-test-failures.outputs.cache-hit != 'true'
         with:
           name: tests-execution-file-partition

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -40,12 +40,12 @@ jobs:
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: 25.5
           cache: 'pnpm'
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
       - name: Get Browser Flags
@@ -135,7 +135,7 @@ jobs:
         #   DEBUG: '*,-babel*,-vite*,-rollup*,-ember*,-broccoli*,-pnpm*,-embroider*,-tree-sync*,-fs-tree-diff*'
       # - name: Upload Assets
       #   if: failure() || success()
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       #   with:
       #     name: built-files
       #     path: 'tests/performance/dist-*'

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -40,12 +40,12 @@ jobs:
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: 25.5
           cache: 'pnpm'
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
       - name: Get Browser Flags
@@ -135,7 +135,7 @@ jobs:
         #   DEBUG: '*,-babel*,-vite*,-rollup*,-ember*,-broccoli*,-pnpm*,-embroider*,-tree-sync*,-fs-tree-diff*'
       # - name: Upload Assets
       #   if: failure() || success()
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       #   with:
       #     name: built-files
       #     path: 'tests/performance/dist-*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
         env:
           FORCE_COLOR: 2
           CI: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tarballs
           path: tmp/tarballs/**/*.tgz
@@ -236,7 +236,7 @@ jobs:
         env:
           FORCE_COLOR: 2
           CI: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tarballs
           path: tmp/tarballs/**/*.tgz
@@ -400,7 +400,7 @@ jobs:
           FORCE_COLOR: 2
           CI: true
           GITHUB_AUTH: ${{ secrets.GH_DEPLOY_TOKEN }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tarballs
           path: tmp/tarballs/**/*.tgz


### PR DESCRIPTION
## Summary
- The new security policy requires all GitHub Actions to be pinned to a full-length commit SHA. Surfaced as a failure on #10743 (`actions/setup-node@v6`, `oven-sh/setup-bun@v2`, `actions/cache@v4` not allowed).
- Swept the rest of `.github/` for the same tag-based `uses:` pattern and pinned everything found: `actions/cache` (incl. `/restore` and `/save`), `actions/upload-artifact`, `actions-ecosystem/action-add-labels`, `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`.
- Each pin resolves to the commit SHA of the tag currently referenced, verified against the GitHub API; version kept as a trailing comment for readability.

## Test plan
- [ ] CI runs green on this PR (the `install` job in particular, which previously failed the action-pinning check)