### PR TITLE
chore(deps): drop tsx from tests/codemods in favor of node's native TS support

### DIFF
--- a/packages/codemods/src/cli/apply.ts
+++ b/packages/codemods/src/cli/apply.ts
@@ -1,11 +1,11 @@
 import type { Command } from 'commander';
 import { Argument, Option } from 'commander';
 
-import { logger } from '../../utils/logger.js';
-import type { RunOptions } from '../legacy-compat-builders/run.js';
+import { logger } from '../../utils/logger.ts';
+import type { RunOptions } from '../legacy-compat-builders/run.ts';
 import type { MigrateOptions } from '../schema-migration/config.ts';
-import { type ConfigOptions, loadConfig, mergeOptions } from '../schema-migration/utils/config.js';
-import type { SharedCodemodOptions } from './index.js';
+import { type ConfigOptions, loadConfig, mergeOptions } from '../schema-migration/utils/config.ts';
+import type { SharedCodemodOptions } from './index.ts';
 
 export function createApplyCommand(program: Command) {
   const applyCommand = program

--- a/packages/codemods/src/cli/index.ts
+++ b/packages/codemods/src/cli/index.ts
@@ -1,8 +1,8 @@
 import { program } from 'commander';
 
 import { version } from '../../package.json' with { type: 'json' };
-import { createApplyCommand } from './apply.js';
-import { createListCommand } from './list.js';
+import { createApplyCommand } from './apply.ts';
+import { createListCommand } from './list.ts';
 
 export interface SharedCodemodOptions {
   dry?: boolean;

--- a/packages/codemods/src/index.ts
+++ b/packages/codemods/src/index.ts
@@ -1,2 +1,2 @@
-export { default as legacyCompatBuilders } from './legacy-compat-builders/index.js';
-export { log as legacyCompatBuildersLog } from './legacy-compat-builders/log.js';
+export { default as legacyCompatBuilders } from './legacy-compat-builders/index.ts';
+export { log as legacyCompatBuildersLog } from './legacy-compat-builders/log.ts';

--- a/packages/codemods/src/legacy-compat-builders/config.ts
+++ b/packages/codemods/src/legacy-compat-builders/config.ts
@@ -1,6 +1,6 @@
-import type { ImportInfo } from '../utils/imports.js';
-import type { Config } from './legacy-store-method.js';
-import { singularTypeParam, validateForFindRecord } from './legacy-store-method.js';
+import type { ImportInfo } from '../utils/imports.ts';
+import type { Config } from './legacy-store-method.ts';
+import { singularTypeParam, validateForFindRecord } from './legacy-store-method.ts';
 
 const LegacyCompatBuildersSourceValue = '@warp-drive/legacy/compat/builders';
 export const IMPORT_INFOS = [

--- a/packages/codemods/src/legacy-compat-builders/index.ts
+++ b/packages/codemods/src/legacy-compat-builders/index.ts
@@ -1,10 +1,10 @@
 import type { API, FileInfo } from 'jscodeshift';
 
-import { addImport, parseExistingImports } from '../utils/imports.js';
-import { CONFIGS, IMPORT_INFOS } from './config.js';
-import { transformLegacyStoreMethod } from './legacy-store-method.js';
-import type { Options } from './options.js';
-import { TransformResult } from './result.js';
+import { addImport, parseExistingImports } from '../utils/imports.ts';
+import { CONFIGS, IMPORT_INFOS } from './config.ts';
+import { transformLegacyStoreMethod } from './legacy-store-method.ts';
+import type { Options } from './options.ts';
+import { TransformResult } from './result.ts';
 
 /**
  * | Result       | How-to                      | Meaning                                            |

--- a/packages/codemods/src/legacy-compat-builders/legacy-store-method.ts
+++ b/packages/codemods/src/legacy-compat-builders/legacy-store-method.ts
@@ -14,13 +14,13 @@ import type {
   YieldExpression,
 } from 'jscodeshift';
 
-import { isRecord } from '../../utils/types.js';
-import { TransformError } from '../utils/error.js';
-import type { ParsedImportInfo } from '../utils/imports.js';
-import type { LegacyStoreMethod } from './config.js';
-import { log } from './log.js';
-import type { Options } from './options.js';
-import { TransformResult } from './result.js';
+import { isRecord } from '../../utils/types.ts';
+import { TransformError } from '../utils/error.ts';
+import type { ParsedImportInfo } from '../utils/imports.ts';
+import type { LegacyStoreMethod } from './config.ts';
+import { log } from './log.ts';
+import type { Options } from './options.ts';
+import { TransformResult } from './result.ts';
 
 interface LegacyStoreMethodCallExpression extends CallExpression {
   callee: MemberExpression & {

--- a/packages/codemods/src/legacy-compat-builders/log.ts
+++ b/packages/codemods/src/legacy-compat-builders/log.ts
@@ -1,3 +1,3 @@
-import { logger } from '../../utils/logger.js';
+import { logger } from '../../utils/logger.ts';
 
 export const log = logger.for('legacy-compat-builders');

--- a/packages/codemods/src/legacy-compat-builders/options.ts
+++ b/packages/codemods/src/legacy-compat-builders/options.ts
@@ -1,5 +1,5 @@
-import type { SharedCodemodOptions } from '../cli/index.js';
-import type { LegacyStoreMethod } from './config.js';
+import type { SharedCodemodOptions } from '../cli/index.ts';
+import type { LegacyStoreMethod } from './config.ts';
 
 export interface Options extends SharedCodemodOptions {
   storeNames: string[];

--- a/packages/codemods/src/legacy-compat-builders/result.ts
+++ b/packages/codemods/src/legacy-compat-builders/result.ts
@@ -1,4 +1,4 @@
-import type { ParsedImportInfo } from '../utils/imports.js';
+import type { ParsedImportInfo } from '../utils/imports.ts';
 
 export class TransformResult {
   attemptedTransform = false;

--- a/packages/codemods/src/legacy-compat-builders/run.ts
+++ b/packages/codemods/src/legacy-compat-builders/run.ts
@@ -3,9 +3,9 @@ import jscodeshift from 'jscodeshift';
 import { styleText } from 'node:util';
 import path from 'path';
 
-import type { LegacyStoreMethod } from './config.js';
-import transform from './index.js';
-import { log } from './log.js';
+import type { LegacyStoreMethod } from './config.ts';
+import transform from './index.ts';
+import { log } from './log.ts';
 
 export interface RunOptions {
   patterns: string[];

--- a/packages/codemods/src/schema-migration/codemod.ts
+++ b/packages/codemods/src/schema-migration/codemod.ts
@@ -2,17 +2,17 @@ import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { glob, readFile } from 'fs/promises';
 import { join, resolve } from 'path';
 
-import type { InstanciatedLogger } from '../../utils/logger.js';
-import type { FinalOptions } from './config.js';
-import { analyzeModelMixinUsage } from './processors/mixin-analyzer.js';
-import { generateIntermediateModelTraitArtifacts } from './processors/model.js';
-import type { SchemaArtifactRegistry } from './utils/artifact.js';
-import { buildEntityRegistry, linkEntities } from './utils/artifact.js';
-import type { TransformArtifact } from './utils/ast-utils.js';
-import type { ParsedFile } from './utils/file-parser.js';
-import { parseFile } from './utils/file-parser.js';
-import { extractBaseName } from './utils/path-utils.js';
-import { FILE_EXTENSION_REGEX, TRAILING_SINGLE_WILDCARD_REGEX, TRAILING_WILDCARD_REGEX } from './utils/string.js';
+import type { InstanciatedLogger } from '../../utils/logger.ts';
+import type { FinalOptions } from './config.ts';
+import { analyzeModelMixinUsage } from './processors/mixin-analyzer.ts';
+import { generateIntermediateModelTraitArtifacts } from './processors/model.ts';
+import type { SchemaArtifactRegistry } from './utils/artifact.ts';
+import { buildEntityRegistry, linkEntities } from './utils/artifact.ts';
+import type { TransformArtifact } from './utils/ast-utils.ts';
+import type { ParsedFile } from './utils/file-parser.ts';
+import { parseFile } from './utils/file-parser.ts';
+import { extractBaseName } from './utils/path-utils.ts';
+import { FILE_EXTENSION_REGEX, TRAILING_SINGLE_WILDCARD_REGEX, TRAILING_WILDCARD_REGEX } from './utils/string.ts';
 
 export type Filename = string;
 export type InputFile = { path: string; code: string };

--- a/packages/codemods/src/schema-migration/processors/mixin-analyzer.ts
+++ b/packages/codemods/src/schema-migration/processors/mixin-analyzer.ts
@@ -1,11 +1,11 @@
 import { dirname, resolve } from 'path';
 
-import type { InstanciatedLogger } from '../../../utils/logger.js';
-import type { Codemod } from '../codemod.js';
-import type { FinalOptions } from '../config.js';
-import { extractBaseName } from '../utils/ast-utils.js';
-import type { ParsedFile } from '../utils/file-parser.js';
-import { getImportSourceConfig, resolveImportPath, resolveRelativeImport } from '../utils/path-utils.js';
+import type { InstanciatedLogger } from '../../../utils/logger.ts';
+import type { Codemod } from '../codemod.ts';
+import type { FinalOptions } from '../config.ts';
+import { extractBaseName } from '../utils/ast-utils.ts';
+import type { ParsedFile } from '../utils/file-parser.ts';
+import { getImportSourceConfig, resolveImportPath, resolveRelativeImport } from '../utils/path-utils.ts';
 
 /**
  * Check if a resolved path is within the mixin source directory

--- a/packages/codemods/src/schema-migration/processors/mixin.ts
+++ b/packages/codemods/src/schema-migration/processors/mixin.ts
@@ -1,12 +1,12 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-import { logger } from '../../../utils/logger.js';
-import type { TransformerResult } from '../codemod.js';
-import type { TransformOptions } from '../config.js';
-import type { SchemaArtifact, SchemaArtifactRegistry } from '../utils/artifact.js';
-import { createTraitArtifactConfig, isConnectedToModel as isConnectedToModelInRegistry } from '../utils/artifact.js';
-import type { PropertyInfo, SchemaField, TransformArtifact } from '../utils/ast-utils.js';
+import { logger } from '../../../utils/logger.ts';
+import type { TransformerResult } from '../codemod.ts';
+import type { TransformOptions } from '../config.ts';
+import type { SchemaArtifact, SchemaArtifactRegistry } from '../utils/artifact.ts';
+import { createTraitArtifactConfig, isConnectedToModel as isConnectedToModelInRegistry } from '../utils/artifact.ts';
+import type { PropertyInfo, SchemaField, TransformArtifact } from '../utils/ast-utils.ts';
 import {
   buildTraitArtifacts,
   buildTraitSchemaObject,
@@ -15,10 +15,10 @@ import {
   generateMergedSchemaCode,
   mapFieldsToTypeProperties,
   toPascalCase,
-} from '../utils/ast-utils.js';
-import { createExtensionFromOriginalFile } from '../utils/extension-generation.js';
-import { resolveTraitImportPath, transformModelToResourceImport } from '../utils/import-utils.js';
-import { pascalToKebab } from '../utils/string.js';
+} from '../utils/ast-utils.ts';
+import { createExtensionFromOriginalFile } from '../utils/extension-generation.ts';
+import { resolveTraitImportPath, transformModelToResourceImport } from '../utils/import-utils.ts';
+import { pascalToKebab } from '../utils/string.ts';
 
 const log = logger.for('mixin-processor');
 

--- a/packages/codemods/src/schema-migration/processors/model.ts
+++ b/packages/codemods/src/schema-migration/processors/model.ts
@@ -2,12 +2,12 @@ import { parse, type SgNode } from '@ast-grep/napi';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 
-import { logger } from '../../../utils/logger.js';
-import type { TransformerResult } from '../codemod.js';
-import { getConfiguredImport, type TransformOptions } from '../config.js';
-import type { SchemaArtifactRegistry } from '../utils/artifact.js';
-import { createResourceArtifactConfig, createTraitArtifactConfig, SchemaArtifact } from '../utils/artifact.js';
-import type { ExtractedType, SchemaField, TransformArtifact } from '../utils/ast-utils.js';
+import { logger } from '../../../utils/logger.ts';
+import type { TransformerResult } from '../codemod.ts';
+import { getConfiguredImport, type TransformOptions } from '../config.ts';
+import type { SchemaArtifactRegistry } from '../utils/artifact.ts';
+import { createResourceArtifactConfig, createTraitArtifactConfig, SchemaArtifact } from '../utils/artifact.ts';
+import type { ExtractedType, SchemaField, TransformArtifact } from '../utils/ast-utils.ts';
 import {
   buildLegacySchemaObject,
   buildTraitArtifacts,
@@ -28,7 +28,7 @@ import {
   mixinNameToTraitName,
   SCHEMA_OPTION_REF_PREFIX,
   toPascalCase,
-} from '../utils/ast-utils.js';
+} from '../utils/ast-utils.ts';
 import {
   FILE_EXTENSION_JS,
   FILE_EXTENSION_TS,
@@ -41,14 +41,14 @@ import {
   NODE_KIND_IMPORT_STATEMENT,
   NODE_KIND_MEMBER_EXPRESSION,
   NODE_KIND_PROPERTY_IDENTIFIER,
-} from '../utils/code-processing.js';
-import { createExtensionFromOriginalFile } from '../utils/extension-generation.js';
-import type { ParsedFile } from '../utils/file-parser.js';
-import { parseFile } from '../utils/file-parser.js';
-import { resolveTraitImportPath } from '../utils/import-utils.js';
-import { extractBaseName, removeQuotes, replaceWildcardPattern } from '../utils/path-utils.js';
-import type { FieldTypeInfo } from '../utils/schema-generation.js';
-import { normalizePath, removeFileExtension, toKebabCase } from '../utils/string.js';
+} from '../utils/code-processing.ts';
+import { createExtensionFromOriginalFile } from '../utils/extension-generation.ts';
+import type { ParsedFile } from '../utils/file-parser.ts';
+import { parseFile } from '../utils/file-parser.ts';
+import { resolveTraitImportPath } from '../utils/import-utils.ts';
+import { extractBaseName, removeQuotes, replaceWildcardPattern } from '../utils/path-utils.ts';
+import type { FieldTypeInfo } from '../utils/schema-generation.ts';
+import { normalizePath, removeFileExtension, toKebabCase } from '../utils/string.ts';
 
 /**
  * Find and return the source text of export declarations (e.g. `export const BIRTHAGE = 0;`)

--- a/packages/codemods/src/schema-migration/tasks/migrate.ts
+++ b/packages/codemods/src/schema-migration/tasks/migrate.ts
@@ -1,10 +1,10 @@
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { basename, dirname, join, resolve } from 'path';
 
-import { type InstanciatedLogger, logger } from '../../../utils/logger.js';
-import type { SkippedFile, TransformerResult } from '../codemod.js';
-import { Codemod } from '../codemod.js';
-import type { FinalOptions, MigrateOptions, TransformOptions } from '../config.js';
+import { type InstanciatedLogger, logger } from '../../../utils/logger.ts';
+import type { SkippedFile, TransformerResult } from '../codemod.ts';
+import { Codemod } from '../codemod.ts';
+import type { FinalOptions, MigrateOptions, TransformOptions } from '../config.ts';
 import {
   DEFAULT_INPUT_DIR,
   DEFAULT_MIXIN_SOURCE_DIR,
@@ -13,12 +13,12 @@ import {
   DEFAULT_RESOURCES_DIR,
   DEFAULT_TRAITS_DIR,
   DEFAULT_WARP_DRIVE_IMPORTS,
-} from '../config.js';
-import { toArtifacts as mixinToArtifacts } from '../processors/mixin.js';
-import { processIntermediateModelsToTraits, toArtifacts as modelToArtifacts } from '../processors/model.js';
-import type { SchemaArtifact, SchemaArtifactRegistry } from '../utils/artifact.js';
-import { findEntityByBaseName } from '../utils/artifact.js';
-import type { TransformArtifact } from '../utils/schema-generation.js';
+} from '../config.ts';
+import { toArtifacts as mixinToArtifacts } from '../processors/mixin.ts';
+import { processIntermediateModelsToTraits, toArtifacts as modelToArtifacts } from '../processors/model.ts';
+import type { SchemaArtifact, SchemaArtifactRegistry } from '../utils/artifact.ts';
+import { findEntityByBaseName } from '../utils/artifact.ts';
+import type { TransformArtifact } from '../utils/schema-generation.ts';
 
 const migrateLog = logger.for('migrate');
 

--- a/packages/codemods/src/schema-migration/utils/artifact.ts
+++ b/packages/codemods/src/schema-migration/utils/artifact.ts
@@ -1,8 +1,8 @@
-import type { InstanciatedLogger } from '../../../utils/logger.js';
-import type { Filename } from '../codemod.js';
+import type { InstanciatedLogger } from '../../../utils/logger.ts';
+import type { Filename } from '../codemod.ts';
 import type { TransformOptions } from '../config';
 import type { ModelAnalysisResult } from '../processors/model';
-import type { ParsedFile } from './file-parser.js';
+import type { ParsedFile } from './file-parser.ts';
 import { toPascalCase } from './path-utils';
 
 interface ResourceArtifactIdentifiers {

--- a/packages/codemods/src/schema-migration/utils/ast-helpers.ts
+++ b/packages/codemods/src/schema-migration/utils/ast-helpers.ts
@@ -1,11 +1,11 @@
 import type { SgNode } from '@ast-grep/napi';
 import { Lang, parse } from '@ast-grep/napi';
 
-import { logger } from '../../../utils/logger.js';
-import type { TransformOptions } from '../config.js';
-import { isMixinImportPath, isSpecialMixinImport } from './import-utils.js';
-import { getLanguageFromPath, removeQuotes } from './path-utils.js';
-import { MIXIN_SUFFIX_REGEX } from './string.js';
+import { logger } from '../../../utils/logger.ts';
+import type { TransformOptions } from '../config.ts';
+import { isMixinImportPath, isSpecialMixinImport } from './import-utils.ts';
+import { getLanguageFromPath, removeQuotes } from './path-utils.ts';
+import { MIXIN_SUFFIX_REGEX } from './string.ts';
 
 const log = logger.for('ast-helpers');
 

--- a/packages/codemods/src/schema-migration/utils/ast-utils.ts
+++ b/packages/codemods/src/schema-migration/utils/ast-utils.ts
@@ -28,8 +28,8 @@ export {
   resolveImportPath,
   isImportFromSource,
   getImportSourceConfig,
-} from './path-utils.js';
-export type { ImportSourceConfig } from './path-utils.js';
+} from './path-utils.ts';
+export type { ImportSourceConfig } from './path-utils.ts';
 
 export {
   DEFAULT_EMBER_DATA_SOURCE,
@@ -41,8 +41,8 @@ export {
   extractTypeFromDecorator,
   extractTypeFromMethod,
   extractTypesFromInterface,
-} from './type-utils.js';
-export type { ExtractedType, SchemaFieldForType } from './type-utils.js';
+} from './type-utils.ts';
+export type { ExtractedType, SchemaFieldForType } from './type-utils.ts';
 
 // Re-export from ast-helpers
 export {
@@ -57,7 +57,7 @@ export {
   findAssociatedInterface,
   getEmberDataImports,
   getMixinImports,
-} from './ast-helpers.js';
+} from './ast-helpers.ts';
 
 // Re-export from schema-generation
 export {
@@ -76,8 +76,8 @@ export {
   mapFieldsToTypeProperties,
   buildTraitSchemaObject,
   SCHEMA_OPTION_REF_PREFIX,
-} from './schema-generation.js';
-export type { TransformArtifact, PropertyInfo, SchemaField, MergedSchemaOptions } from './schema-generation.js';
+} from './schema-generation.ts';
+export type { TransformArtifact, PropertyInfo, SchemaField, MergedSchemaOptions } from './schema-generation.ts';
 
 // Re-export from import-utils
 export {
@@ -98,7 +98,7 @@ export {
   WARP_DRIVE_MODEL,
   FRAGMENT_DECORATOR_SOURCE,
   FRAGMENT_BASE_SOURCE,
-} from './import-utils.js';
+} from './import-utils.ts';
 
 // Re-export from extension-generation
-export { generateExtensionCode, createExtensionFromOriginalFile } from './extension-generation.js';
+export { generateExtensionCode, createExtensionFromOriginalFile } from './extension-generation.ts';

--- a/packages/codemods/src/schema-migration/utils/code-processing.ts
+++ b/packages/codemods/src/schema-migration/utils/code-processing.ts
@@ -1,6 +1,6 @@
 import type { SgNode } from '@ast-grep/napi';
 
-import { removeQuotes } from './path-utils.js';
+import { removeQuotes } from './path-utils.ts';
 
 /** AST node kind for identifier nodes */
 export const NODE_KIND_IDENTIFIER = 'identifier';

--- a/packages/codemods/src/schema-migration/utils/extension-generation.ts
+++ b/packages/codemods/src/schema-migration/utils/extension-generation.ts
@@ -1,21 +1,21 @@
 import { Lang as AstLang, type Lang, parse, type SgNode } from '@ast-grep/napi';
 import { dirname, join, relative, resolve, sep } from 'path';
 
-import { logger } from '../../../utils/logger.js';
-import type { TransformOptions } from '../config.js';
-import { DEFAULT_RESOURCES_DIR, DEFAULT_TRAITS_DIR } from '../config.js';
-import type { ArtifactConfig } from './artifact.js';
-import { findDefaultExport } from './ast-helpers.js';
-import { getModelImportSources } from './import-utils.js';
-import { getFileExtension, getLanguageFromPath, indentCode, removeQuotes } from './path-utils.js';
-import type { TransformArtifact } from './schema-generation.js';
+import { logger } from '../../../utils/logger.ts';
+import type { TransformOptions } from '../config.ts';
+import { DEFAULT_RESOURCES_DIR, DEFAULT_TRAITS_DIR } from '../config.ts';
+import type { ArtifactConfig } from './artifact.ts';
+import { findDefaultExport } from './ast-helpers.ts';
+import { getModelImportSources } from './import-utils.ts';
+import { getFileExtension, getLanguageFromPath, indentCode, removeQuotes } from './path-utils.ts';
+import type { TransformArtifact } from './schema-generation.ts';
 import {
   EXPORT_DEFAULT_LINE_END_REGEX,
   EXPORT_LINE_END_REGEX,
   extractDirectory,
   removeFileExtension,
   removeSameDirPrefix,
-} from './string.js';
+} from './string.ts';
 
 const log = logger.for('extension-generation');
 

--- a/packages/codemods/src/schema-migration/utils/file-parser.ts
+++ b/packages/codemods/src/schema-migration/utils/file-parser.ts
@@ -8,15 +8,15 @@
 
 import { parse, type SgNode } from '@ast-grep/napi';
 
-import { logger } from '../../../utils/logger.js';
-import type { TransformOptions } from '../config.js';
+import { logger } from '../../../utils/logger.ts';
+import type { TransformOptions } from '../config.ts';
 import {
   findClassDeclaration,
   findDefaultExport,
   getEmberDataImports,
   getMixinImports,
   parseDecoratorArgumentsWithNodes,
-} from './ast-helpers.js';
+} from './ast-helpers.ts';
 import {
   NODE_KIND_ARROW_FUNCTION,
   NODE_KIND_CALL_EXPRESSION,
@@ -33,25 +33,25 @@ import {
   NODE_KIND_METHOD_DEFINITION,
   NODE_KIND_PAIR,
   NODE_KIND_PROPERTY_IDENTIFIER,
-} from './code-processing.js';
+} from './code-processing.ts';
 import {
   DEFAULT_EMBER_DATA_SOURCE,
   DEFAULT_MIXIN_SOURCE,
   findEmberImportLocalName,
   FRAGMENT_BASE_SOURCE,
   WARP_DRIVE_MODEL,
-} from './import-utils.js';
+} from './import-utils.ts';
 import {
   extractBaseName,
   extractCamelCaseName,
   extractPascalCaseName,
   getLanguageFromPath,
   removeQuotes,
-} from './path-utils.js';
-import { convertToSchemaField } from './schema-generation.js';
-import { mixinNameToKebab } from './string.js';
-import type { ExtractedType } from './type-utils.js';
-import { extractTypeFromDeclaration, extractTypeFromDecorator, extractTypeFromMethod } from './type-utils.js';
+} from './path-utils.ts';
+import { convertToSchemaField } from './schema-generation.ts';
+import { mixinNameToKebab } from './string.ts';
+import type { ExtractedType } from './type-utils.ts';
+import { extractTypeFromDeclaration, extractTypeFromDecorator, extractTypeFromMethod } from './type-utils.ts';
 
 const log = logger.for('file-parser');
 

