### PR TITLE
ci: split browser-tests Development and Production into parallel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,8 +134,9 @@ jobs:
       fail-fast: false
       matrix:
         launcher: [Chrome] # Firefox currently has an issue on ubuntu we cannot replicate on macos 03/29/2023
+        stage: [development, production]
     runs-on: ubuntu-latest
-    name: Test ${{matrix.launcher}}
+    name: Test ${{matrix.launcher}} (${{ matrix.stage }})
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/setup
@@ -152,21 +153,10 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: failed-test-log.txt
-          key: failed-test-log_${{ github.sha }}
+          key: failed-test-log_${{ github.sha }}_${{ matrix.stage }}
 
-      - name: Development
-        run: timeout $BROWSER_TIMEOUT pnpm run test
-        env:
-          TESTEM_CI_LAUNCHER: ${{ matrix.launcher }}
-          CI: true
-          DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' && 'engine,socket.io*' }}
-          # DISPLAY_TEST_NAMES: true # uncomment this line to see the test names in the logs
-          FORCE_COLOR: 2
-          BROWSER_TIMEOUT: 600 # 10 minutes
-
-      - name: Production
-        id: run-tests-production
-        run: timeout $BROWSER_TIMEOUT pnpm test:production
+      - name: ${{ matrix.stage }}
+        run: timeout $BROWSER_TIMEOUT pnpm run ${{ matrix.stage == 'production' && 'test:production' || 'test' }}
         env:
           TESTEM_CI_LAUNCHER: ${{ matrix.launcher }}
           CI: true
@@ -176,10 +166,10 @@ jobs:
           BROWSER_TIMEOUT: 600 # 10 minutes
 
       - name: Upload testem logs
-        if: ${{ always() && steps.run-tests-production.conclusion != 'skipped' }}
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: client-testem-logs
+          name: client-testem-logs-${{ matrix.stage }}
           path: './tests/dont-write-new-tests-here/testem.log'
           retention-days: 1
 
@@ -188,13 +178,13 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: failed-test-log.txt
-          key: failed-test-log_${{ github.sha }}
+          key: failed-test-log_${{ github.sha }}_${{ matrix.stage }}
 
       - name: Archive Tests Execution File
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: (success() || failure()) && steps.retry-test-failures.outputs.cache-hit != 'true'
         with:
-          name: tests-execution-file-partition
+          name: tests-execution-file-partition-${{ matrix.stage }}
           path: 'tests/dont-write-new-tests-here/test-execution-*.json'
           retention-days: 1
 


### PR DESCRIPTION
## Summary
- The `browser-tests` job currently runs the Development and Production test suites sequentially in one job (~70s each), after a shared ~65s setup step.
- Splits them into two matrix legs (`stage: [development, production]`) so they run concurrently on separate runners instead of stacking in one job.
- `lts`/`releases` (`needs: [browser-tests]`) still wait for both legs since the job id is unchanged, so no downstream changes were needed there.

Per-leg adjustments to avoid the two parallel runs stepping on each other:
- Failed-test-retry cache key now includes `${{ matrix.stage }}` (was keyed only on `github.sha`, which both legs would've shared).
- `client-testem-logs` and `tests-execution-file-partition` artifact names now include `${{ matrix.stage }}`, since `upload-artifact@v4` requires unique names per run.
- The `Upload testem logs` step's `steps.run-tests-production.conclusion != 'skipped'` guard was removed — each leg only has one test step now, so it always runs.

## Test plan
- [ ] CI: confirm both `Test Chrome (development)` and `Test Chrome (production)` jobs run and pass
- [ ] Confirm `lts` and `releases` still wait for both legs before starting
- [ ] Confirm failed-test retry and artifact upload work per-leg without collisions