### PR TITLE
chore(deps): remove dead url/zlib shims, replace tmp/strip-ansi with builtins

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,11 @@
     "globby": "^14.1.0",
     "lerna-changelog": "^2.2.0",
     "prettier": "^3.8.1",
-    "prettier-plugin-ember-template-tag": "^2.1.3",
+    "prettier-plugin-ember-template-tag": "^2.1.6",
     "semver": "^7.7.2",
     "silent-error": "^1.1.1",
     "typedoc": "^0.28.20",
-    "typescript": "^5.9.3",
-    "url": "^0.11.4",
-    "zlib": "1.0.5"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "turbo": "^2.7.6"

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -44,7 +44,6 @@
     "inquirer": "^10.0.0",
     "jscodeshift": "^17.3.0",
     "prettier": "^3.8.1",
-    "strip-ansi": "^7.1.0",
     "typescript": "^5.9.3",
     "winston": "^3.17.0"
   },

--- a/packages/codemods/utils/logger.ts
+++ b/packages/codemods/utils/logger.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import type { Options, SourceLocation } from 'jscodeshift';
-import { styleText } from 'node:util';
-import stripAnsi from 'strip-ansi';
+import { stripVTControlCharacters as stripAnsi,styleText } from 'node:util';
 import type { Logform, Logger as WinstonLogger } from 'winston';
 import { createLogger as createWinstonLogger, format as winstonFormat, transports as winstonTransports } from 'winston';
 

--- a/packages/codemods/utils/logger.ts
+++ b/packages/codemods/utils/logger.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import type { Options, SourceLocation } from 'jscodeshift';
-import { stripVTControlCharacters as stripAnsi,styleText } from 'node:util';
+import { stripVTControlCharacters as stripAnsi, styleText } from 'node:util';
 import type { Logform, Logger as WinstonLogger } from 'winston';
 import { createLogger as createWinstonLogger, format as winstonFormat, transports as winstonTransports } from 'winston';
 

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -98,8 +98,7 @@
     "@warp-drive/react": "workspace:*",
     "debug": "^4.4.1",
     "dom-element-descriptors": "^0.5.1",
-    "qunit-dom": "^3.5.0",
-    "tmp": "^0.2.5"
+    "qunit-dom": "^3.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/packages/diagnostic/server/browsers/index.js
+++ b/packages/diagnostic/server/browsers/index.js
@@ -1,6 +1,6 @@
+import fs from 'node:fs';
 import os from 'os';
 import path from 'path';
-import tmp from 'tmp';
 
 import { debug } from '../utils/debug.js';
 import { isWin, platformName } from '../utils/platform.js';