--- a/packages/codemods/src/schema-migration/utils/import-utils.ts
+++ b/packages/codemods/src/schema-migration/utils/import-utils.ts
@@ -3,17 +3,17 @@ import { parse } from '@ast-grep/napi';
 import { existsSync, readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 
-import { logger } from '../../../utils/logger.js';
-import type { TransformOptions } from '../config.js';
-import type { SchemaArtifactRegistry } from './artifact.js';
+import { logger } from '../../../utils/logger.ts';
+import type { TransformOptions } from '../config.ts';
+import type { SchemaArtifactRegistry } from './artifact.ts';
 import {
   deriveResourceExtensionName,
   deriveTraitExtensionName,
   deriveTraitInterfaceName,
   findEntityByBaseName,
   isConnectedToModel,
-} from './artifact.js';
-import { findClassDeclaration, findDefaultExport } from './ast-helpers.js';
+} from './artifact.ts';
+import { findClassDeclaration, findDefaultExport } from './ast-helpers.ts';
 import {
   extractBaseName,
   getImportSourceConfig,
@@ -23,7 +23,7 @@ import {
   removeQuotes,
   resolveRelativeImport,
   toPascalCase,
-} from './path-utils.js';
+} from './path-utils.ts';
 import {
   EXT_FILE_PATH_REGEX,
   FILE_EXTENSION_REGEX,
@@ -31,7 +31,7 @@ import {
   IMPORT_PATH_SINGLE_QUOTE_REGEX,
   IMPORT_TYPE_DEFAULT_REGEX,
   SCHEMA_PATH_REGEX,
-} from './string.js';
+} from './string.ts';
 
 const log = logger.for('import-utils');
 

