### PR TITLE
chore(renovate): expand docs group with remaining docs-viewer plugins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,16 @@
       "groupName": "qunit"
     },
     {
-      "matchPackageNames": ["/typedoc/", "/vitepress/"],
+      "matchPackageNames": [
+        "/typedoc/",
+        "/vitepress/",
+        "vite-plugin-pwa",
+        "@mdit/plugin-footnote",
+        "vite-plugin-image-optimizer",
+        "svgo",
+        "sharp",
+        "front-matter"
+      ],
       "groupName": "docs"
     },
     {


### PR DESCRIPTION
## Summary
- Adds `vite-plugin-pwa`, `@mdit/plugin-footnote`, `vite-plugin-image-optimizer`, `svgo`, `sharp`, and `front-matter` to the existing `docs` Renovate group (added in #10762), so these `docs-viewer` build/asset-processing dependencies update together with typedoc/vitepress instead of generating separate PRs.
- All six package names confirmed against `docs-viewer/package.json`.

## Test plan
- [ ] Confirm Renovate bundles updates for these packages into the `docs` group on its next run