@@ -140,21 +140,24 @@ export async function getBrowser(browser) {
 
 const TMP_DIRS = new Map();
 
+process.on('exit', () => {
+  for (const dir of TMP_DIRS.values()) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 export function getTmpDir(browser) {
   if (TMP_DIRS.has(browser)) {
-    return TMP_DIRS.get(browser).name;
+    return TMP_DIRS.get(browser);
   }
 
   const userDataDir = os.tmpdir();
   const tmpPath = path.join(userDataDir, 'testem-' + browser.replace(' ', '_'));
 
-  const tmpDir = tmp.dirSync({
-    template: `${tmpPath}-XXXXXX`,
-    unsafeCleanup: true,
-  });
+  const tmpDir = fs.mkdtempSync(`${tmpPath}-`);
 
   TMP_DIRS.set(browser, tmpDir);
-  return tmpDir.name;
+  return tmpDir;
 }
 
 export function recommendedArgs(browser, options = {}) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       prettier-plugin-ember-template-tag:
-        specifier: ^2.1.3
-        version: 2.1.3(prettier@3.8.1)
+        specifier: ^2.1.6
+        version: 2.1.7(prettier@3.8.1)
       semver:
         specifier: ^7.7.2
         version: 7.7.2
@@ -130,12 +130,6 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-      url:
-        specifier: ^0.11.4
-        version: 0.11.4
-      zlib:
-        specifier: 1.0.5
-        version: 1.0.5
 
   docs-viewer:
     dependencies:
@@ -458,9 +452,6 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
-      strip-ansi:
-        specifier: ^7.1.0
-        version: 7.1.0
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -578,9 +569,6 @@ importers:
       qunit-dom:
         specifier: ^3.5.0
         version: 3.5.0
-      tmp:
-        specifier: ^0.2.5
-        version: 0.2.5
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -1636,8 +1624,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(@babel/core@7.29.7)
       ember-template-imports:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.4.0
+        version: 4.4.0
       ember-try:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3160,8 +3148,8 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       prettier-plugin-ember-template-tag:
-        specifier: ^2.1.3
-        version: 2.1.3(prettier@3.8.1)
+        specifier: ^2.1.6
+        version: 2.1.7(prettier@3.8.1)
       qunit:
         specifier: 2.19.4
         version: 2.19.4(patch_hash=44177f0047189d474ebdeba20fc8ddc3c8c2a5777d65cbb5f0fac0979bf66301)
@@ -3222,8 +3210,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       ember-eslint-parser:
-        specifier: ^0.5.11
-        version: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+        specifier: ^0.14.4
+        version: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint:
         specifier: ^9.34.0
         version: 9.34.0
@@ -3464,8 +3452,8 @@ importers:
         specifier: ~6.12.0
         version: 6.12.0(@glimmer/component@2.0.0)
       ember-template-imports:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.4.0
+        version: 4.4.0
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.2)
@@ -9433,8 +9421,8 @@ packages:
     resolution: {integrity: sha512-GeI1LLLt470sjaq/huKGQTDJPDOH0FlrX8FFVcSZPXO2U9FQH7Kc8BaXb4GpViJbfLLC4d7tIUZI4NBnuXSmKg==}
     engines: {node: 10.* || >= 12}
 
-  ember-template-imports@4.3.0:
-    resolution: {integrity: sha512-jZ5D6KLKU8up/AynZltmKh4lkXBPgTGSPgomprI/55XvIVqn42UNUpEz7ra/mO3QiGODDZOUesbggPe49i38sQ==}
+  ember-template-imports@4.4.0:
+    resolution: {integrity: sha512-HNOHabTEMbRluci1uScvh3ljMDo9E46dHHNcJAIf5yjOhIQ/zN4Y0DVDWrRfcbihlHvt4v/iF69G+8tffC1YkA==}
     engines: {node: 16.* || >= 18}
 
   ember-tracked-storage-polyfill@1.0.0:
@@ -11745,10 +11733,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  mktemp@0.4.0:
-    resolution: {integrity: sha512-IXnMcJ6ZyTuhRmJSjzvHSRhlVPiN9Jwc6e59V0bEJ0ba6OBeX2L0E+mRN1QseeOF4mM+F1Rit6Nh7o+rl2Yn/A==}
-    engines: {node: '>0.9'}
-
   mktemp@2.0.2:
     resolution: {integrity: sha512-Q9wJ/xhzeD9Wua1MwDN2v3ah3HENsUVSlzzL9Qw149cL9hHZkXtQGl3Eq36BbdLV+/qUwaP1WtJQ+H/+Oxso8g==}
     engines: {node: 20 || 22 || 24}
@@ -12362,8 +12346,8 @@ packages:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
 
-  prettier-plugin-ember-template-tag@2.1.3:
-    resolution: {integrity: sha512-FfAvkU+fqDC3Zs8+qGhBHYuwq1DED+UTPMH33QXxivZxRekkItBNXfi1Y+YkIbhCnu6UeTE2aYdbQSLlkOC2bA==}
+  prettier-plugin-ember-template-tag@2.1.7:
+    resolution: {integrity: sha512-NQS/a03LCefDbOJ1o0NeN+4VdfZRJt6NBp6/5yLMXTQ2TNT4fkcbhfXkvcgl7lN9nmssm6GweX51G/CAEvtazg==}
     engines: {node: 18.* || >= 20}
     peerDependencies:
       prettier: '>= 3.0.0'
@@ -12457,9 +12441,6 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -12489,9 +12470,6 @@ packages:
   quick-lru@4.0.1:
     resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
     engines: {node: '>=8'}
-
-  quick-temp@0.1.8:
-    resolution: {integrity: sha512-YsmIFfD9j2zaFwJkzI6eMG7y0lQP7YeWzgtFgNl38pGWZBSXJooZbOWwkcRot7Vt0Fg9L23pX0tqWU3VvLDsiA==}
 
   quick-temp@0.1.9:
     resolution: {integrity: sha512-yI0h7tIhKVObn03kD+Ln9JFi4OljD28lfaOsTdfpTR0xzrhGOod+q66CjGafUqYX2juUfT9oHIGrTBBo22mkRA==}
@@ -14058,10 +14036,6 @@ packages:
   url-parse-lax@3.0.0:
     resolution: {integrity: sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==}
     engines: {node: '>=4'}
-
-  url@0.11.4:
-    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
-    engines: {node: '>= 0.4'}
 
   use@3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
@@ -16497,7 +16471,6 @@ snapshots:
       inquirer: 10.2.2
       jscodeshift: 17.3.0
       prettier: 3.8.1
-      strip-ansi: 7.1.0
       typescript: 5.9.2
       winston: 3.17.0
     transitivePeerDependencies:
@@ -19525,7 +19498,7 @@ snapshots:
 
   '@typescript-eslint/project-service@8.41.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.41.0
       debug: 4.4.1
       typescript: 5.9.2
@@ -20022,7 +19995,6 @@ snapshots:
       debug: 4.4.1
       dom-element-descriptors: 0.5.1
       qunit-dom: 3.5.0
-      tmp: 0.2.5
     optionalDependencies:
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(993f53f6d041f81322d142b0c2ef5131)
     transitivePeerDependencies:
@@ -20038,7 +20010,6 @@ snapshots:
       debug: 4.4.1
       dom-element-descriptors: 0.5.1
       qunit-dom: 3.5.0
-      tmp: 0.2.5
     optionalDependencies:
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(030cd7dd2b3d1da08afa379351eb7195)
     transitivePeerDependencies:
@@ -20054,7 +20025,6 @@ snapshots:
       debug: 4.4.1
       dom-element-descriptors: 0.5.1
       qunit-dom: 3.5.0
-      tmp: 0.2.5
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -20068,7 +20038,6 @@ snapshots:
       debug: 4.4.1
       dom-element-descriptors: 0.5.1
       qunit-dom: 3.5.0
-      tmp: 0.2.5
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -20160,7 +20129,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20215,7 +20184,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20270,7 +20239,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20325,7 +20294,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20380,7 +20349,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20435,7 +20404,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20490,7 +20459,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20545,7 +20514,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20600,7 +20569,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20655,7 +20624,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20710,7 +20679,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20765,7 +20734,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20820,7 +20789,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -20875,7 +20844,7 @@ snapshots:
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
       comment-json: 4.2.5
       debug: 4.4.1
-      ember-eslint-parser: 0.5.11(3279a992b2d5b39bf1646384ab870d2f)
+      ember-eslint-parser: 0.14.4(51113162d3b00fee9b27a79065193efd)
       eslint: 9.34.0
       eslint-config-prettier: 10.1.8(eslint@9.34.0)
       eslint-plugin-import: 2.32.0(438d9ce730bf71cdcaed57735e15ead7)
@@ -22049,7 +22018,7 @@ snapshots:
   broccoli-plugin@1.3.1:
     dependencies:
       promise-map-series: 0.2.3
-      quick-temp: 0.1.8
+      quick-temp: 0.1.9
       rimraf: 2.7.1
       symlink-or-copy: 1.3.1
 
@@ -23571,6 +23540,22 @@ snapshots:
 
   ember-disable-prototype-extensions@1.1.3: {}
 
+  ember-eslint-parser@0.14.4(51113162d3b00fee9b27a79065193efd):
+    dependencies:
+      '@glimmer/syntax': 0.95.0
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.2)
+      content-tag: 4.2.0
+      ember-estree: 0.6.11
+      eslint-scope: 9.1.2
+      html-tags: 5.1.0
+      mathml-tag-names: 4.0.0
+      svg-tags: 1.0.0
+    optionalDependencies:
+      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.2)
+    transitivePeerDependencies:
+      - typescript
+
   ember-eslint-parser@0.14.4(855c0f8a9624c67993aff9e8e4964158):
     dependencies:
       '@glimmer/syntax': 0.95.0
