### PR TITLE
chore(deps): remove glob and globby, use node:fs's built-in glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-source": "~6.12.0",
     "execa": "^9.6.0",
     "git-repo-version": "^1.0.2",
-    "globby": "^14.1.0",
     "lerna-changelog": "^2.2.0",
     "prettier": "^3.8.1",
     "prettier-plugin-ember-template-tag": "^2.1.6",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "@ast-grep/napi": "^0.45.1",
     "commander": "^14.0.0",
-    "globby": "^14.1.0",
     "ignore": "^7.0.5",
     "inquirer": "^10.0.0",
     "jscodeshift": "^17.3.0",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ast-grep/napi": "^0.45.1",
     "commander": "^14.0.0",
-    "glob": "^11.0.0",
+    "globby": "^14.1.0",
     "ignore": "^7.0.5",
     "inquirer": "^10.0.0",
     "jscodeshift": "^17.3.0",

--- a/packages/codemods/src/schema-migration/codemod.ts
+++ b/packages/codemods/src/schema-migration/codemod.ts
@@ -1,6 +1,5 @@
 import { existsSync, mkdirSync, readFileSync } from 'fs';
-import { readFile } from 'fs/promises';
-import { globby } from 'globby';
+import { glob, readFile } from 'fs/promises';
 import { join, resolve } from 'path';
 
 import type { InstanciatedLogger } from '../../utils/logger.js';
