### PR TITLE
chore(deps): remove ember-cli-dependency-checker from dont-write-new-tests-here

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1581,9 +1581,6 @@ importers:
       ember-cli-babel:
         specifier: ^8.2.0
         version: 8.2.0(@babel/core@7.29.7)
-      ember-cli-dependency-checker:
-        specifier: ^3.3.3
-        version: 3.3.3(ember-cli@6.12.0)
       ember-cli-htmlbars:
         specifier: ^7.0.1
         version: 7.0.1(030cd7dd2b3d1da08afa379351eb7195)
@@ -9150,12 +9147,6 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     peerDependencies:
       ember-cli: '*'
-
-  ember-cli-dependency-checker@3.3.3:
-    resolution: {integrity: sha512-mvp+HrE0M5Zhc2oW8cqs8wdhtqq0CfQXAYzaIstOzHJJn/U01NZEGu3hz7J7zl/+jxZkyygylzcS57QqmPXMuQ==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      ember-cli: ^3.2.0 || >=4.0.0
 
   ember-cli-get-component-path-option@1.0.0:
     resolution: {integrity: sha512-k47TDwcJ2zPideBCZE8sCiShSxQSpebY2BHcX2DdipMmBox5gsfyVrbKJWIHeSTTKyEUgmBIvQkqTOozEziCZA==}
@@ -19045,6 +19036,9 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
@@ -19088,10 +19082,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -22945,15 +22945,6 @@ snapshots:
       tmp-sync: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  ember-cli-dependency-checker@3.3.3(ember-cli@6.12.0):
-    dependencies:
-      chalk: 2.4.2
-      ember-cli: 6.12.0
-      find-yarn-workspace-root: 2.0.0
-      is-git-url: 1.0.0
-      resolve: 1.22.10
-      semver: 5.7.2
 
   ember-cli-get-component-path-option@1.0.0: {}
 

--- a/tests/dont-write-new-tests-here/package.json
+++ b/tests/dont-write-new-tests-here/package.json
@@ -74,7 +74,6 @@
     "ember-cached-decorator-polyfill": "^1.0.2",
     "ember-cli": "~6.12.0",
     "ember-cli-babel": "^8.2.0",
-    "ember-cli-dependency-checker": "^3.3.3",
     "ember-cli-htmlbars": "^7.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-terser": "~4.0.2",


### PR DESCRIPTION
## Summary
Follow-up from a `node_modules` dependency audit — investigated why `ember-cli`, `ember-cli-blueprint-test-helpers`, and `ember-cli-dependency-checker` are still direct dependencies. The first two are genuinely load-bearing (Embroider's compat mode still needs `ember-cli`'s `EmberApp`/addon-resolution scaffolding even though final bundling goes through Vite; `ember-cli-blueprint-test-helpers` is directly `require()`'d by `tests/blueprints`'s mocha suite, which runs in CI via `blueprint-tests.yml`).

`ember-cli-dependency-checker` is different: it's default boilerplate that ships with every `ember new`-scaffolded app, not something added here deliberately. It self-registers as an Ember CLI addon (`init()` hook) and prints a console warning if npm dependency versions look mismatched — nothing in the repo asserts against or otherwise depends on that check.

## Test plan
- [x] `pnpm install` / `pnpm install --frozen-lockfile` succeed; no other reference to `ember-cli-dependency-checker` anywhere in the repo
- [x] `pnpm check:types` passes (81/81)
- [x] `pnpm --filter main-test-app run build:tests` builds successfully (this is the app that had the dependency)
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)