### PR TITLE
chore(deps): force a single prettier version, remove leftover zlib duplicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
       "rollup": "^4.62.4",
       "@babel/types": "^7.29.8",
       "@babel/parser": "^7.29.8",
-      "@babel/traverse": "^7.29.8"
+      "@babel/traverse": "^7.29.8",
+      "prettier": "^3.8.1"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   '@babel/types': ^7.29.8
   '@babel/parser': ^7.29.8
   '@babel/traverse': ^7.29.8
+  prettier: ^3.8.1
 
 packageExtensionsChecksum: sha256-LCLIYKLZ85Sw43nBftLnN6QRYf2xc5hd/XNTpLbwBeM=
 
@@ -2823,9 +2824,6 @@ importers:
       vite-plugin-compression2:
         specifier: ^2.2.0
         version: 2.2.0(rollup@4.62.4)
-      zlib:
-        specifier: 1.0.5
-        version: 1.0.5
 
   tests/utilities:
     devDependencies:
@@ -11396,12 +11394,7 @@ packages:
     resolution: {integrity: sha512-NQS/a03LCefDbOJ1o0NeN+4VdfZRJt6NBp6/5yLMXTQ2TNT4fkcbhfXkvcgl7lN9nmssm6GweX51G/CAEvtazg==}
     engines: {node: 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
-
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
+      prettier: ^3.8.1
 
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
@@ -13576,10 +13569,6 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
-
-  zlib@1.0.5:
-    resolution: {integrity: sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==}
-    engines: {node: '>=0.2.0'}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -17760,11 +17749,17 @@ snapshots:
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__component@4.0.22':
     dependencies:
       '@types/ember': 4.0.11
       '@types/ember__object': 4.0.12
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__controller@4.0.12':
     dependencies:
@@ -17800,10 +17795,16 @@ snapshots:
       '@types/ember__controller': 4.0.12
       '@types/ember__object': 4.0.12
       '@types/ember__service': 4.0.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__runloop@4.0.10':
     dependencies:
       '@types/ember': 4.0.11
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
 
   '@types/ember__service@4.0.9':
     dependencies:
@@ -20039,7 +20040,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      prettier: 2.8.8
+      prettier: 3.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -25041,8 +25042,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  prettier@2.8.8: {}
-
   prettier@3.8.1: {}
 
   pretty-bytes@5.6.0: {}
@@ -25336,7 +25335,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      prettier: 2.8.8
+      prettier: 3.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -27709,7 +27708,5 @@ snapshots:
       '@yuku-parser/binding-win32-x64': 0.8.4
 
   zimmerframe@1.1.4: {}
-
-  zlib@1.0.5: {}
 
   zwitch@2.0.4: {}

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -48,8 +48,7 @@
     "terser": "^5.43.1",
     "vite": "^7.3.1",
     "vite-bundle-analyzer": "^1.3.9",
-    "vite-plugin-compression2": "^2.2.0",
-    "zlib": "1.0.5"
+    "vite-plugin-compression2": "^2.2.0"
   },
   "sideEffects": [
     "@warp-drive/ember/install"


### PR DESCRIPTION
## Summary
- Removes `tests/performance`'s own separate `zlib: "1.0.5"` devDependency, missed in the earlier root-level url/zlib removal (#10778). Its source already imports `node:zlib` (fixed in that same earlier change), so this declaration was pure dead weight.
- Adds a `pnpm.overrides` entry forcing `prettier` to a single version (`^3.8.1`) everywhere. The `prettier@2.8.8` slot was force-installed transitively by `ember-source` (via `ember-cli-typescript-blueprint-polyfill`'s `babel-remove-types`/`remove-types`, both requiring `prettier ^2.5.1` as a hard, non-peer dependency) — confirmed this is permanent, even against `ember-source`'s latest release (7.2.0 still has the same dependency).

**Why this is safe** despite prettier 3 changing `format()` from sync to async-only: both `babel-remove-types` and `remove-types` wrap their `prettier.format()` call inside an `async function` and `return` it directly. Returning a promise from an async function auto-flattens for the caller — so whether the installed prettier's `format()` returns a string (v2) or a Promise (v3), callers get the correctly resolved string either way. Verified this two ways:
- Directly: ran `removeTypes()` from both packages against the forced prettier 3 install, confirmed correct string output (not `[object Promise]` or a crash)
- End-to-end: `pnpm test:blueprints`, the full Ember blueprint-generation integration suite — 38/38 passing

## Test plan
- [x] `pnpm install` / `pnpm install --frozen-lockfile` succeed; single `prettier` version in `node_modules/.pnpm`, `zlib` fully gone
- [x] `pnpm test:blueprints` — 38/38 passing (this is the actual code path that calls prettier v2's API internally)
- [x] `pnpm check:types` passes (81/81)
- [x] `pnpm lint` passes (83/83)
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)