### PR TITLE
chore(deps): dedupe lodash, caniuse-lite, rollup, and babel across the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,13 @@
       "testem": "~3.11.0",
       "typescript": "5.9.2",
       "@types/bun": "1.3.14",
-      "bun-types": "1.3.14"
+      "bun-types": "1.3.14",
+      "lodash": "^4.18.1",
+      "caniuse-lite": "^1.0.30001809",
+      "rollup": "^4.62.4",
+      "@babel/types": "^7.29.8",
+      "@babel/parser": "^7.29.8",
+      "@babel/traverse": "^7.29.8"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -44,7 +44,7 @@
     "ignore": "^7.0.5",
     "inquirer": "^10.0.0",
     "jscodeshift": "^17.3.0",
-    "prettier": "3.6.2",
+    "prettier": "^3.8.1",
     "strip-ansi": "^7.1.0",
     "typescript": "^5.9.3",
     "winston": "^3.17.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ overrides:
   typescript: 5.9.2
   '@types/bun': 1.3.14
   bun-types: 1.3.14
+  lodash: ^4.18.1
+  caniuse-lite: ^1.0.30001809
+  rollup: ^4.62.4
+  '@babel/types': ^7.29.8
+  '@babel/parser': ^7.29.8
+  '@babel/traverse': ^7.29.8
 
 packageExtensionsChecksum: sha256-LCLIYKLZ85Sw43nBftLnN6QRYf2xc5hd/XNTpLbwBeM=
 
@@ -474,8 +480,8 @@ importers:
         specifier: ^17.3.0
         version: 17.3.0
       prettier:
-        specifier: 3.6.2
-        version: 3.6.2
+        specifier: ^3.8.1
+        version: 3.8.1
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -1394,7 +1400,7 @@ importers:
         version: 1.20.6(acb8c44acf8e4c4c164bebbda8d94c61)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(21dcdae5c469ac5b0a3a896c983cfcd3)
+        version: 1.5.0(501fdc553beeddba5d4ad5b5689b99d4)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1409,7 +1415,7 @@ importers:
         version: 2.0.3
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive-internal/specs':
         specifier: workspace:*
         version: file:specs(afc14080d36289e127bff205211fb83c)
@@ -1453,8 +1459,8 @@ importers:
         specifier: workspace:*
         version: file:packages/eslint-plugin-warp-drive(ed922cd6604ff90d7e65898b45d638bf)
       rollup:
-        specifier: ^4.46.2
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -1748,13 +1754,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(@babel/core@7.29.7)
@@ -1792,8 +1798,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -1835,13 +1841,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -1876,8 +1882,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -1940,13 +1946,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(@babel/core@7.29.7)
@@ -1978,8 +1984,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -2024,13 +2030,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(@babel/core@7.29.7)
@@ -2065,8 +2071,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -2255,7 +2261,7 @@ importers:
         version: 1.20.6(acb8c44acf8e4c4c164bebbda8d94c61)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(21dcdae5c469ac5b0a3a896c983cfcd3)
+        version: 1.5.0(501fdc553beeddba5d4ad5b5689b99d4)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2270,7 +2276,7 @@ importers:
         version: 2.0.3
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(acb8c44acf8e4c4c164bebbda8d94c61)
@@ -2317,8 +2323,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.43.1
         version: 5.43.1
@@ -2354,7 +2360,7 @@ importers:
         version: 1.20.6(acb8c44acf8e4c4c164bebbda8d94c61)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(21dcdae5c469ac5b0a3a896c983cfcd3)
+        version: 1.5.0(501fdc553beeddba5d4ad5b5689b99d4)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2369,7 +2375,7 @@ importers:
         version: 2.0.3
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive-internal/specs':
         specifier: workspace:*
         version: file:specs(ccf6b20aa692b5661bd86dff4bc04865)
@@ -2410,8 +2416,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.43.1
         version: 5.43.1
@@ -2645,13 +2651,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(@babel/core@7.29.7)
@@ -2692,8 +2698,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -2732,7 +2738,7 @@ importers:
         version: 1.20.6(acb8c44acf8e4c4c164bebbda8d94c61)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(21dcdae5c469ac5b0a3a896c983cfcd3)
