### PR TITLE
chore(renovate): group typedoc and vitepress dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,10 @@
       "groupName": "qunit"
     },
     {
+      "matchPackageNames": ["/typedoc/", "/vitepress/"],
+      "groupName": "docs"
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"
     }


### PR DESCRIPTION
## Summary
- Add a `docs` package group matching `/typedoc/` and `/vitepress/` so `typedoc`, its plugins (`typedoc-plugin-markdown`, `typedoc-plugin-no-inherit`, `typedoc-plugin-mdn-links`, `typedoc-vitepress-theme`), `vitepress`, and its plugins (`vitepress-plugin-llms`, `vitepress-plugin-group-icons`, `vitepress-plugin-tabs`) get bundled into a single Renovate PR instead of one per package.
- Follows the same regex-match convention as the existing `qunit` group rule.

## Test plan
- [ ] Confirm Renovate picks up the new group on its next run and bundles docs-related updates together