@@ -97,7 +96,7 @@ async function findFiles(
 
   for (const source of sources) {
     try {
-      const files = await globby(source);
+      const files = await Array.fromAsync(glob(source));
 
       for (const file of files) {
         const skipReason = predicate(file);

--- a/packages/codemods/src/schema-migration/codemod.ts
+++ b/packages/codemods/src/schema-migration/codemod.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { readFile } from 'fs/promises';
-import { glob } from 'glob';
+import { globby } from 'globby';
 import { join, resolve } from 'path';
 
 import type { InstanciatedLogger } from '../../utils/logger.js';
@@ -97,7 +97,7 @@ async function findFiles(
 
   for (const source of sources) {
     try {
-      const files = await glob(source);
+      const files = await globby(source);
 
       for (const file of files) {
         const skipReason = predicate(file);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,9 +437,6 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
-      globby:
-        specifier: ^14.1.0
-        version: 14.1.0
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
@@ -3017,9 +3014,6 @@ importers:
       globals:
         specifier: ^16.3.0
         version: 16.3.0
-      globby:
-        specifier: ^14.1.0
-        version: 14.1.0
       rollup:
         specifier: ^4.62.4
         version: 4.62.4
@@ -3422,9 +3416,6 @@ importers:
       '@babel/traverse':
         specifier: ^7.29.8
         version: 7.29.8
-      globby:
-        specifier: ^14.1.0
-        version: 14.1.0
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -15818,7 +15809,6 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.45.1
       commander: 14.0.0
-      globby: 14.1.0
       ignore: 7.0.5
       inquirer: 10.2.2
       jscodeshift: 17.3.0
@@ -19399,7 +19389,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19454,7 +19443,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19509,7 +19497,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19564,7 +19551,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
       typescript: 5.9.2
@@ -19619,7 +19605,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
       typescript: 5.9.2
@@ -19674,7 +19659,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19729,7 +19713,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19784,7 +19767,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19839,7 +19821,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19894,7 +19875,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19949,7 +19929,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -20004,7 +19983,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(tsx@4.20.5)(typescript@5.9.2)
       typescript: 5.9.2
@@ -20059,7 +20037,6 @@ snapshots:
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.3.0
-      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -20233,7 +20210,6 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
       '@warp-drive/core': file:warp-drive-packages/core(acb8c44acf8e4c4c164bebbda8d94c61)
-      globby: 14.1.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,9 +437,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
-      glob:
-        specifier: ^11.0.0
-        version: 11.0.3
+      globby:
+        specifier: ^14.1.0
+        version: 14.1.0
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
@@ -3014,12 +3014,12 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@9.34.0)
-      glob:
-        specifier: ^11.0.3
-        version: 11.0.3
       globals:
         specifier: ^16.3.0
         version: 16.3.0
+      globby:
+        specifier: ^14.1.0
+        version: 14.1.0
       rollup:
         specifier: ^4.62.4
         version: 4.62.4
@@ -3422,9 +3422,9 @@ importers:
       '@babel/traverse':
         specifier: ^7.29.8
         version: 7.29.8
-      glob:
-        specifier: ^11.0.0
-        version: 11.0.3
+      globby:
+        specifier: ^14.1.0
+        version: 14.1.0
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -15818,7 +15818,7 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.45.1
       commander: 14.0.0
-      glob: 11.0.3
+      globby: 14.1.0
       ignore: 7.0.5
       inquirer: 10.2.2
       jscodeshift: 17.3.0
@@ -18523,6 +18523,9 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -18558,10 +18561,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -18581,6 +18590,9 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/esrecurse@4.3.1': {}
 
@@ -19386,8 +19398,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19441,8 +19453,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19496,8 +19508,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19551,8 +19563,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
       typescript: 5.9.2
@@ -19606,8 +19618,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(2d08bf30f09f74acf5c22716525a3b86)
       typescript: 5.9.2
@@ -19661,8 +19673,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19716,8 +19728,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19771,8 +19783,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19826,8 +19838,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19881,8 +19893,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19936,8 +19948,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -19991,8 +20003,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(tsx@4.20.5)(typescript@5.9.2)
       typescript: 5.9.2
@@ -20046,8 +20058,8 @@ snapshots:
       eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.2)
       eslint-plugin-qunit: 8.1.2(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      glob: 11.0.3
       globals: 16.3.0
+      globby: 14.1.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.2)
       typescript: 5.9.2
@@ -20221,7 +20233,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
       '@warp-drive/core': file:warp-drive-packages/core(acb8c44acf8e4c4c164bebbda8d94c61)
-      glob: 11.0.3
+      globby: 14.1.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
       git-repo-version:
         specifier: ^1.0.2
         version: 1.0.2
-      globby:
-        specifier: ^14.1.0
-        version: 14.1.0
       lerna-changelog:
         specifier: ^2.2.0
         version: 2.2.0
@@ -6391,10 +6388,6 @@ packages:
   '@simple-dom/interface@1.4.0':
     resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
 
-  '@sindresorhus/merge-streams@2.3.0':
-    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
-    engines: {node: '>=18'}
-
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -9936,10 +9929,6 @@ packages:
   globalyzer@0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
 
-  globby@14.1.0:
-    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
-    engines: {node: '>=18'}
-
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
@@ -11766,10 +11755,6 @@ packages:
     resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
     engines: {node: '>=16'}
 
-  path-type@6.0.0:
-    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
-    engines: {node: '>=18'}
-
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -12618,10 +12603,6 @@ packages:
   slash@2.0.0:
     resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
     engines: {node: '>=6'}
-
-  slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -18291,8 +18272,6 @@ snapshots:
       '@simple-dom/interface': 1.4.0
 
   '@simple-dom/interface@1.4.0': {}
-
-  '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -24084,15 +24063,6 @@ snapshots:
 
   globalyzer@0.1.0: {}
 
-  globby@14.1.0:
-    dependencies:
-      '@sindresorhus/merge-streams': 2.3.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      path-type: 6.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.3.0
-
   globrex@0.1.2: {}
 
   gopd@1.2.0: {}
@@ -26072,8 +26042,6 @@ snapshots:
 
   path-to-regexp@8.2.0: {}
 
-  path-type@6.0.0: {}
-
   pathe@1.1.2: {}
 
   pathe@2.0.3: {}
@@ -27076,8 +27044,6 @@ snapshots:
       totalist: 3.0.1
 
   slash@2.0.0: {}
-
-  slash@5.1.0: {}
 
   smart-buffer@4.2.0: {}
 

--- a/scripts/copy-declarations.mjs
+++ b/scripts/copy-declarations.mjs
@@ -1,6 +1,6 @@
 import { styleText } from 'node:util';
 import path from 'path';
-import { globby } from 'globby';
+import { glob } from 'node:fs/promises';
 import fs from 'fs';
 
 /** @type {import('bun-types')} */
@@ -53,14 +53,14 @@ async function main() {
     )
   );
 
-  const files = await globby([`${inputPath}/**/*.d.ts`]);
+  const files = await Array.fromAsync(glob(`${inputPath}/**/*.d.ts`));
 
   if (files.length === 0) {
     console.log(styleText('red', `\nNo **/*.d.ts files found in ${styleText('white', relativeInputPath)}\n`));
     process.exitCode = 1;
   }
 
-  console.log(styleText('grey', `\nFound ${styleText('cyan', files.length)} files\n`));
+  console.log(styleText('grey', `\nFound ${styleText('cyan', String(files.length))} files\n`));
 
   for (const file of files) {
     const relativeFile = path.relative(process.cwd(), file);
@@ -79,7 +79,7 @@ async function main() {
     await Bun.write(outFile, inFile);
   }
 
-  console.log(styleText('grey', styleText('bold', `\n✅ Copied ${styleText('cyan', files.length)} files\n`)));
+  console.log(styleText('grey', styleText('bold', `\n✅ Copied ${styleText('cyan', String(files.length))} files\n`)));
 }
 
 await main();

--- a/tools/internal-config/package.json
+++ b/tools/internal-config/package.json
@@ -18,7 +18,6 @@
     "comment-json": "^4.2.5",
     "debug": "^4.4.1",
     "globals": "^16.3.0",
-    "globby": "^14.1.0",
     "ember-eslint-parser": "^0.14.4",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",

--- a/tools/internal-config/package.json
+++ b/tools/internal-config/package.json
@@ -18,7 +18,7 @@
     "comment-json": "^4.2.5",
     "debug": "^4.4.1",
     "globals": "^16.3.0",
-    "glob": "^11.0.3",
+    "globby": "^14.1.0",
     "ember-eslint-parser": "^0.14.4",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",

--- a/tools/internal-config/rollup/external.js
+++ b/tools/internal-config/rollup/external.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { globSync } from '../utils/glob.js';
+import { globbySync } from 'globby';
 
 function loadConfig() {
   const configPath = path.join(process.cwd(), './package.json');
@@ -13,7 +13,7 @@ export function entryPoints(globs, resolve, options) {
 
   // expand all globs
   globs.forEach((glob) => {
-    glob.includes('*') || glob.includes('{') ? files.push(...globSync(glob)) : files.push(glob);
+    glob.includes('*') || glob.includes('{') ? files.push(...globbySync(glob)) : files.push(glob);
   });
 
   const srcDir = fixViteHijack(

--- a/tools/internal-config/rollup/external.js
+++ b/tools/internal-config/rollup/external.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs';
-import { globbySync } from 'globby';
 
 function loadConfig() {
   const configPath = path.join(process.cwd(), './package.json');
@@ -13,7 +12,7 @@ export function entryPoints(globs, resolve, options) {
 
   // expand all globs
   globs.forEach((glob) => {
-    glob.includes('*') || glob.includes('{') ? files.push(...globbySync(glob)) : files.push(glob);
+    glob.includes('*') || glob.includes('{') ? files.push(...fs.globSync(glob)) : files.push(glob);
   });
 
   const srcDir = fixViteHijack(

--- a/tools/internal-config/tsdown/keep-assets.js
+++ b/tools/internal-config/tsdown/keep-assets.js
@@ -1,6 +1,5 @@
 import { join } from 'path';
-import { copyFileSync, mkdirSync } from 'fs';
-import { globbySync } from 'globby';
+import { copyFileSync, globSync, mkdirSync } from 'fs';
 
 export function keepAssets({ from, include, dist }) {
   return {
@@ -9,7 +8,7 @@ export function keepAssets({ from, include, dist }) {
     // the assets go into the output directory in the same relative locations as
     // in the input directory
     async closeBundle() {
-      const files = globbySync(include, { cwd: join(process.cwd(), from) });
+      const files = globSync(include, { cwd: join(process.cwd(), from) });
       for (let name of files) {
         const fromPath = join(process.cwd(), from, name);
         const toPath = join(process.cwd(), dist, name);

--- a/tools/internal-config/tsdown/keep-assets.js
+++ b/tools/internal-config/tsdown/keep-assets.js
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { copyFileSync, mkdirSync } from 'fs';
-import { globSync } from '../utils/glob.js';
+import { globbySync } from 'globby';
 
 export function keepAssets({ from, include, dist }) {
   return {
@@ -9,7 +9,7 @@ export function keepAssets({ from, include, dist }) {
     // the assets go into the output directory in the same relative locations as
     // in the input directory
     async closeBundle() {
-      const files = globSync(include, { cwd: join(process.cwd(), from) });
+      const files = globbySync(include, { cwd: join(process.cwd(), from) });
       for (let name of files) {
         const fromPath = join(process.cwd(), from, name);
         const toPath = join(process.cwd(), dist, name);

--- a/tools/internal-config/utils/glob.js
+++ b/tools/internal-config/utils/glob.js
@@ -1,9 +1,0 @@
-import { sync } from 'glob';
-
-export function globSync(pattern, options) {
-  let result = [];
-  sync(pattern, options).forEach((file) => {
-    result.push(file);
-  });
-  return result;
-}

--- a/warp-drive-packages/schema-dsl/package.json
+++ b/warp-drive-packages/schema-dsl/package.json
@@ -48,8 +48,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.29.8",
-    "@babel/traverse": "^7.29.8",
-    "globby": "^14.1.0"
+    "@babel/traverse": "^7.29.8"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/warp-drive-packages/schema-dsl/package.json
+++ b/warp-drive-packages/schema-dsl/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@babel/parser": "^7.29.8",
     "@babel/traverse": "^7.29.8",
-    "glob": "^11.0.0"
+    "globby": "^14.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/warp-drive-packages/schema-dsl/src/vite-plugin.js
+++ b/warp-drive-packages/schema-dsl/src/vite-plugin.js
@@ -1,8 +1,7 @@
 import { parse } from '@babel/parser';
 import _traverse from '@babel/traverse';
-import { readFileSync } from 'fs';
+import { globSync, readFileSync } from 'fs';
 import { resolve } from 'path';
-import { globbySync } from 'globby';
 
 const traverse = typeof _traverse === 'function' ? _traverse : _traverse.default;
 
@@ -226,7 +225,7 @@ export function schemaDSL(options) {
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) return;
 
       const pattern = resolve(root, options.schemas);
-      const files = globbySync(pattern);
+      const files = globSync(pattern);
       const result = [];
 
       for (const file of files) {

--- a/warp-drive-packages/schema-dsl/src/vite-plugin.js
+++ b/warp-drive-packages/schema-dsl/src/vite-plugin.js
@@ -2,7 +2,7 @@ import { parse } from '@babel/parser';
 import _traverse from '@babel/traverse';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { globSync } from 'glob';
+import { globbySync } from 'globby';
 
 const traverse = typeof _traverse === 'function' ? _traverse : _traverse.default;
 
@@ -226,7 +226,7 @@ export function schemaDSL(options) {
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) return;
 
       const pattern = resolve(root, options.schemas);
-      const files = globSync(pattern);
+      const files = globbySync(pattern);
       const result = [];
 
       for (const file of files) {


### PR DESCRIPTION
## Summary
- Removes both `glob` and `globby` from the repo entirely, replacing all usages with Node's built-in `fs.glob`/`fs.globSync`/`fs.promises.glob` (stable well before this repo's `node >= 25.5.0` requirement).
- `glob` was a direct dependency of three packages (`@ember-data/codemods`, `@warp-drive/schema-dsl`, `@warp-drive/internal-config`); `globby` was a root devDependency used only by `scripts/copy-declarations.mjs`.
- Verified directly (not assumed) that the built-in covers every pattern actually used here, including brace expansion (`**/*.{js,ts}`) and absolute-path patterns. `docs-viewer/src/site-utils.ts` already uses the same built-in elsewhere in this repo.

## Changes
- `packages/codemods`: `glob()` (from `glob`) → `Array.fromAsync(glob(...))` (from `node:fs/promises`, whose `glob` returns an async iterable rather than a promise of an array)
- `warp-drive-packages/schema-dsl`: `globSync()` (from `glob`) → `globSync()` (from `node:fs`)
- `tools/internal-config`: deletes `utils/glob.js` (a thin wrapper around `glob`'s `sync()`) and points its two callers (`rollup/external.js`, `tsdown/keep-assets.js`) at `fs.globSync`/`globSync` directly
- `scripts/copy-declarations.mjs` (runs under Bun): `globby()` → `Array.fromAsync(glob(...))` from `node:fs/promises`, verified directly under `bun`
- Along the way, found and fixed a real, pre-existing, unrelated bug in `copy-declarations.mjs`: both `styleText('cyan', files.length)` calls passed a number where `util.styleText` requires a string, so the script threw `ERR_INVALID_ARG_TYPE` on every single run (confirmed this crashes identically with the old `globby`-based code, regardless of glob implementation). Wrapped both in `String()`.

## Test plan
- [x] Verified empirically that `fs.glob`/`fs.globSync`/`fs.promises.glob` handle brace expansion, arrays of patterns, `cwd`, and absolute/relative patterns matching every usage in this repo, under both Node and Bun
- [x] `tsc --noEmit` clean for `@ember-data/codemods`
- [x] `turbo run build:pkg --force` succeeds across all 35 packages (exercises `external.js`'s `entryPoints()` via every package's rollup/tsdown config)
- [x] `@warp-drive/schema-dsl`'s vite-plugin and `@warp-drive/internal-config`'s `keep-assets`/`external` smoke-tested directly with Node
- [x] `scripts/copy-declarations.mjs` smoke-tested directly with `bun`, both the zero-files and files-found paths
- [x] `lint` and `prettier --check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)