+        version: 1.5.0(501fdc553beeddba5d4ad5b5689b99d4)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2747,7 +2753,7 @@ importers:
         version: 2.0.3
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive-internal/specs':
         specifier: workspace:*
         version: file:specs(ccf6b20aa692b5661bd86dff4bc04865)
@@ -2791,8 +2797,8 @@ importers:
         specifier: workspace:*
         version: file:packages/eslint-plugin-warp-drive(ed922cd6604ff90d7e65898b45d638bf)
       rollup:
-        specifier: ^4.46.2
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -2831,13 +2837,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -2872,8 +2878,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.43.1
         version: 5.43.1
@@ -2885,7 +2891,7 @@ importers:
         version: 1.2.1
       vite-plugin-compression2:
         specifier: ^2.2.0
-        version: 2.2.0(rollup@4.48.1)
+        version: 2.2.0(rollup@4.62.4)
       zlib:
         specifier: 1.0.5
         version: 1.0.5
@@ -2951,13 +2957,13 @@ importers:
         version: 1.20.6(@babel/core@7.29.7)
       '@embroider/vite':
         specifier: ^1.5.0
-        version: 1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)
+        version: 1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)
       '@glimmer/component':
         specifier: ^2.0.0
         version: 2.0.0
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.7)(rollup@4.48.1)
+        version: 6.0.4(@babel/core@7.29.7)(rollup@4.62.4)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(@babel/core@7.29.7)
@@ -2992,8 +2998,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@babel/core@7.29.7)
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       terser:
         specifier: ^5.39.0
         version: 5.43.1
@@ -3229,7 +3235,7 @@ importers:
         version: 9.34.0
       '@nullvoxpopuli/ember-rolldown':
         specifier: ^2.7.0
-        version: 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+        version: 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.7)
@@ -3282,8 +3288,8 @@ importers:
         specifier: ^16.3.0
         version: 16.3.0
       rollup:
-        specifier: ^4.48.0
-        version: 4.48.1
+        specifier: ^4.62.4
+        version: 4.62.4
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.2)
@@ -4156,11 +4162,6 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.28.3':
-    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
@@ -4746,28 +4747,8 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.3':
-    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.28.4':
-    resolution: {integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.28.6':
-    resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.29.8':
     resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.1':
-    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.2':
-    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.8':
@@ -4956,7 +4937,7 @@ packages:
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
     peerDependencies:
-      rollup: ^4.6.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -6516,7 +6497,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       '@types/babel__core': ^7.1.9
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       '@types/babel__core':
         optional: true
@@ -6529,7 +6510,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       '@types/babel__core': ^7.1.9
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       '@types/babel__core':
         optional: true
@@ -6542,7 +6523,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       '@types/babel__core': ^7.1.9
-      rollup: ^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       '@types/babel__core':
         optional: true
@@ -6553,7 +6534,7 @@ packages:
     resolution: {integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^2.78.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -6562,7 +6543,7 @@ packages:
     resolution: {integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -6571,7 +6552,7 @@ packages:
     resolution: {integrity: sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      rollup: ^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -6580,24 +6561,14 @@ packages:
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.62.4
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.48.1':
-    resolution: {integrity: sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.62.4':
     resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.48.1':
-    resolution: {integrity: sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.4':
@@ -6605,19 +6576,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.48.1':
-    resolution: {integrity: sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.4':
     resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.48.1':
-    resolution: {integrity: sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.4':
@@ -6625,19 +6586,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.48.1':
-    resolution: {integrity: sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.4':
     resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.48.1':
-    resolution: {integrity: sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.4':
@@ -6645,23 +6596,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.48.1':
-    resolution: {integrity: sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.48.1':
-    resolution: {integrity: sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
@@ -6669,23 +6608,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.48.1':
-    resolution: {integrity: sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.48.1':
-    resolution: {integrity: sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
@@ -6705,18 +6632,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.48.1':
-    resolution: {integrity: sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.48.1':
-    resolution: {integrity: sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
@@ -6729,23 +6644,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.48.1':
-    resolution: {integrity: sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.48.1':
-    resolution: {integrity: sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
@@ -6753,21 +6656,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.48.1':
-    resolution: {integrity: sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.48.1':
-    resolution: {integrity: sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -6776,12 +6667,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.48.1':
-    resolution: {integrity: sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
@@ -6799,19 +6684,9 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.48.1':
-    resolution: {integrity: sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.4':
     resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.48.1':
-    resolution: {integrity: sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.4':
@@ -6821,11 +6696,6 @@ packages:
 
   '@rollup/rollup-win32-x64-gnu@4.62.4':
     resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.48.1':
-    resolution: {integrity: sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg==}
     cpu: [x64]
     os: [win32]
 
@@ -8478,9 +8348,6 @@ packages:
     resolution: {integrity: sha512-eOgiEWqjppB+3DN/5E82EQ8dTINus8d9GXMCbEsUnp2hcUIcXmBvzWmD3tXMk3CuBK0v+ddK9qw0EAF+JVRMjQ==}
     engines: {node: '>=10.13'}
 
-  caniuse-lite@1.0.30001735:
-    resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
-
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
@@ -8859,7 +8726,7 @@ packages:
       just: ^0.1.8
       liquid-node: ^3.0.1
       liquor: ^0.0.5
-      lodash: ^4.17.20
+      lodash: ^4.18.1
       marko: ^3.14.4
       mote: ^0.2.0
       mustache: ^4.0.1
@@ -11533,9 +11400,6 @@ packages:
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -12585,11 +12449,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -13045,12 +12904,7 @@ packages:
   rollup-plugin-copy-assets@2.0.3:
     resolution: {integrity: sha512-ETShhQGb9SoiwcNrvb3BhUNSGR89Jao0+XxxfzzLW1YsUzx8+rMO4z9oqWWmo6OHUmfNQRvqRj0cAyPkS9lN9w==}
     peerDependencies:
-      rollup: '>=1.1.2'
-
-  rollup@4.48.1:
-    resolution: {integrity: sha512-jVG20NvbhTYDkGAty2/Yh7HK6/q3DGSRH4o8ALKGArmMuaauM9kLfoMZ+WliPwA5+JHr2lTn3g557FxBV87ifg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
+      rollup: ^4.62.4
 
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
@@ -14235,7 +14089,7 @@ packages:
       bun-types-no-globals: '*'
       esbuild: '*'
       rolldown: '*'
-      rollup: '*'
+      rollup: ^4.62.4
       unloader: '*'
       vite: '*'
       webpack: '*'
@@ -15376,10 +15230,6 @@ snapshots:
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-
-  '@babel/parser@7.28.3':
-    dependencies:
       '@babel/types': 7.29.8
 
   '@babel/parser@7.29.8':
@@ -16608,42 +16458,6 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
 
-  '@babel/traverse@7.28.3':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.8
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.28.4':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.8
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.28.6':
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.8
-      '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.8
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.8
-      debug: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -16655,16 +16469,6 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.27.1':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-
-  '@babel/types@7.28.2':
-    dependencies:
-      '@babel/helper-string-parser': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.8':
     dependencies:
@@ -16778,7 +16582,7 @@ snapshots:
       ignore: 7.0.5
       inquirer: 10.2.2
       jscodeshift: 17.3.0
-      prettier: 3.6.2
+      prettier: 3.8.1
       strip-ansi: 7.1.0
       typescript: 5.9.2
       winston: 3.17.0
@@ -17310,7 +17114,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
       '@babel/runtime': 7.29.7
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.8
       '@embroider/core': 4.4.2(@glint/template@1.6.1)
       '@embroider/macros': 1.20.6(acb8c44acf8e4c4c164bebbda8d94c61)
       '@types/babel__code-frame': 7.0.6
@@ -17336,7 +17140,7 @@ snapshots:
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
       jsdom: 26.1.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       pkg-up: 3.1.0
       resolve: 1.22.10
       resolve-package-path: 4.0.3
@@ -17363,7 +17167,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
       '@babel/runtime': 7.29.7
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.29.8
       '@embroider/core': 4.4.2
       '@embroider/macros': 1.20.6(@babel/core@7.29.7)
       '@types/babel__code-frame': 7.0.6
@@ -17389,7 +17193,7 @@ snapshots:
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
       jsdom: 26.1.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       pkg-up: 3.1.0
       resolve: 1.22.10
       resolve-package-path: 4.0.3
@@ -17487,7 +17291,7 @@ snapshots:
       babel-import-util: 3.0.1
       ember-cli-babel: 8.2.0
       find-up: 5.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       resolve: 1.22.10
       semver: 7.7.2
     transitivePeerDependencies:
@@ -17501,7 +17305,7 @@ snapshots:
       babel-import-util: 3.0.1
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       find-up: 5.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       resolve: 1.22.10
       semver: 7.7.2
     transitivePeerDependencies:
@@ -17515,7 +17319,7 @@ snapshots:
       babel-import-util: 3.0.1
       ember-cli-babel: 8.2.0(@babel/core@7.29.7)
       find-up: 5.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       resolve: 1.22.10
       semver: 7.7.2
     optionalDependencies:
@@ -17600,41 +17404,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/vite@1.5.0(21dcdae5c469ac5b0a3a896c983cfcd3)':
+  '@embroider/vite@1.5.0(501fdc553beeddba5d4ad5b5689b99d4)':
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/core': 4.4.2(@glint/template@1.6.1)
       '@embroider/macros': 1.20.6(acb8c44acf8e4c4c164bebbda8d94c61)
       '@embroider/reverse-exports': 0.2.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.48.1)
-      assert-never: 1.4.0
-      browserslist: 4.25.2
-      browserslist-to-esbuild: 2.1.1(browserslist@4.25.2)
-      chalk: 5.6.2
-      content-tag: 4.2.0
-      debug: 4.4.1
-      fast-glob: 3.3.3
-      fs-extra: 10.1.0
-      jsdom: 25.0.1
-      send: 0.18.0
-      source-map-url: 0.4.1
-      terser: 5.43.1
-      vite: 7.3.1(terser@5.43.1)
-    transitivePeerDependencies:
-      - '@glint/template'
-      - bufferutil
-      - canvas
-      - rollup
-      - supports-color
-      - utf-8-validate
-
-  '@embroider/vite@1.5.0(5b7ff81b9dec3da9b574ea6a44e3bce8)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@embroider/core': 4.4.2
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
-      '@embroider/reverse-exports': 0.2.0
-      '@rollup/pluginutils': 5.1.4(rollup@4.48.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
       assert-never: 1.4.0
       browserslist: 4.25.2
       browserslist-to-esbuild: 2.1.1(browserslist@4.25.2)
@@ -17704,6 +17480,34 @@ snapshots:
       source-map-url: 0.4.1
       terser: 5.43.1
       vite: 7.3.1
+    transitivePeerDependencies:
+      - '@glint/template'
+      - bufferutil
+      - canvas
+      - rollup
+      - supports-color
+      - utf-8-validate
+
+  '@embroider/vite@1.5.0(a7e0a8a33bbba1613a4473ff30ce5eeb)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@embroider/core': 4.4.2
+      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/reverse-exports': 0.2.0
+      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
+      assert-never: 1.4.0
+      browserslist: 4.25.2
+      browserslist-to-esbuild: 2.1.1(browserslist@4.25.2)
+      chalk: 5.6.2
+      content-tag: 4.2.0
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      fs-extra: 10.1.0
+      jsdom: 25.0.1
+      send: 0.18.0
+      source-map-url: 0.4.1
+      terser: 5.43.1
+      vite: 7.3.1(terser@5.43.1)
     transitivePeerDependencies:
       - '@glint/template'
       - bufferutil
@@ -18560,53 +18364,32 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
 
-  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(@types/babel__core@7.20.5)(rollup@4.48.1)':
+  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(@types/babel__core@7.20.5)(rollup@4.62.4)':
     dependencies:
       '@babel/core': 7.29.7
       '@rolldown/pluginutils': 1.0.1
-      '@rollup/plugin-babel': 7.1.0(0b9d755f9298be48f19a9ba54f30bb2f)
+      '@rollup/plugin-babel': 7.1.0(45a47724d0c3ddc593192c302cc4ddd7)
     transitivePeerDependencies:
       - '@types/babel__core'
       - rollup
       - supports-color
 
-  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(rollup@4.48.1)':
+  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(rollup@4.62.4)':
     dependencies:
       '@babel/core': 7.29.7
       '@rolldown/pluginutils': 1.0.1
-      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(rollup@4.48.1)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(rollup@4.62.4)
     transitivePeerDependencies:
       - '@types/babel__core'
       - rollup
       - supports-color
 
-  '@nullvoxpopuli/ember-rolldown@2.7.0(21b3de1a5cac6d42a0c904ef4f131b45)':
+  '@nullvoxpopuli/ember-rolldown@2.7.0(076cebb5ec1e095ecf1ac53378db30f5)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@embroider/core': 4.4.2
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.48.1)
-      babel-plugin-ember-template-compilation: 4.0.0
-      content-tag: 4.2.0
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-    optionalDependencies:
-      tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@glint/template'
-      - '@types/babel__core'
-      - bufferutil
-      - canvas
-      - rollup
-      - supports-color
-      - utf-8-validate
-
-  '@nullvoxpopuli/ember-rolldown@2.7.0(32deefa55e09a77ad97a1a20a35e2740)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@embroider/core': 4.4.2
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.48.1)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(@types/babel__core@7.20.5)(rollup@4.62.4)
       babel-plugin-ember-template-compilation: 4.0.0
       content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.7)
@@ -18622,33 +18405,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nullvoxpopuli/ember-rolldown@2.7.0(5159dbb6ccbb10b65fdffb41dc84bb6f)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@embroider/core': 4.4.2(@glint/template@1.6.1)
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.48.1)
-      babel-plugin-ember-template-compilation: 4.0.0
-      content-tag: 4.2.0
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-    optionalDependencies:
-      tsdown: 0.22.14(typescript@5.9.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@glint/template'
-      - '@types/babel__core'
-      - bufferutil
-      - canvas
-      - rollup
-      - supports-color
-      - utf-8-validate
-
-  '@nullvoxpopuli/ember-rolldown@2.7.0(5aaf6904f4b62bc3ebd1ed7a2b8749af)':
+  '@nullvoxpopuli/ember-rolldown@2.7.0(52ee6e0e3587b83bbc0fb68dcf661ede)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@embroider/core': 4.4.2
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.48.1)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
       babel-plugin-ember-template-compilation: 4.0.0
       content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.7)
@@ -18664,12 +18426,54 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nullvoxpopuli/ember-rolldown@2.7.0(5ea8c13813352e102e7b60b4a20ecf96)':
+  '@nullvoxpopuli/ember-rolldown@2.7.0(83a7f8e739bc5bff11003b33fdb3f42f)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@embroider/core': 4.4.2(@glint/template@1.6.1)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
+      babel-plugin-ember-template-compilation: 4.0.0
+      content-tag: 4.2.0
+      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+    optionalDependencies:
+      tsdown: 0.22.14(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - '@types/babel__core'
+      - bufferutil
+      - canvas
+      - rollup
+      - supports-color
+      - utf-8-validate
+
+  '@nullvoxpopuli/ember-rolldown@2.7.0(a36ea611edff5ceb33c951b661f2b6b2)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@embroider/core': 4.4.2
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(@types/babel__core@7.20.5)(rollup@4.48.1)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
+      babel-plugin-ember-template-compilation: 4.0.0
+      content-tag: 4.2.0
+      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+    optionalDependencies:
+      tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - '@types/babel__core'
+      - bufferutil
+      - canvas
+      - rollup
+      - supports-color
+      - utf-8-validate
+
+  '@nullvoxpopuli/ember-rolldown@2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@embroider/core': 4.4.2
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
       babel-plugin-ember-template-compilation: 4.0.0
       content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.7)
@@ -19127,13 +18931,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@6.0.4(@babel/core@7.29.7)(rollup@4.48.1)':
+  '@rollup/plugin-babel@6.0.4(@babel/core@7.29.7)(rollup@4.62.4)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4(rollup@4.48.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
     optionalDependencies:
-      rollup: 4.48.1
+      rollup: 4.62.4
     transitivePeerDependencies:
       - supports-color
 
@@ -19147,26 +18951,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@7.1.0(0b9d755f9298be48f19a9ba54f30bb2f)':
+  '@rollup/plugin-babel@7.1.0(45a47724d0c3ddc593192c302cc4ddd7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4(rollup@4.48.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
       workerpool: 9.3.4
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.48.1
+      rollup: 4.62.4
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(rollup@4.48.1)':
+  '@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(rollup@4.62.4)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4(rollup@4.48.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
       workerpool: 9.3.4
     optionalDependencies:
-      rollup: 4.48.1
+      rollup: 4.62.4
     transitivePeerDependencies:
       - supports-color
 
@@ -19197,81 +19001,43 @@ snapshots:
 
   '@rollup/pluginutils@5.1.4':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.5
-
-  '@rollup/pluginutils@5.1.4(rollup@4.48.1)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.5
-    optionalDependencies:
-      rollup: 4.48.1
 
   '@rollup/pluginutils@5.1.4(rollup@4.62.4)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.4
 
-  '@rollup/rollup-android-arm-eabi@4.48.1':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.62.4':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.48.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.48.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.4':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.48.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.48.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.4':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.48.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.48.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.48.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.48.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.48.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
@@ -19283,43 +19049,22 @@ snapshots:
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.48.1':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.48.1':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.48.1':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.48.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.48.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.48.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.62.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.48.1':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
@@ -19331,22 +19076,13 @@ snapshots:
   '@rollup/rollup-openharmony-arm64@4.62.4':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.48.1':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.62.4':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.48.1':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.62.4':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.62.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.48.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.4':
@@ -19517,7 +19253,7 @@ snapshots:
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.8
-      '@babel/types': 7.27.1
+      '@babel/types': 7.29.8
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.7
@@ -20062,8 +19798,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.7)
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
       '@vue/babel-helper-vue-transform-on': 1.5.0
       '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.7)
       '@vue/shared': 3.5.18
@@ -20516,7 +20252,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20534,7 +20270,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20571,7 +20307,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(5159dbb6ccbb10b65fdffb41dc84bb6f)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(83a7f8e739bc5bff11003b33fdb3f42f)
       '@rolldown/plugin-babel': 0.2.3(76ae02852a388f8a0b5326c13ea94f1a)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20589,7 +20325,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20626,7 +20362,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(56ff18176b12193f0c1c1c271c3d01b5)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20644,7 +20380,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20681,7 +20417,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(21b3de1a5cac6d42a0c904ef4f131b45)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(a36ea611edff5ceb33c951b661f2b6b2)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20699,7 +20435,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20736,7 +20472,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(21b3de1a5cac6d42a0c904ef4f131b45)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(a36ea611edff5ceb33c951b661f2b6b2)
       '@rolldown/plugin-babel': 0.2.3(359fdc389a44e19a5aec38d478957a40)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20754,7 +20490,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20791,7 +20527,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20809,7 +20545,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20846,7 +20582,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(359fdc389a44e19a5aec38d478957a40)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20864,7 +20600,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20901,7 +20637,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(5ea8c13813352e102e7b60b4a20ecf96)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(076cebb5ec1e095ecf1ac53378db30f5)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20919,7 +20655,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -20956,7 +20692,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(5159dbb6ccbb10b65fdffb41dc84bb6f)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(83a7f8e739bc5bff11003b33fdb3f42f)
       '@rolldown/plugin-babel': 0.2.3(56ff18176b12193f0c1c1c271c3d01b5)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -20974,7 +20710,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -21011,7 +20747,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(76ae02852a388f8a0b5326c13ea94f1a)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -21029,7 +20765,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -21066,7 +20802,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(5159dbb6ccbb10b65fdffb41dc84bb6f)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(83a7f8e739bc5bff11003b33fdb3f42f)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -21084,7 +20820,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -21121,7 +20857,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(717f3e912b14f3dc61040ade147236d3)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -21139,7 +20875,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -21176,7 +20912,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(5aaf6904f4b62bc3ebd1ed7a2b8749af)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(52ee6e0e3587b83bbc0fb68dcf661ede)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -21194,7 +20930,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(tsx@4.20.5)(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -21231,7 +20967,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(32deefa55e09a77ad97a1a20a35e2740)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(b6311b2cd7278fa6ffc8f2e1155543ce)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(vite@7.3.1)
       '@rolldown/pluginutils': 1.0.1
       '@types/debug': 4.1.12
@@ -21249,7 +20985,7 @@ snapshots:
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       glob: 11.0.3
       globals: 16.3.0
-      rollup: 4.48.1
+      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.2)
@@ -22543,7 +22279,7 @@ snapshots:
 
   browserslist@4.25.2:
     dependencies:
-      caniuse-lite: 1.0.30001735
+      caniuse-lite: 1.0.30001809
       electron-to-chromium: 1.5.203
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.2)
@@ -22659,8 +22395,6 @@ snapshots:
   can-write-to-dir@1.1.1:
     dependencies:
       path-temp: 2.1.0
-
-  caniuse-lite@1.0.30001735: {}
 
   caniuse-lite@1.0.30001809: {}
 
@@ -23031,11 +22765,11 @@ snapshots:
       ora: 3.4.0
       through2: 3.0.2
 
-  consolidate@0.16.0(lodash@4.17.21)(mustache@4.2.0):
+  consolidate@0.16.0(lodash@4.18.1)(mustache@4.2.0):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       mustache: 4.2.0
 
   consolidate@0.16.0(mustache@4.2.0):
@@ -23771,7 +23505,7 @@ snapshots:
       inquirer: 13.2.1
       is-git-url: 1.0.0
       is-language-code: 5.1.3
-      lodash: 4.17.21
+      lodash: 4.18.1
       markdown-it: 14.1.0
       markdown-it-terminal: 0.4.0(markdown-it@14.1.0)
       minimatch: 10.1.1
@@ -23792,7 +23526,7 @@ snapshots:
       silent-error: 1.1.1
       sort-package-json: 3.6.1
       symlink-or-copy: 1.3.1
-      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)(lodash@4.17.21)
+      testem: 3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)(lodash@4.18.1)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       walk-sync: 4.0.1
@@ -24674,7 +24408,7 @@ snapshots:
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -24763,7 +24497,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -26112,7 +25846,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   is-regex@1.2.1:
     dependencies:
@@ -26253,7 +25987,7 @@ snapshots:
   jscodeshift@17.3.0:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.29.8
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1(@babel/core@7.29.7)
@@ -26583,8 +26317,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.uniqby@4.7.0: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 
@@ -27729,15 +27461,13 @@ snapshots:
 
   prettier-plugin-ember-template-tag@2.1.3(prettier@3.8.1):
     dependencies:
-      '@babel/traverse': 7.28.6
+      '@babel/traverse': 7.29.8
       content-tag: 4.1.0
       prettier: 3.8.1
     transitivePeerDependencies:
       - supports-color
 
   prettier@2.8.8: {}
-
-  prettier@3.6.2: {}
 
   prettier@3.8.1: {}
 
@@ -28251,32 +27981,6 @@ snapshots:
   rollup-plugin-copy-assets@2.0.3:
     dependencies:
       fs-extra: 7.0.1
-
-  rollup@4.48.1:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.48.1
-      '@rollup/rollup-android-arm64': 4.48.1
-      '@rollup/rollup-darwin-arm64': 4.48.1
-      '@rollup/rollup-darwin-x64': 4.48.1
-      '@rollup/rollup-freebsd-arm64': 4.48.1
-      '@rollup/rollup-freebsd-x64': 4.48.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.48.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.48.1
-      '@rollup/rollup-linux-arm64-gnu': 4.48.1
-      '@rollup/rollup-linux-arm64-musl': 4.48.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.48.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.48.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.48.1
-      '@rollup/rollup-linux-riscv64-musl': 4.48.1
-      '@rollup/rollup-linux-s390x-gnu': 4.48.1
-      '@rollup/rollup-linux-x64-gnu': 4.48.1
-      '@rollup/rollup-linux-x64-musl': 4.48.1
-      '@rollup/rollup-win32-arm64-msvc': 4.48.1
-      '@rollup/rollup-win32-ia32-msvc': 4.48.1
-      '@rollup/rollup-win32-x64-msvc': 4.48.1
-      fsevents: 2.3.3
 
   rollup@4.62.4:
     dependencies:
@@ -29253,7 +28957,7 @@ snapshots:
       - walrus
       - whiskers
 
-  testem@3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)(lodash@4.17.21):
+  testem@3.11.0(patch_hash=cf147865cff81f2d0f3ed51d274f9fdee7b4ad675a902248aa317c07272fbea5)(lodash@4.18.1):
     dependencies:
       '@xmldom/xmldom': 0.8.10
       backbone: 1.6.1
@@ -29261,7 +28965,7 @@ snapshots:
       charm: 1.0.2
       commander: 2.20.3
       compression: 1.8.0
-      consolidate: 0.16.0(lodash@4.17.21)(mustache@4.2.0)
+      consolidate: 0.16.0(lodash@4.18.1)(mustache@4.2.0)
       execa: 1.0.0
       express: 4.21.2
       fireworm: 0.7.2
@@ -30013,9 +29717,9 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-compression2@2.2.0(rollup@4.48.1):
+  vite-plugin-compression2@2.2.0(rollup@4.62.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.4(rollup@4.48.1)
+      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
       tar-mini: 0.2.0
     transitivePeerDependencies:
       - rollup
@@ -30045,7 +29749,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.48.1
+      rollup: 4.62.4
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -30055,7 +29759,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.48.1
+      rollup: 4.62.4
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
@@ -30066,7 +29770,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.48.1
+      rollup: 4.62.4
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
## Summary
- Adds `pnpm.overrides` to force a single installed version of packages that were resolving to multiple copies purely due to un-normalized version ranges across transitive deps (all changes stay within the same major version):
  - `lodash` (4.17.21 + 4.18.1 → 4.18.1)
  - `caniuse-lite` (2 versions → latest)
  - `rollup` + `@rollup/rollup-darwin-arm64` (2 versions → latest)
  - `@babel/types`, `@babel/parser`, `@babel/traverse` (multiple minors → latest)
- Loosens `packages/codemods`'s exact `prettier: "3.6.2"` pin to `^3.8.1` so it dedupes against the root's prettier instead of shipping its own copy. Verified directly via the codemods fixture/unit tests (140 + 212 passing) since this is a runtime dependency of the published `@ember-data/codemods` package.
- Removes dead dependencies found while auditing what's actually used:
  - `co` — source usage was removed in `a7f3c6acf` ("chore: remove co usage") but the dependency itself was never dropped
  - `command-line-args` — added for an old release script that's since been rewritten; zero usage anywhere
  - `common-tags` — zero usage in our own source; still pulled in transitively via `vite-plugin-pwa` → `workbox-build`, so the explicit root declaration was redundant
  - `glob` in `tests/example-app-ember` — zero usage (the only "glob" hits were Vite's unrelated `import.meta.glob()` and `globalIgnores()`)
- Swaps `rimraf`'s one call site (`tests/smoke-tests/helpers.ts`) for `node:fs/promises`' `rm(path, { recursive: true, force: true })` (a stable builtin, well within this repo's `engines.node >= 25.5.0`), and drops the dependency.

Follow-up from investigating `node_modules` size/dedup opportunities after #10772.

## Test plan
- [x] `pnpm install` / `pnpm install --frozen-lockfile` succeed on top of latest `main`; each overridden package resolves to exactly one version in `node_modules/.pnpm`
- [x] `pnpm check:types` passes (81/81)
- [x] `packages/codemods` fixture tests (140/140) and unit tests (212/212) pass with the bumped prettier
- [x] `fs.rm` swap verified directly (recursive removal works) and the module loads cleanly under `bun`
- [x] `node_modules` size drops after `pnpm prune`
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)