### PR TITLE
perf(tests): skip minification in production test builds

### DIFF
--- a/tests/core/tests/polaris-mode/derivation-field-read-test.ts
+++ b/tests/core/tests/polaris-mode/derivation-field-read-test.ts
@@ -115,7 +115,7 @@ module('Reads | derivation', function (hooks) {
         (e as Error).message,
         DEBUG
           ? "No 'concat' derivation registered for use by the 'derived' field 'fullName'"
-          : 't.derivation(...) is not a function',
+          : 'schema.derivation(...) is not a function',
         'record.fullName throws'
       );
     }

--- a/tests/core/vite.config.mjs
+++ b/tests/core/vite.config.mjs
@@ -5,6 +5,9 @@ import { schemaDSL } from '@warp-drive/schema-dsl/vite';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: {
         tests: 'index.html',

--- a/tests/dont-write-new-tests-here/vite.config.mjs
+++ b/tests/dont-write-new-tests-here/vite.config.mjs
@@ -5,13 +5,10 @@ import { babel } from '@rollup/plugin-babel';
 export default defineConfig({
   build: {
     outDir: 'dist-test',
-    // @embroider/vite's `ember()` plugin defaults `build.minify` to
-    // `'terser'` for production builds unless something else is
-    // configured, which would require adding `terser` as a devDependency
-    // just for this test app. Use esbuild's (already-bundled, faster)
-    // minifier instead - exact minification output doesn't matter here
-    // since main-test-app is never published/shipped.
-    minify: 'esbuild',
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`
+    // for production builds. main-test-app is never published/shipped, so skip
+    // minification entirely rather than paying for it.
+    minify: false,
   },
   plugins: [
     classicEmberSupport(),

--- a/tests/ember-data__adapter/vite.config.mjs
+++ b/tests/ember-data__adapter/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: { tests: 'index.html' },
     },

--- a/tests/ember-data__graph/vite.config.mjs
+++ b/tests/ember-data__graph/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: { tests: 'index.html' },
     },

--- a/tests/experiments/vite.config.mjs
+++ b/tests/experiments/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: {
         tests: 'index.html',

--- a/tests/framework-ember/vite.config.mjs
+++ b/tests/framework-ember/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: {
         tests: 'index.html',

--- a/tests/json-api/vite.config.mjs
+++ b/tests/json-api/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: { tests: 'index.html' },
     },

--- a/tests/legacy/vite.config.mjs
+++ b/tests/legacy/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: {
         tests: 'index.html',

--- a/tests/utilities/vite.config.mjs
+++ b/tests/utilities/vite.config.mjs
@@ -4,6 +4,9 @@ import { babel } from '@rollup/plugin-babel';
 
 export default defineConfig({
   build: {
+    // @embroider/vite's `ember()` plugin defaults `build.minify` to `'terser'`.
+    // These are test-only bundles that are never shipped, so skip minification.
+    minify: false,
     rollupOptions: {
       input: { tests: 'index.html' },
     },


### PR DESCRIPTION
## Summary
- \`test:production\` depends on \`build:production\`, which runs \`vite build\` for each test app.
- \`@embroider/vite\`'s \`ember()\` plugin defaults \`build.minify\` to \`'terser'\` for production-mode builds. These bundles are test-only and never shipped, so paying for a terser pass just slows down the test run for no benefit.
- Set \`minify: false\` in the affected \`vite.config.mjs\` files (core, json-api, legacy, utilities, framework-ember, experiments, ember-data__graph, ember-data__adapter, dont-write-new-tests-here).
- \`framework-vue\`/\`framework-svelte\`/\`framework-react\` don't use the \`ember()\` plugin and already default to esbuild's minifier, so they're untouched. \`ember-data__request\`/\`ember-data__model\`'s \`build:production\`/\`test:production\` scripts are currently deactivated, so left as-is.

## Test plan
- [x] Ran \`build:production\` for \`tests/core\` locally and confirmed the build succeeds unminified.
- [ ] CI green across the test suites in \`test:production\`.