### PR TITLE
ci: route lts/releases matrix jobs through turbo for caching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,12 +213,19 @@ jobs:
         timeout-minutes: 12
         env:
           CI: true
+        # `@embroider/try apply` rewrites this package's package.json in place
+        # to pin the scenario's dependency versions (verified: it touches
+        # nothing else), and package.json is already a tracked build:tests/
+        # test input in turbo.json -- so routing through turbo here, instead
+        # of calling the package's own build:tests/test scripts directly,
+        # gets scenario-aware caching for free: a rerun of the same scenario
+        # on the same commit is a cache hit, while different scenarios still
+        # get distinct hashes because their pinned versions differ.
         run: |
           cd tests/dont-write-new-tests-here;
           pnpm dlx @embroider/try apply ${{ matrix.scenario }};
           pnpm install --no-frozen-lockfile --ignore-scripts --prefer-offline;
-          pnpm build:tests;
-          pnpm run test;
+          pnpm exec turbo run test;
 
   releases:
     timeout-minutes: 12
@@ -245,9 +252,12 @@ jobs:
       - name: Basic tests with ${{ matrix.release }}
         env:
           CI: true
+        # See the matching note on the `lts` job above: routing through turbo
+        # here (instead of the package's own build:tests/test scripts) gets
+        # scenario-aware caching for free, since @embroider/try apply's
+        # package.json rewrite is already a tracked turbo input.
         run: |
           cd tests/dont-write-new-tests-here;
           pnpm dlx @embroider/try apply ${{ matrix.release }};
           pnpm install --no-frozen-lockfile --ignore-scripts --prefer-offline;
-          pnpm build:tests;
-          pnpm run test;
+          pnpm exec turbo run test;


### PR DESCRIPTION
## Summary
- The `lts` (4 scenarios) and `releases` (2 channels) matrix jobs called `main-test-app`'s `build:tests`/`test` scripts directly, completely bypassing turbo. Every leg did a full, uncached ember build + test run on every push -- including reruns of the exact same commit.
- Verified `@embroider/try apply` (which replaced `ember-try` for this matrix in #10783) only ever rewrites this package's `package.json`, and does so deterministically from a clean checkout -- confirmed byte-identical output across two independent applications of the same scenario.
- `package.json` is already a tracked input on `build:tests`/`test` in `turbo.json`, so **no `turbo.json` changes are needed**: swapping the raw script calls for `pnpm exec turbo run test` (which pulls in `build:tests` as its dependency) gets scenario-aware caching for free -- same scenario reruns hit cache, different scenarios still get distinct hashes since their pinned dependency versions differ.

## Test plan
- [x] Verified locally: applying the same scenario twice from a clean `package.json` baseline produces byte-identical output
- [x] Verified locally: `turbo run build:tests` after applying a scenario is a cache miss the first time, then a `FULL TURBO` cache hit (22/22 cached) on rerun with no changes -- ~20s -> ~100ms
- [x] Verified locally: switching to a different scenario correctly misses the cache (no false collision)
- [ ] CI: confirm `lts`/`releases` jobs still pass with the turbo-routed invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)