@@ -23604,7 +23589,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@glimmer/syntax': 0.95.0
-      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@5.9.2)
       content-tag: 2.0.3
       eslint-scope: 7.2.2
       html-tags: 3.3.1
@@ -23833,10 +23818,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-template-imports@4.3.0:
+  ember-template-imports@4.4.0:
     dependencies:
       broccoli-stew: 3.0.0
-      content-tag: 3.1.3
+      content-tag: 4.2.0
       ember-cli-version-checker: 5.1.2
     transitivePeerDependencies:
       - supports-color
@@ -26743,8 +26728,6 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  mktemp@0.4.0: {}
-
   mktemp@2.0.2: {}
 
   mocha@11.2.2:
@@ -27340,10 +27323,10 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-ember-template-tag@2.1.3(prettier@3.8.1):
+  prettier-plugin-ember-template-tag@2.1.7(prettier@3.8.1):
     dependencies:
       '@babel/traverse': 7.29.8
-      content-tag: 4.1.0
+      content-tag: 4.2.0
       prettier: 3.8.1
     transitivePeerDependencies:
       - supports-color
@@ -27407,8 +27390,6 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  punycode@1.4.1: {}
-
   punycode@2.3.1: {}
 
   qs@6.13.0:
@@ -27433,12 +27414,6 @@ snapshots:
       resolve: 1.22.11
 
   quick-lru@4.0.1: {}
