### PR TITLE
ci: cache test outputs and give each job its own turbo cache slot

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -59,6 +59,12 @@ inputs:
     description: Whether to setup an SSL Cert
     required: false
     default: false
+  cache-key-suffix:
+    description: |
+      Identifies this job (and matrix leg, if any) for the local turbo build
+      cache -- see the note on 'Restore Turbo Local Build Cache' below.
+    required: false
+    default: 'install'
 
 runs:
   using: composite
@@ -117,23 +123,29 @@ runs:
         restore-keys: |
           turbo-remote-cache-
 
-    # `build:pkg`'s hash is purely a function of file contents, so it's
-    # identical for a given commit regardless of which workflow or job
-    # computes it. Turborepo always checks its local on-disk cache
-    # (`.turbo/cache`) before the remote
-    # (felixmosh) cache, so sharing that directory here -- keyed by commit,
-    # not by run -- lets whichever workflow builds it first save the others
-    # the redundant rebuild (and the matching remote-cache upload traffic).
-    # Whichever job computes it first wins the exact key (a hit skips both the
-    # rebuild and the no-op re-save); the prefix-matched restore-key gives
-    # partial reuse for unchanged packages across commits.
+    # Turborepo always checks its local on-disk cache (`.turbo/cache`) before
+    # the remote (felixmosh) cache, and every turbo task's hash is purely a
+    # function of file contents, so sharing that directory here -- keyed by
+    # commit, not by run -- lets a later job/workflow skip a rebuild another
+    # one already did for the same commit, without any remote-cache traffic.
+    #
+    # actions/cache keys are immutable: whichever job finishes first wins a
+    # given key, and every later job's save under that *same* key is silently
+    # a no-op. `cache-key-suffix` gives each job (and matrix leg) its own key,
+    # so e.g. browser-tests' own build:tests/test entries actually get saved
+    # instead of losing a race to whichever job saves under a shared key
+    # first (in practice, always `install`, since nothing else starts
+    # sooner). The `${{ github.sha }}-` restore-key still lets every job
+    # start by restoring *some* same-commit save -- typically install's,
+    # since it finishes first -- before adding its own entries on top.
     - name: 'Restore Turbo Local Build Cache'
       if: ${{ inputs.install == 'true' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo/cache
-        key: turbo-local-cache-${{ github.sha }}
+        key: turbo-local-cache-${{ github.sha }}-${{ inputs.cache-key-suffix }}
         restore-keys: |
+          turbo-local-cache-${{ github.sha }}-
           turbo-local-cache-
 
     - name: 'Setup local TurboRepo server'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           ACTIONS_RUNNER_DEBUG: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' }}
           DISABLE_TURBO_CACHE: ${{ secrets.ACTIONS_RUNNER_DEBUG == 'true' }}
+          cache-key-suffix: lint
       - name: Prettier
         run: pnpm lint:prettier
         env:
@@ -123,6 +124,7 @@ jobs:
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           with-cert: true
+          cache-key-suffix: special-build-tests-${{ matrix.name }}
       - name: ${{ matrix.name }}
         # -k sends SIGKILL 30s after SIGTERM in case a hung child (e.g. a
         # wedged headless Chrome) doesn't respond to SIGTERM alone, so a stuck
@@ -153,6 +155,7 @@ jobs:
           with-cert: true
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key-suffix: browser-tests-${{ matrix.stage }}
 
       - name: Check for Test Failure Retry
         id: retry-test-failures
@@ -209,6 +212,7 @@ jobs:
           with-cert: true
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key-suffix: lts-${{ matrix.scenario }}
       - name: Basic tests with ${{ matrix.scenario }}
         timeout-minutes: 12
         env:
@@ -249,6 +253,7 @@ jobs:
           with-cert: true
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-key-suffix: releases-${{ matrix.release }}
       - name: Basic tests with ${{ matrix.release }}
         env:
           CI: true

--- a/turbo.json
+++ b/turbo.json
@@ -277,14 +277,19 @@
       ]
     },
 
+    // outputs are the artifacts main.yml's browser-tests job uploads after
+    // this task runs (ember-exam/testem, only produced by main-test-app; a
+    // no-op glob match for every other package's test task). Declaring them
+    // means a cache hit restores the same files a real run would have
+    // produced, instead of leaving them stale/missing for those upload steps.
     "test": {
       "inputs": ["../../packages/diagnostic/server/**", "../../packages/holodeck/**", ".mock-cache/**"],
-      "outputs": [],
+      "outputs": ["testem.log", "test-execution-*.json"],
       "dependsOn": ["build:tests"]
     },
     "test:production": {
       "inputs": ["../../packages/diagnostic/server/**", "../../packages/holodeck/**", ".mock-cache/**"],
-      "outputs": [],
+      "outputs": ["testem.log", "test-execution-*.json"],
       "dependsOn": ["build:production"]
     }
   }


### PR DESCRIPTION
## Summary

Implements Findings 2 & 3 from the turbo-cache CI analysis (Finding 1 was #10797).

### Finding 2 — `test`/`test:production` had `outputs: []`
A cache hit skipped execution but restored nothing, so `testem.log`/`test-execution-*.json` (uploaded via `actions/upload-artifact` right after in `browser-tests`) were stale or missing on a hit, unlike a real run. Declared them as `outputs` (only `main-test-app` produces them; harmless no-op glob elsewhere) so a cache hit is fully equivalent to a real run for anything downstream.

### Finding 3 — only the `install` job ever actually persisted anything
`actions/cache` keys are immutable: the first job to finish wins a save under a given key, every later save under that *same* key silently no-ops. The shared `turbo-local-cache-<sha>` key meant only `install` (always first, since everything else `needs: [install]`) ever persisted anything -- `lint`'s own lint-cache, and every `browser-tests`/`special-build-tests`/`lts`/`releases` job's `build:tests`/`test` entries, were computed and then discarded at the end of each job.

Added a `cache-key-suffix` input to the setup action (default `'install'`, matching prior de facto behavior) so each job/matrix-leg gets its own slot (`lint`, `browser-tests-<stage>`, `special-build-tests-<name>`, `lts-<scenario>`, `releases-<release>`), with a new `turbo-local-cache-<sha>-` restore-key so every job still starts from *some* same-commit save (typically `install`'s) before adding its own entries on top.

## Test plan
- [x] Verified locally: `outputs` declaration correctly recognized by turbo (`--dry=json`)
- [x] Verified locally: swapped in a stand-in `test` script writing both files, confirmed cache miss → real write → delete files → rerun → `cache hit, replaying logs` with both files correctly restored with original content
- [ ] CI: confirm `lint`, `browser-tests`, `special-build-tests`, `lts`, `releases` all still pass with distinct cache slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)