### PR TITLE
chore: reduce pnpm security age strictness from 2yrs to 1yr

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20400,6 +20400,9 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/eslint-scope@3.7.7':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,33 +55,35 @@ trustPolicy: no-downgrade
 ## for native-binary packages that ship per-platform builds, e.g.
 ## @oxc-parser's platform binaries) than an active compromise.
 ##
-## 1051200 minutes = 2 years -- long enough that "published a while ago"
+## 525600 minutes = 1 year -- long enough that "published a while ago"
 ## reliably means "aged past the danger window", rather than tying this to
 ## the much shorter minimumReleaseAge above, which is about delaying
 ## brand-new releases rather than judging whether a trust regression is
 ## still a meaningful signal.
 ##
-trustPolicyIgnoreAfter: 1051200
+trustPolicyIgnoreAfter: 525600
 
 ## hosted-git-info@6.1.3 (2024-11-21) is a transitive dependency of the
 ## frozen ember-cli@4.12.3 fixture used by the ember-lts-3.28 ember-try
-## scenario. It isn't old enough yet to clear trustPolicyIgnoreAfter above
-## (needs ~2026-11-21), but it never had provenance to begin with -- the
-## "downgrade" is pnpm comparing it against a *later major* (7.x/8.x) that
-## added provenance, not an actual regression within the 6.x line. See
+## scenario. It never had provenance to begin with -- the "downgrade" is
+## pnpm comparing it against a *later major* (7.x/8.x) that added
+## provenance, not an actual regression within the 6.x line. See
 ## https://github.com/pnpm/pnpm/issues/10202. ember-cli@4.12.3 is a fixed,
-## never-changing version, so this pin is safe to carry indefinitely.
+## never-changing version, so this pin is safe to carry indefinitely. Now
+## also covered by trustPolicyIgnoreAfter above regardless; kept explicit
+## for documentation and in case the window is widened again later.
 ##
 trustPolicyExclude:
   - hosted-git-info@6.1.3
   ## @embroider/config-meta-loader@1.0.1-unstable.f9c81e9 (2025-03-14) is
-  ## pinned exactly across several tests/* fixtures. It isn't old enough yet
-  ## to clear trustPolicyIgnoreAfter above (needs ~2027-03-14), but the
-  ## "downgrade" is pnpm comparing it against a *later, unrelated* 1.0.0
-  ## release (2025-04-03) that added provenance -- not a regression within
-  ## this "-unstable" prerelease line, which never had provenance to begin
-  ## with. Same pnpm/pnpm#10202 false positive as hosted-git-info@6.1.3
-  ## above.
+  ## pinned exactly across several tests/* fixtures. The "downgrade" is
+  ## pnpm comparing it against a *later, unrelated* 1.0.0 release
+  ## (2025-04-03) that added provenance -- not a regression within this
+  ## "-unstable" prerelease line, which never had provenance to begin with.
+  ## Same pnpm/pnpm#10202 false positive as hosted-git-info@6.1.3 above.
+  ## Now also covered by trustPolicyIgnoreAfter above regardless; kept
+  ## explicit for documentation and in case the window is widened again
+  ## later.
   - "@embroider/config-meta-loader@1.0.1-unstable.f9c81e9"
   ## undici-types@6.21.0 (2024-11-13) is a transitive dependency of
   ## @types/node -- effectively unpinnable directly, since it's whatever
@@ -91,7 +93,9 @@ trustPolicyExclude:
   ## entries above: pnpm compares against later releases (here, even later
   ## releases within the *same* 6.x line) regardless of whether provenance
   ## was ever a realistic expectation for the version actually being
-  ## installed.
+  ## installed. Now also covered by trustPolicyIgnoreAfter above
+  ## regardless; kept explicit for documentation and in case the window is
+  ## widened again later.
   - undici-types@6.21.0
 
 packages:


### PR DESCRIPTION
<!-- AUTO-GENERATED SUMMARY -->