--- a/packages/codemods/src/schema-migration/utils/path-utils.ts
+++ b/packages/codemods/src/schema-migration/utils/path-utils.ts
@@ -3,7 +3,7 @@ import { Lang as AstLang } from '@ast-grep/napi';
 import { existsSync } from 'fs';
 import path, { dirname, resolve } from 'path';
 
-import type { TransformOptions } from '../config.js';
+import type { TransformOptions } from '../config.ts';
 import {
   capitalizeFirstLetter,
   capitalizeWord,
@@ -16,7 +16,7 @@ import {
   WHITESPACE_REGEX,
   WORD_BOUNDARY_REGEX,
   WORD_SEPARATOR_REGEX,
-} from './string.js';
+} from './string.ts';
 
 /**
  * Extract the file name (without extension) from a file path

--- a/packages/codemods/src/schema-migration/utils/schema-generation.ts
+++ b/packages/codemods/src/schema-migration/utils/schema-generation.ts
@@ -2,15 +2,15 @@ import type { SgNode } from '@ast-grep/napi';
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-import { logger } from '../../../utils/logger.js';
-import { getConfiguredImport, type TransformOptions } from '../config.js';
-import type { ArtifactConfig, SchemaArtifactRegistry } from './artifact.js';
-import { deriveResourceExtensionName, deriveTraitExtensionName } from './artifact.js';
-import { type ExtensionContext, generateRegistrationBlock } from './extension-generation.js';
-import { generateTraitImport, isModelImportPath, transformModelToResourceImport } from './import-utils.js';
-import { normalizeClassicImport, removeQuotes, toPascalCase } from './path-utils.js';
-import type { ExtractedType } from './type-utils.js';
-import { schemaFieldToTypeScriptType } from './type-utils.js';
+import { logger } from '../../../utils/logger.ts';
+import { getConfiguredImport, type TransformOptions } from '../config.ts';
+import type { ArtifactConfig, SchemaArtifactRegistry } from './artifact.ts';
+import { deriveResourceExtensionName, deriveTraitExtensionName } from './artifact.ts';
+import { type ExtensionContext, generateRegistrationBlock } from './extension-generation.ts';
+import { generateTraitImport, isModelImportPath, transformModelToResourceImport } from './import-utils.ts';
+import { normalizeClassicImport, removeQuotes, toPascalCase } from './path-utils.ts';
+import type { ExtractedType } from './type-utils.ts';
+import { schemaFieldToTypeScriptType } from './type-utils.ts';
 
 const log = logger.for('schema-generation');
 

--- a/packages/codemods/src/schema-migration/utils/type-utils.ts
+++ b/packages/codemods/src/schema-migration/utils/type-utils.ts
@@ -1,10 +1,10 @@
 import type { SgNode } from '@ast-grep/napi';
 
-import { logger } from '../../../utils/logger.js';
-import type { PackageImport, TransformOptions } from '../config.js';
-import { parseObjectLiteralFromNode } from './ast-helpers.js';
-import { DEFAULT_EMBER_DATA_SOURCE, DEFAULT_MIXIN_SOURCE } from './import-utils.js';
-import { removeQuotes, toPascalCase } from './path-utils.js';
+import { logger } from '../../../utils/logger.ts';
+import type { PackageImport, TransformOptions } from '../config.ts';
+import { parseObjectLiteralFromNode } from './ast-helpers.ts';
+import { DEFAULT_EMBER_DATA_SOURCE, DEFAULT_MIXIN_SOURCE } from './import-utils.ts';
+import { removeQuotes, toPascalCase } from './path-utils.ts';
 
 const log = logger.for('type-utils');
 // logger.prototype.constructor.options = {

--- a/packages/codemods/src/utils/imports.ts
+++ b/packages/codemods/src/utils/imports.ts
@@ -10,8 +10,8 @@ import type {
   TSTypeParameter,
 } from 'jscodeshift';
 
-import { log } from '../legacy-compat-builders/log.js';
-import { TransformError } from './error.js';
+import { log } from '../legacy-compat-builders/log.ts';
+import { TransformError } from './error.ts';
 
 type IdentifierLike = Identifier | JSXIdentifier | TSTypeParameter;
 

--- a/packages/codemods/utils/logger.ts
+++ b/packages/codemods/utils/logger.ts
@@ -4,7 +4,7 @@ import { stripVTControlCharacters as stripAnsi, styleText } from 'node:util';
 import type { Logform, Logger as WinstonLogger } from 'winston';
 import { createLogger as createWinstonLogger, format as winstonFormat, transports as winstonTransports } from 'winston';
 
-import { isRecord } from './types.js';
+import { isRecord } from './types.ts';
 
 export interface LoggerOptions extends Options {
   verbose?: '0' | '1' | '2';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1307,19 +1307,16 @@ importers:
         version: 17.3.0
       '@warp-drive/internal-config':
         specifier: workspace:*
-        version: file:tools/internal-config(tsx@4.20.5)
+        version: file:tools/internal-config
       eslint:
         specifier: ^9.34.0
         version: 9.34.0
       qunit:
         specifier: 2.26.0
         version: 2.26.0
-      tsx:
-        specifier: ^4.20.5
-        version: 4.20.5
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(tsx@4.20.5)
+        version: 3.2.7
 
   tests/core:
     devDependencies:
@@ -4640,34 +4637,16 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.25.4':
-    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.4':
-    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.4':
-    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -4676,34 +4655,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.4':
-    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.4':
-    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -4712,22 +4673,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.4':
-    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.4':
-    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -4736,22 +4685,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.4':
-    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.4':
-    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -4760,22 +4697,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.4':
-    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.4':
-    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -4784,22 +4709,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.4':
-    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.4':
-    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -4808,22 +4721,10 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.4':
-    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.4':
-    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -4832,34 +4733,16 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.4':
-    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.4':
-    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -4868,22 +4751,10 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.4':
-    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -4898,23 +4769,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.4':
-    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.4':
-    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
@@ -4922,22 +4781,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.4':
-    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.4':
-    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -9020,11 +8867,6 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.25.4:
-    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
@@ -13008,11 +12850,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.20.5:
-    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
@@ -16417,127 +16254,64 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.4':
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
-  '@esbuild/android-arm@0.25.4':
-    optional: true
-
   '@esbuild/android-arm@0.27.2':
-    optional: true
-
-  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.4':
-    optional: true
-
   '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.4':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.4':
-    optional: true
-
   '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.4':
-    optional: true
-
   '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.4':
-    optional: true
-
   '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.4':
-    optional: true
-
   '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
-  '@esbuild/linux-x64@0.25.4':
-    optional: true
-
   '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.4':
-    optional: true
-
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -16546,25 +16320,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.4':
-    optional: true
-
   '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.4':
-    optional: true
-
   '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -17193,27 +16955,6 @@ snapshots:
       - '@types/babel__core'
       - rollup
       - supports-color
-
-  '@nullvoxpopuli/ember-rolldown@2.7.0(166ba9dd813fae8ccf61cefc52fd2714)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@embroider/core': 4.4.2
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
-      babel-plugin-ember-template-compilation: 4.0.0
-      content-tag: 4.2.0
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-    optionalDependencies:
-      tsdown: 0.22.14(tsx@4.20.5)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@glint/template'
-      - '@types/babel__core'
-      - bufferutil
-      - canvas
-      - rollup
-      - supports-color
-      - utf-8-validate
 
   '@nullvoxpopuli/ember-rolldown@2.7.0(35190290210cd7126c88e642f3389863)':
     dependencies:
@@ -18230,9 +17971,6 @@ snapshots:
   '@types/ember__utils@4.0.7':
     dependencies:
       '@types/ember': 4.0.11
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   '@types/esrecurse@4.3.1': {}
 
@@ -18505,13 +18243,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@7.3.1(tsx@4.20.5))':
+  '@vitest/mocker@3.2.7(vite@7.3.1)':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(tsx@4.20.5)
+      vite: 7.3.1
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -19595,60 +19333,6 @@ snapshots:
       globals: 16.3.0
       rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
-      typescript: 5.9.3
-      typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@babel/plugin-transform-runtime'
-      - '@babel/runtime'
-      - '@glint/template'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@types/babel__core'
-      - '@typescript/native-preview'
-      - '@vitejs/devtools'
-      - '@volar/typescript'
-      - bufferutil
-      - canvas
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jiti
-      - oxc-resolver
-      - publint
-      - rolldown
-      - supports-color
-      - tsx
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - vite
-      - vue-tsc
-
-  '@warp-drive/internal-config@file:tools/internal-config(tsx@4.20.5)':
-    dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
-      '@babel/core': 7.29.7
-      '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
-      '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(166ba9dd813fae8ccf61cefc52fd2714)
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
-      '@rolldown/pluginutils': 1.0.1
-      '@types/debug': 4.1.13
-      '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
-      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
-      comment-json: 4.2.5
-      debug: 4.4.3
-      ember-eslint-parser: 0.14.5(70be1ffd0039cc420d8577c8284ed44f)
-      eslint: 9.34.0
-      eslint-config-prettier: 10.1.8(eslint@9.34.0)
-      eslint-plugin-import: 2.32.0(fc509f8ea4793045ea15ebf2a929a9a3)
-      eslint-plugin-mocha: 10.5.0(eslint@9.34.0)
-      eslint-plugin-n: 17.21.3(eslint@9.34.0)(typescript@5.9.3)
-      eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
-      eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
-      globals: 16.3.0
-      rollup: 4.62.4
-      tsdown: 0.22.14(tsx@4.20.5)(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -22628,34 +22312,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  esbuild@0.25.4:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.4
-      '@esbuild/android-arm': 0.25.4
-      '@esbuild/android-arm64': 0.25.4
-      '@esbuild/android-x64': 0.25.4
-      '@esbuild/darwin-arm64': 0.25.4
-      '@esbuild/darwin-x64': 0.25.4
-      '@esbuild/freebsd-arm64': 0.25.4
-      '@esbuild/freebsd-x64': 0.25.4
-      '@esbuild/linux-arm': 0.25.4
-      '@esbuild/linux-arm64': 0.25.4
-      '@esbuild/linux-ia32': 0.25.4
-      '@esbuild/linux-loong64': 0.25.4
-      '@esbuild/linux-mips64el': 0.25.4
-      '@esbuild/linux-ppc64': 0.25.4
-      '@esbuild/linux-riscv64': 0.25.4
-      '@esbuild/linux-s390x': 0.25.4
-      '@esbuild/linux-x64': 0.25.4
-      '@esbuild/netbsd-arm64': 0.25.4
-      '@esbuild/netbsd-x64': 0.25.4
-      '@esbuild/openbsd-arm64': 0.25.4
-      '@esbuild/openbsd-x64': 0.25.4
-      '@esbuild/sunos-x64': 0.25.4
-      '@esbuild/win32-arm64': 0.25.4
-      '@esbuild/win32-ia32': 0.25.4
-      '@esbuild/win32-x64': 0.25.4
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -27510,32 +27166,6 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.22.14(tsx@4.20.5)(typescript@5.9.3):
-    dependencies:
-      ansis: 4.3.1
-      cac: 7.0.0
-      defu: 6.1.7
-      empathic: 2.0.1
-      hookable: 6.1.1
-      import-without-cache: 0.4.0
-      obug: 2.1.4
-      picomatch: 4.0.5
-      rolldown: 1.2.3
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)(typescript@5.9.3)
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tree-kill: 1.2.2
-      unconfig-core: 7.5.0
-      verkit: 0.3.2
-    optionalDependencies:
-      tsx: 4.20.5
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript/native-preview'
-      - '@volar/typescript'
-      - oxc-resolver
-      - vue-tsc
-
   tsdown@0.22.14(typescript@5.9.3):
     dependencies:
       ansis: 4.3.1
@@ -27564,13 +27194,6 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
-
-  tsx@4.20.5:
-    dependencies:
-      esbuild: 0.25.4
-      get-tsconfig: 4.10.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   turbo@2.9.14:
     optionalDependencies:
@@ -27890,13 +27513,13 @@ snapshots:
 
   vite-bundle-analyzer@1.2.1: {}
 
-  vite-node@3.2.4(tsx@4.20.5):
+  vite-node@3.2.4:
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(tsx@4.20.5)
+      vite: 7.3.1
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -27961,18 +27584,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       terser: 5.43.1
-
-  vite@7.3.1(tsx@4.20.5):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.62.4
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      fsevents: 2.3.3
-      tsx: 4.20.5
 
   vite@8.2.1:
     dependencies:
@@ -28067,11 +27678,11 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@3.2.7(tsx@4.20.5):
+  vitest@3.2.7:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.3.1(tsx@4.20.5))
+      '@vitest/mocker': 3.2.7(vite@7.3.1)
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -28089,8 +27700,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(tsx@4.20.5)
-      vite-node: 3.2.4(tsx@4.20.5)
+      vite: 7.3.1
+      vite-node: 3.2.4
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti

--- a/tests/codemods/package.json
+++ b/tests/codemods/package.json
@@ -18,9 +18,9 @@
     "check:types": "",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "test": "pnpm test:fixtures && pnpm test:unit",
-    "test:fixtures": "tsx --test tests/index.spec.ts",
+    "test:fixtures": "node --test tests/index.spec.ts",
     "test:unit": "vitest run tests/",
-    "fixme": "tsx --test tests/index.spec.ts",
+    "fixme": "node --test tests/index.spec.ts",
     "_syncPnpm": "bun run sync-dependencies-meta-injected"
   },
   "files": [
@@ -42,7 +42,6 @@
     "@warp-drive/internal-config": "workspace:*",
     "eslint": "^9.34.0",
     "qunit": "^2.26.0",
-    "tsx": "^4.20.5",
     "vitest": "^3.2.7"
   },
   "volta": {

--- a/tests/codemods/tests/index.spec.ts
+++ b/tests/codemods/tests/index.spec.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env node
 
 import type { Transform } from 'jscodeshift';
 import { applyTransform, type TestOptions } from 'jscodeshift/src/testUtils.js';
@@ -9,7 +9,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import * as prettier from 'prettier';
 
-import { legacyCompatBuilders, legacyCompatBuildersLog } from '@ember-data/codemods';
+import { legacyCompatBuilders, legacyCompatBuildersLog } from '../../../packages/codemods/src/index.ts';
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory


### PR DESCRIPTION
## Summary
`tests/codemods/tests/index.spec.ts` was the only consumer of `tsx` in the whole repo. It was needed for two independent reasons, both now resolved:

1. **Cross-package resolution.** The test imported `@ember-data/codemods` by package specifier, which resolves through pnpm's workspace symlink into `node_modules`. Node's native type-stripping refuses to run for any file resolved through a `node_modules` path, full stop. Fix: import via a relative path (`../../../packages/codemods/src/index.ts`) instead, which never touches `node_modules` resolution.
2. **Internal `.js`-for-`.ts` convention.** Once past #1, `packages/codemods/src/index.ts` itself writes `.js` in its own import specifiers (the standard tsc/bundler convention meaning "the compiled output of this `.ts` file"). Node's native stripper doesn't do that remapping — it looks for a literal `.js` file and fails. This is pervasive in the package (27 files under `src/` and `utils/`), so rewrote all of them to use `.ts` extensions directly, which Node's stripper resolves as-is.

No tsconfig changes were needed — `allowImportingTsExtensions: true` was already set (a precondition satisfied by the package's existing `emitDeclarationOnly: true`), so `tsc --noEmit`, `tsc` (declarations), and `bun build` (the CLI bundle) all accept the new extensions unmodified.

`test:fixtures`/`fixme` now run via `node --test` instead of `tsx --test`.

**Correction from an earlier draft of this description:** `tsx` is fully removed from `node_modules`, not just as a direct dependency. `tsdown` lists `tsx` as an optional peerDependency (not a real one), and this repo has `auto-install-peers=false`, so nothing else in the workspace pulls it in. Verified with `pnpm why tsx` returning empty and no `tsx@*` directory left in `node_modules/.pnpm`.

## Test plan
- [x] `pnpm --filter codemods-tests run test` — 140/140 fixture tests + 212/212 unit tests pass
- [x] `pnpm --filter @ember-data/codemods run build:pkg` (tsc declarations) and `build:cli` (bun bundle) both succeed unmodified
- [x] `pnpm check:types` passes (81/81)
- [x] `pnpm lint` passes (83/83)
- [x] Confirmed no other file in the repo imports `packages/codemods` across a package boundary in a way this doesn't cover — the `schema-migration` subpath imports elsewhere in `tests/codemods` run under vitest, which has its own transform pipeline and was never affected
- [x] Confirmed `tsx` is fully removed from `node_modules` (not just the direct dependency)
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)