-
-  quick-temp@0.1.8:
-    dependencies:
-      mktemp: 0.4.0
-      rimraf: 2.7.1
-      underscore.string: 3.3.6
 
   quick-temp@0.1.9:
     dependencies:
@@ -29085,7 +29060,7 @@ snapshots:
       debug: 4.4.1
       fs-tree-diff: 2.0.1
       mkdirp: 0.5.6
-      quick-temp: 0.1.8
+      quick-temp: 0.1.9
       walk-sync: 0.3.4
     transitivePeerDependencies:
       - supports-color
@@ -29539,11 +29514,6 @@ snapshots:
   url-parse-lax@3.0.0:
     dependencies:
       prepend-http: 2.0.0
-
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.14.0
 
   use@3.1.1: {}
 

--- a/tests/dont-write-new-tests-here/package.json
+++ b/tests/dont-write-new-tests-here/package.json
@@ -92,7 +92,7 @@
     "ember-source": "~6.12.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-strict-resolver": "^1.3.0",
-    "ember-template-imports": "4.3.0",
+    "ember-template-imports": "4.4.0",
     "ember-try": "^4.0.0",
     "loader.js": "^4.7.0",
     "pretender": "^3.4.7",

--- a/tests/performance/fixtures/index.js
+++ b/tests/performance/fixtures/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const zlib = require('zlib');
+const zlib = require('node:zlib');
 
 console.log(`\n\nRegenerating Fixtures For Performance Benchmarks`);
 const BROTLI_OPTIONS = {

--- a/tests/performance/vite.config.mjs
+++ b/tests/performance/vite.config.mjs
@@ -4,7 +4,7 @@ import { babel } from '@rollup/plugin-babel';
 import { compression } from 'vite-plugin-compression2';
 // import { analyzer } from 'vite-bundle-analyzer';
 
-import zlib from 'zlib';
+import zlib from 'node:zlib';
 
 export default defineConfig({
   plugins: [

--- a/tests/smoke-tests/dt-types/package.json
+++ b/tests/smoke-tests/dt-types/package.json
@@ -102,7 +102,7 @@
     "globals": "^16.3.0",
     "loader.js": "^4.7.0",
     "prettier": "^3.8.1",
-    "prettier-plugin-ember-template-tag": "^2.1.3",
+    "prettier-plugin-ember-template-tag": "^2.1.6",
     "qunit": "^2.22.0",
     "qunit-dom": "^3.5.0",
     "tracked-built-ins": "^4.0.0",

--- a/tests/smoke-tests/native-types/package.json
+++ b/tests/smoke-tests/native-types/package.json
@@ -82,7 +82,7 @@
     "globals": "^16.3.0",
     "loader.js": "^4.7.0",
     "prettier": "^3.8.1",
-    "prettier-plugin-ember-template-tag": "^2.1.3",
+    "prettier-plugin-ember-template-tag": "^2.1.6",
     "qunit": "^2.22.0",
     "qunit-dom": "^3.5.0",
     "tracked-built-ins": "^4.0.0",

--- a/tests/vite-basic-compat/package.json
+++ b/tests/vite-basic-compat/package.json
@@ -81,7 +81,7 @@
     "globals": "^16.3.0",
     "loader.js": "^4.7.0",
     "prettier": "^3.8.1",
-    "prettier-plugin-ember-template-tag": "^2.1.3",
+    "prettier-plugin-ember-template-tag": "^2.1.6",
     "qunit": "^2.22.0",
     "qunit-dom": "^3.5.0",
     "tracked-built-ins": "^4.0.0",

--- a/tools/internal-config/package.json
+++ b/tools/internal-config/package.json
@@ -19,7 +19,7 @@
     "debug": "^4.4.1",
     "globals": "^16.3.0",
     "glob": "^11.0.3",
-    "ember-eslint-parser": "^0.5.11",
+    "ember-eslint-parser": "^0.14.4",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/warp-drive-packages/build-config/src/-private/utils/features.ts
+++ b/warp-drive-packages/build-config/src/-private/utils/features.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 
 import * as CURRENT_FEATURES from '../../canary-features.ts';
 type FEATURE = keyof typeof CURRENT_FEATURES;

--- a/warp-drive-packages/ember/package.json
+++ b/warp-drive-packages/ember/package.json
@@ -71,7 +71,7 @@
     "decorator-transforms": "^2.3.0",
     "ember-provide-consume-context": "^0.8.0",
     "ember-source": "~6.12.0",
-    "ember-template-imports": "^4.3.0",
+    "ember-template-imports": "^4.4.0",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
## Summary
- **Removes `url` and `zlib`** (root devDependencies) — both are npm packages that shadow Node core modules of the same name. Verified empirically (planted a fake `zlib` package in `node_modules` and confirmed Node's resolver ignored it for both `require()` and `import`) that these can never actually be loaded — Node always prefers its own builtins for bare specifiers like `'url'`/`'zlib'`. Updated the handful of `from 'url'`/`from 'zlib'` imports to the explicit `node:` prefix.
- **Replaces `tmp`** (`packages/diagnostic/server/browsers/index.js`) with `fs.mkdtempSync` + a `process.on('exit', ...)` cleanup handler, matching `tmp`'s own `unsafeCleanup` behavior. Verified: repeat calls for the same browser return the same dir, and the dir is removed on process exit.
- **Replaces `strip-ansi`** (`packages/codemods/utils/logger.ts`) with `util.stripVTControlCharacters`, merged into the file's existing `node:util` import (which already pulled in `styleText` from the earlier chalk removal).
- **Bumps stale template-tag tooling** that was pulling in old `content-tag` majors: `ember-eslint-parser` (`^0.5.11` → `^0.14.4`), `ember-template-imports` (`4.3.0` → `4.4.0`), `prettier-plugin-ember-template-tag` (`^2.1.3` → `^2.1.6`, capped below `2.1.8` to satisfy this repo's `minimumReleaseAge` guard).
  - Note: this did **not** reduce `content-tag`'s installed-version count (still 4) — each fix unmasked a different pre-existing consumer (`eslint-plugin-ember`, `@glint/ember-tsc`, `ember-cli`) that independently needed the same old version. Full consolidation would require a major `eslint-plugin-ember` bump (12→13, unverified rule changes) and/or bumping `@glint/ember-tsc` off a very old pinned override (`1.0.3` → latest `1.11.0`), both bigger/riskier than this PR's scope. Flagging as a follow-up, not attempting here.

## Test plan
- [x] `pnpm install` / `pnpm install --frozen-lockfile` succeed
- [x] `pnpm check:types` passes (81/81)
- [x] `pnpm lint` passes (84/84, after an import-sort autofix)
- [x] `pnpm test:vite` passes (2/2)
- [x] `packages/codemods` fixture (140) + unit (212) tests pass
- [x] Manually verified `getTmpDir` creates/caches/cleans up correctly, and `util.stripVTControlCharacters` round-trips ANSI-styled text correctly
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)