### PR TITLE
chore(deps): dedupe ember-source, vite, @types/node, @vue/compiler-sfc, @shikijs/langs, rxjs

### DIFF
--- a/docs-viewer/package.json
+++ b/docs-viewer/package.json
@@ -39,7 +39,7 @@
     "vite-plugin-image-optimizer": "^2.0.3",
     "vite-plugin-pwa": "^1.3.0",
     "vue": "^3.5.41",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "volta": {
     "extends": "../package.json"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bun-types": "^1.4.0",
     "comment-json": "^4.6.2",
     "debug": "^4.4.3",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "execa": "^9.6.1",
     "git-repo-version": "^1.0.2",
     "lerna-changelog": "^2.2.0",
@@ -139,7 +139,10 @@
       "@babel/types": "^7.29.8",
       "@babel/parser": "^7.29.8",
       "@babel/traverse": "^7.29.8",
-      "prettier": "^3.8.1"
+      "prettier": "^3.8.1",
+      "@types/node": "catalog:",
+      "@vue/compiler-sfc": "3.5.41",
+      "@shikijs/langs": "4.4.3"
     },
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/packages/-ember-data/package.json
+++ b/packages/-ember-data/package.json
@@ -108,7 +108,7 @@
     "@ember/test-waiters": "^4.1.2",
     "@types/qunit": "2.19.14",
     "@warp-drive/internal-config": "workspace:*",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "eslint": "^9.34.0",
     "qunit": "^2.26.0",
     "tsdown": "^0.22.14",

--- a/packages/-warp-drive/package.json
+++ b/packages/-warp-drive/package.json
@@ -64,7 +64,7 @@
     "@babel/plugin-transform-typescript": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@types/debug": "^4.1.13",
-    "@types/node": "^24.3.0",
+    "@types/node": "catalog:",
     "@types/semver": "^7.8.0",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",

--- a/packages/-warp-drive/src/-private/shared/docs.ts
+++ b/packages/-warp-drive/src/-private/shared/docs.ts
@@ -19,7 +19,7 @@ function getDefaultValueDescriptor(value: unknown) {
       return styleText('cyan', `Function`);
     }
   } else {
-    return styleText('grey', 'N/A');
+    return styleText('gray', 'N/A');
   }
 }
 
@@ -28,15 +28,15 @@ function buildOptionDoc(flag: Flag, index: number): string {
   const flag_shape =
     styleText('magentaBright', flag.positional ? `<${flag.flag}>` : `--${flag.flag}`) +
     (flag.required ? styleText('yellow', styleText('italic', ` required`)) : '');
-  const flag_aliases_str = styleText('grey', flag_aliases?.join(', ') || 'N/A');
-  const flag_mispellings_str = styleText('grey', flag_mispellings?.join(', ') || 'N/A');
+  const flag_aliases_str = styleText('gray', flag_aliases?.join(', ') || 'N/A');
+  const flag_mispellings_str = styleText('gray', flag_mispellings?.join(', ') || 'N/A');
 
   return `${flag_shape} ${styleText('greenBright', flag.name)}
   ${indent(description, 1)}
   ${styleText('yellow', 'default')}: ${getDefaultValueDescriptor(flag.default_value)}
   ${styleText('yellow', 'aliases')}: ${flag_aliases_str}
   ${styleText('yellow', 'alt')}: ${flag_mispellings_str}
-  ${styleText('grey', 'Examples')}:
+  ${styleText('gray', 'Examples')}:
   ${examples
     .map((example) => {
       if (typeof example === 'string') {

--- a/packages/-warp-drive/src/-private/shared/utils.ts
+++ b/packages/-warp-drive/src/-private/shared/utils.ts
@@ -131,7 +131,7 @@ export function isKeyOf<T extends object>(key: string, obj: T): key is keyof T &
 /**
  * colorizes a string based on color<<>> syntax
  * where color is one of the following:
- * - gr (grey)
+ * - gr (gray)
  * - bg (brightGreen)
  * - bm (brightMagenta)
  * - cy (cyan)
@@ -139,11 +139,11 @@ export function isKeyOf<T extends object>(key: string, obj: T): key is keyof T &
  *
  * e.g.
  *
- * color`This is gr<<grey>> and this is bg<<bright green>> and this is bm<<bright magenta>> and this is cy<<cyan>> and this is ye<<yellow>>`
+ * color`This is gr<<gray>> and this is bg<<bright green>> and this is bm<<bright magenta>> and this is cy<<cyan>> and this is ye<<yellow>>`
  */
 export function color(str: string): string {
   const colors = {
-    gr: 'grey',
+    gr: 'gray',
     gb: 'greenBright',
     mb: 'magentaBright',
     cy: 'cyan',
@@ -181,12 +181,12 @@ export function rebalanceLines(str: string, max_length = 75): string {
       continue;
     }
     if (line.trim() === '---') {
-      lines[i] = styleText('grey', getPadding(max_length, '-'));
+      lines[i] = styleText('gray', getPadding(max_length, '-'));
       inContext = false;
       continue;
     }
     if (line.trim() === '===') {
-      lines[i] = styleText('grey', getPadding(max_length, '='));
+      lines[i] = styleText('gray', getPadding(max_length, '='));
       inContext = false;
       continue;
     }

--- a/packages/-warp-drive/src/-private/warp-drive/commands/retrofit.ts
+++ b/packages/-warp-drive/src/-private/warp-drive/commands/retrofit.ts
@@ -262,7 +262,7 @@ async function retrofitTypesForProject(
 
   // add the packages to the package.json
   // and install them
-  write(styleText('grey', `\t📦  Updating versions for ${toInstall.size} packages`));
+  write(styleText('gray', `\t📦  Updating versions for ${toInstall.size} packages`));
   if (toInstall.size > 0) {
     // add the packages to the package.json
     for (const [pkgName, config] of toInstall) {
@@ -304,7 +304,7 @@ async function retrofitTypesForProject(
 
   const overrideChanges = new Set<string>();
   if (pkg.pnpm?.overrides) {
-    write(styleText('grey', `\t🔍  Checking for pnpm overrides to update`));
+    write(styleText('gray', `\t🔍  Checking for pnpm overrides to update`));
     for (const pkgName of Object.keys(pkg.pnpm.overrides)) {
       if (toInstall.has(pkgName)) {
         const value = pkg.pnpm.overrides[pkgName];
@@ -317,7 +317,7 @@ async function retrofitTypesForProject(
         }
       }
     }
-    write(styleText('grey', `\t✅ Updated ${overrideChanges.size} pnpm overrides`));
+    write(styleText('gray', `\t✅ Updated ${overrideChanges.size} pnpm overrides`));
   }
 
   const removed = new Set();
@@ -331,7 +331,7 @@ async function retrofitTypesForProject(
       delete devDeps[pkgName];
     }
   }
-  write(styleText('grey', `\t🗑  Removing ${removed.size} DefinitelyTyped packages`));
+  write(styleText('gray', `\t🗑  Removing ${removed.size} DefinitelyTyped packages`));
 
   if (removed.size > 0 || toInstall.size > 0 || overrideChanges.size > 0) {
     writePkgJson(pkg);
@@ -356,7 +356,7 @@ async function retrofitTypesForProject(
   }
 
   if (options?.isRoot) {
-    write(styleText('grey', `\t☑️ Skipped tsconfig.json update for monorepo root`));
+    write(styleText('gray', `\t☑️ Skipped tsconfig.json update for monorepo root`));
     return;
   }
 
@@ -380,7 +380,7 @@ async function retrofitTypesForProject(
     }
     tsConfig.compilerOptions.types.sort();
     fs.writeFileSync(fullTsConfigPath, JSON.stringify(tsConfig, null, 2) + '\n');
-    write(styleText('grey', `\t✅  created a tsconfig.json`));
+    write(styleText('gray', `\t✅  created a tsconfig.json`));
   } else {
     let edited = false;
     const tsConfig = JSONC.parse(fs.readFileSync(fullTsConfigPath, { encoding: 'utf-8' })) as {
@@ -416,7 +416,7 @@ async function retrofitTypesForProject(
     if (edited) {
       tsConfig.compilerOptions.types.sort();
       fs.writeFileSync(fullTsConfigPath, JSONC.stringify(tsConfig, null, 2) + '\n');
-      write(styleText('grey', `\t✅  updated tsconfig.json`));
+      write(styleText('gray', `\t✅  updated tsconfig.json`));
     } else {
       write(`\tNo tsconfig updates required!`);
     }

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -51,7 +51,7 @@
     "@types/bun": "^1.4.0",
     "@types/inquirer": "^9.0.10",
     "@types/jscodeshift": "^17.3.0",
-    "@types/node": "22.20.1",
+    "@types/node": "catalog:",
     "@warp-drive/internal-config": "workspace:*",
     "eslint": "^9.34.0"
   },

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },

--- a/packages/diagnostic/package.json
+++ b/packages/diagnostic/package.json
@@ -114,7 +114,7 @@
     "@warp-drive/internal-config": "workspace:*",
     "bun-types": "^1.4.0",
     "ember-cli-test-loader": "^3.1.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },

--- a/packages/internal-exam/package.json
+++ b/packages/internal-exam/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@warp-drive/internal-config": "workspace:*",
     "ember-qunit": "9.1.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "qunit": "^2.26.0"
   },
   "volta": {

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "ember-inflector": "6.0.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -61,7 +61,7 @@
     "@ember-data/tracking": "workspace:*",
     "@ember/test-waiters": "^4.1.2",
     "@warp-drive/internal-config": "workspace:*",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -64,7 +64,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@ember/test-waiters": "^4.1.2",
     "@warp-drive/internal-config": "workspace:*",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -75,7 +75,7 @@
     "@types/semver": "^7.8.0",
     "@warp-drive/diagnostic": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "qunit": "^2.26.0",
     "testem": "^3.20.1",
     "tsdown": "^0.22.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,15 @@ settings:
   peersSuffixMaxLength: 40
   injectWorkspacePackages: true
 
+catalogs:
+  default:
+    ember-source:
+      specifier: ~7.2.0
+      version: 7.2.0
+    vite:
+      specifier: ^8.2.1
+      version: 8.2.1
+
 overrides:
   '@embroider/macros': ^1.20.6
   ember-auto-import: ^2.13.1
@@ -31,6 +40,9 @@ overrides:
   '@babel/parser': ^7.29.8
   '@babel/traverse': ^7.29.8
   prettier: ^3.8.1
+  '@types/node': ^26.2.0
+  '@vue/compiler-sfc': 3.5.41
+  '@shikijs/langs': 4.4.3
 
 packageExtensionsChecksum: sha256-LEmCRx5wRNwDcX02PtZEszrDTCGRr9DkzhrTiN9snXM=
 
@@ -76,7 +88,7 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
@@ -99,8 +111,8 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       execa:
         specifier: ^9.6.1
         version: 9.6.1
@@ -177,7 +189,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1
       vite-plugin-image-optimizer:
         specifier: ^2.0.3
@@ -275,7 +287,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(@babel/core@7.29.7)(ember-source@6.12.0)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(@babel/core@7.29.7)(ember-source@7.2.0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -286,8 +298,8 @@ importers:
         specifier: workspace:*
         version: file:tools/internal-config
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       eslint:
         specifier: ^9.34.0
         version: 9.34.0
@@ -338,8 +350,8 @@ importers:
         specifier: ^4.1.13
         version: 4.1.13
       '@types/node':
-        specifier: ^24.3.0
-        version: 24.3.0
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/semver':
         specifier: ^7.8.0
         version: 7.8.0
@@ -458,8 +470,8 @@ importers:
         specifier: ^17.3.0
         version: 17.3.0
       '@types/node':
-        specifier: 22.20.1
-        version: 22.20.1
+        specifier: ^26.2.0
+        version: 26.2.0
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
@@ -529,8 +541,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.3)
@@ -579,7 +591,7 @@ importers:
         version: 7.29.7
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@glimmer/component':
         specifier: ^2.1.1
         version: 2.1.1
@@ -599,8 +611,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.3)
@@ -729,8 +741,8 @@ importers:
         specifier: 9.1.0
         version: 9.1.0(qunit@2.26.0)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       qunit:
         specifier: 2.26.0
         version: 2.26.0
@@ -911,8 +923,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.3)
@@ -1056,8 +1068,8 @@ importers:
         specifier: workspace:*
         version: file:tools/internal-config
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.3)
@@ -1093,8 +1105,8 @@ importers:
         specifier: workspace:*
         version: file:tools/internal-config
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.3)
@@ -1133,7 +1145,7 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@glimmer/component':
         specifier: ^2.1.1
         version: 2.1.1
@@ -1145,13 +1157,13 @@ importers:
         version: 7.8.0
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       qunit:
         specifier: 2.26.0
         version: 2.26.0
@@ -1254,8 +1266,8 @@ importers:
         specifier: 2.26.0
         version: 2.26.0
       vitest:
-        specifier: ^3.2.7
-        version: 3.2.7
+        specifier: ^4.1.11
+        version: 4.1.11
 
   tests/core:
     devDependencies:
@@ -1270,10 +1282,10 @@ importers:
         version: 7.29.7
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(95817422c39a0abe359b889514446aa3)
+        version: file:packages/unpublished-test-infra(8f001fdc1d041c9e126963fd707428ad)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1291,22 +1303,22 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
       '@glint/tsserver-plugin':
         specifier: 2.7.0
-        version: 2.7.0(9bad86862166aa7da316d34858a7a4f6)
+        version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(fdddd2ec5fd75e3981a5eb92313131b0)
+        version: file:specs(033f70491bbd67195f7939017eb7ebc8)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
+        version: file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
@@ -1332,8 +1344,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -1347,7 +1359,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/dont-write-new-tests-here:
@@ -1396,19 +1408,19 @@ importers:
         version: file:packages/store(2fac7a87d207b317b942783043977b8e)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(59c6700aa21e82e91ae748309fb51e5c)
+        version: file:packages/unpublished-test-infra(66ed04ab38cb0b5cd9e920ee3a8b4b64)
       '@ember/edition-utils':
         specifier: ^1.2.0
         version: 1.2.0
       '@ember/optional-features':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^3.0.0
+        version: 3.0.0
       '@ember/string':
         specifier: ^4.0.1
         version: 4.0.1
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1429,7 +1441,7 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
@@ -1459,7 +1471,7 @@ importers:
         version: file:tools/internal-config(7d28fa5cc489b7c9fe2c5ae481fc97f1)
       '@warp-drive/internal-exam':
         specifier: workspace:*
-        version: file:packages/internal-exam(01438fb5fe999c266963b6564656994a)
+        version: file:packages/internal-exam(a07f33e34e936c810c3a2a08ed5dde16)
       '@warp-drive/json-api':
         specifier: workspace:*
         version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
@@ -1480,10 +1492,10 @@ importers:
         version: 2.4.0(@babel/core@7.29.7)
       ember-cached-decorator-polyfill:
         specifier: ^1.0.2
-        version: 1.0.2(29e34a527242ddfe346e9f269dcccb98)
+        version: 1.0.2(5f449f6cf81f8a9eee2138210a1258e0)
       ember-data:
         specifier: workspace:*
-        version: file:packages/-ember-data(1d338695d99eae50046a37fa15dadf01)
+        version: file:packages/-ember-data(af46dc02664d662116157571e70adacf)
       ember-decorators-polyfill:
         specifier: ^1.1.5
         version: 1.1.5(@babel/core@7.29.7)
@@ -1498,13 +1510,13 @@ importers:
         version: 1.0.0(@babel/core@7.29.7)
       ember-qunit:
         specifier: 9.1.0
-        version: 9.1.0(3dff9a29fe67c87ca679d2dadb026fc7)
+        version: 9.1.0(ce2d83ff26ef0a53f073c9c9088e5c9f)
       ember-route-template:
         specifier: ^1.0.3
         version: 1.0.3
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1530,7 +1542,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1
 
   tests/ember-data__adapter:
@@ -1573,10 +1585,10 @@ importers:
         version: file:packages/store(55de178235eb5990a078df764e61b44e)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9b483ddb925f2432852c0e3262a8c21f)
+        version: file:packages/unpublished-test-infra(5bcd8248f4ce41e0e79b43bfa10341ea)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1606,7 +1618,7 @@ importers:
         version: file:packages/core-types(@babel/core@7.29.7)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
@@ -1626,8 +1638,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -1638,7 +1650,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/ember-data__graph:
@@ -1654,10 +1666,10 @@ importers:
         version: 7.29.7
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9b483ddb925f2432852c0e3262a8c21f)
+        version: file:packages/unpublished-test-infra(5bcd8248f4ce41e0e79b43bfa10341ea)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1681,7 +1693,7 @@ importers:
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
@@ -1704,8 +1716,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -1716,7 +1728,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/ember-data__model:
@@ -1756,7 +1768,7 @@ importers:
         version: file:packages/store(55de178235eb5990a078df764e61b44e)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1786,7 +1798,7 @@ importers:
         version: file:packages/core-types(@babel/core@7.29.7)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
@@ -1800,8 +1812,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -1812,7 +1824,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/ember-data__request:
@@ -1834,7 +1846,7 @@ importers:
         version: file:packages/request-utils(@babel/core@7.29.7)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1864,7 +1876,7 @@ importers:
         version: file:packages/core-types(@babel/core@7.29.7)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
@@ -1881,8 +1893,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -1893,7 +1905,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/example-app-ember:
@@ -1914,11 +1926,11 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@ember/optional-features':
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^3.0.0
+        version: 3.0.0
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -1936,13 +1948,13 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
       '@glint/tsserver-plugin':
         specifier: 2.7.0
-        version: 2.7.0(9bad86862166aa7da316d34858a7a4f6)
+        version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@html-next/vertical-collection':
         specifier: ^5.0.5
         version: 5.0.5
@@ -1975,13 +1987,13 @@ importers:
         version: 2.4.0(@babel/core@7.29.7)
       ember-page-title:
         specifier: ^9.0.3
-        version: 9.0.3(f607f93339c6e406b031c8f1798ad8d2)
+        version: 9.0.3(b7878531927745129b4f7f52f1c24ed8)
       ember-qunit:
         specifier: ^9.1.0
-        version: 9.1.0(3dff9a29fe67c87ca679d2dadb026fc7)
+        version: 9.1.0(ce2d83ff26ef0a53f073c9c9088e5c9f)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2007,7 +2019,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1
 
   tests/experiments:
@@ -2047,10 +2059,10 @@ importers:
         version: file:packages/store(2fac7a87d207b317b942783043977b8e)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(95817422c39a0abe359b889514446aa3)
+        version: file:packages/unpublished-test-infra(8f001fdc1d041c9e126963fd707428ad)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -2068,13 +2080,13 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
       '@glint/tsserver-plugin':
         specifier: 2.7.0
-        version: 2.7.0(9bad86862166aa7da316d34858a7a4f6)
+        version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(40bc2c5d5662a5666eb0d917619838cd)
@@ -2086,7 +2098,7 @@ importers:
         version: file:packages/core-types(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
+        version: file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
@@ -2115,8 +2127,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2127,7 +2139,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/framework-ember:
@@ -2143,7 +2155,7 @@ importers:
         version: 7.29.7
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -2161,22 +2173,22 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
       '@glint/tsserver-plugin':
         specifier: 2.7.0
-        version: 2.7.0(9bad86862166aa7da316d34858a7a4f6)
+        version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(3c5f3288a7098380bb4dfb9c47a538cd)
+        version: file:specs(06a36ace3198fd3ead09eac8cef30b30)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
+        version: file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
@@ -2202,8 +2214,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2214,7 +2226,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/framework-react:
@@ -2280,7 +2292,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1
 
   tests/framework-svelte:
@@ -2334,7 +2346,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1
 
   tests/framework-vue:
@@ -2391,7 +2403,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1
       vue:
         specifier: ^3.5.41
@@ -2413,10 +2425,10 @@ importers:
         version: 7.29.7
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9b483ddb925f2432852c0e3262a8c21f)
+        version: file:packages/unpublished-test-infra(5bcd8248f4ce41e0e79b43bfa10341ea)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -2443,7 +2455,7 @@ importers:
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
@@ -2469,8 +2481,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2481,7 +2493,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/legacy:
@@ -2497,10 +2509,10 @@ importers:
         version: 7.29.7
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(95817422c39a0abe359b889514446aa3)
+        version: file:packages/unpublished-test-infra(8f001fdc1d041c9e126963fd707428ad)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -2518,22 +2530,22 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
       '@glint/tsserver-plugin':
         specifier: 2.7.0
-        version: 2.7.0(9bad86862166aa7da316d34858a7a4f6)
+        version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(3c5f3288a7098380bb4dfb9c47a538cd)
+        version: file:specs(06a36ace3198fd3ead09eac8cef30b30)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
+        version: file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
@@ -2559,8 +2571,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2574,7 +2586,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/performance:
@@ -2593,7 +2605,7 @@ importers:
         version: 7.29.7
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -2637,8 +2649,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2646,7 +2658,7 @@ importers:
         specifier: ^5.43.1
         version: 5.43.1
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
       vite-bundle-analyzer:
         specifier: ^1.3.9
@@ -2698,10 +2710,10 @@ importers:
         version: file:packages/store(55de178235eb5990a078df764e61b44e)
       '@ember-data/unpublished-test-infra':
         specifier: workspace:*
-        version: file:packages/unpublished-test-infra(9b483ddb925f2432852c0e3262a8c21f)
+        version: file:packages/unpublished-test-infra(5bcd8248f4ce41e0e79b43bfa10341ea)
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -2731,7 +2743,7 @@ importers:
         version: file:packages/core-types(@babel/core@7.29.7)
       '@warp-drive/diagnostic':
         specifier: workspace:*
-        version: file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+        version: file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
       '@warp-drive/ember':
         specifier: workspace:*
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
@@ -2748,8 +2760,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-strict-application-resolver:
         specifier: ^0.1.1
         version: 0.1.1(@babel/core@7.29.7)
@@ -2760,7 +2772,7 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(terser@5.43.1)
 
   tests/warp-drive__schema: {}
@@ -2930,8 +2942,8 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       '@types/node':
-        specifier: ^20.19.43
-        version: 20.19.43
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/semver':
         specifier: ^7.8.0
         version: 7.8.0
@@ -2970,8 +2982,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       expect-type:
         specifier: ^1.4.0
         version: 1.4.0
@@ -3008,7 +3020,7 @@ importers:
         version: 7.29.7
       '@ember/test-helpers':
         specifier: 5.2.0
-        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+        version: 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@ember/test-waiters':
         specifier: ^4.1.2
         version: 4.1.2
@@ -3020,13 +3032,13 @@ importers:
         version: 2.1.1
       '@glint/ember-tsc':
         specifier: 1.10.0
-        version: 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+        version: 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@glint/template':
         specifier: 1.8.0
         version: 1.8.0
       '@glint/tsserver-plugin':
         specifier: 2.7.0
-        version: 2.7.0(9bad86862166aa7da316d34858a7a4f6)
+        version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(e21bb88fa88e86ab389341ee1b23f0ca)
@@ -3038,10 +3050,10 @@ importers:
         version: 2.4.0(@babel/core@7.29.7)
       ember-provide-consume-context:
         specifier: ^0.8.0
-        version: 0.8.0(44dc2e23d3b502fe1b7cb6f8457bf31b)
+        version: 0.8.0(5e5deff66abd2d48ecaa53fbd2988501)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0(@glimmer/component@2.1.1)
+        specifier: 'catalog:'
+        version: 7.2.0(@glimmer/component@2.1.1)
       ember-template-imports:
         specifier: ^4.4.0
         version: 4.4.0
@@ -3160,8 +3172,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
       ember-source:
-        specifier: ~6.12.0
-        version: 6.12.0
+        specifier: 'catalog:'
+        version: 7.2.0
       expect-type:
         specifier: ^1.4.0
         version: 1.4.0
@@ -3263,16 +3275,16 @@ importers:
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.70.3
-        version: 2.70.3(1221461afa37aa850757d50ac80114fe)
+        version: 2.70.3(42943648dd27b815df9ecd6cc0da8c47)
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.9)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^6.2.4
-        version: 6.2.4(svelte@5.56.9)(vite@7.3.1)
+        specifier: ^7.3.0
+        version: 7.3.0(svelte@5.56.9)(vite@8.2.1)
       '@warp-drive/internal-config':
         specifier: workspace:*
-        version: file:tools/internal-config(vite@7.3.1)
+        version: file:tools/internal-config(vite@8.2.1)
       svelte:
         specifier: ^5.56.9
         version: 5.56.9
@@ -3280,8 +3292,8 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.1
-        version: 7.3.1
+        specifier: 'catalog:'
+        version: 8.2.1
 
   warp-drive-packages/tc39-proposal-signals:
     dependencies:
@@ -4253,9 +4265,9 @@ packages:
   '@ember/edition-utils@1.2.0':
     resolution: {integrity: sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==}
 
-  '@ember/optional-features@2.3.0':
-    resolution: {integrity: sha512-+M8CkPledQEaDbfIlwlq6Phgpm5jdT3a6WVDJk7b/zadw5xAJkuQKVK7DgR0SFgHGiWlyn6a8AU5p2mCA706RA==}
-    engines: {node: 10.* || 12.* || >= 14}
+  '@ember/optional-features@3.0.0':
+    resolution: {integrity: sha512-HMQqZoBb16I4NyHfQglIYjopSG6folcEJah2WPa0FuolWRA/8cS5ozQmFK5BQx7cijTQJxj6viLpQK9KrXuYdw==}
+    engines: {node: '>= 20.19'}
 
   '@ember/string@4.0.1':
     resolution: {integrity: sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==}
@@ -4332,162 +4344,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -4802,13 +4658,53 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/checkbox@2.5.0':
     resolution: {integrity: sha512-sMgdETOfi2dUHT8r7TT1BTKOwNvdDGFDXYWtQ2J69SvlYNntk9I/gJe7r5yvMwwsuKnYbuRs3pNhx4tgNck5aA==}
     engines: {node: '>=18'}
 
+  '@inquirer/checkbox@5.2.2':
+    resolution: {integrity: sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@3.2.0':
     resolution: {integrity: sha512-oOIwPs0Dvq5220Z8lGL/6LHRTEr9TgLHmiI99Rj1PJ1p1czTys+olrgBqZk4E2qC0YTzeHprxSQmoHioVdJ7Lw==}
     engines: {node: '>=18'}
+
+  '@inquirer/confirm@6.2.0':
+    resolution: {integrity: sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@12.0.0':
+    resolution: {integrity: sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/core@9.2.1':
     resolution: {integrity: sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==}
@@ -4818,41 +4714,135 @@ packages:
     resolution: {integrity: sha512-9KHOpJ+dIL5SZli8lJ6xdaYLPPzB8xB9GZItg39MBybzhxA16vxmszmQFrRwbOA918WA2rvu8xhDEg/p6LXKbw==}
     engines: {node: '>=18'}
 
+  '@inquirer/editor@5.3.0':
+    resolution: {integrity: sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/expand@2.3.0':
     resolution: {integrity: sha512-qnJsUcOGCSG1e5DTOErmv2BPQqrtT6uzqn1vI/aYGiPKq+FgslGZmtdnXbhuI7IlT7OByDoEEqdnhUnVR2hhLw==}
     engines: {node: '>=18'}
+
+  '@inquirer/expand@5.1.2':
+    resolution: {integrity: sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.4':
+    resolution: {integrity: sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/figures@1.0.11':
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
 
+  '@inquirer/figures@2.0.8':
+    resolution: {integrity: sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
   '@inquirer/input@2.3.0':
     resolution: {integrity: sha512-XfnpCStx2xgh1LIRqPXrTNEEByqQWoxsWYzNRSEUxJ5c6EQlhMogJ3vHKu8aXuTacebtaZzMAHwEL0kAflKOBw==}
     engines: {node: '>=18'}
+
+  '@inquirer/input@5.1.3':
+    resolution: {integrity: sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/number@1.1.0':
     resolution: {integrity: sha512-ilUnia/GZUtfSZy3YEErXLJ2Sljo/mf9fiKc08n18DdwdmDbOzRcTv65H1jjDvlsAuvdFXf4Sa/aL7iw/NanVA==}
     engines: {node: '>=18'}
 
+  '@inquirer/number@4.2.0':
+    resolution: {integrity: sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/password@2.2.0':
     resolution: {integrity: sha512-5otqIpgsPYIshqhgtEwSspBQE40etouR8VIxzpJkv9i0dVHIpyhiivbkH9/dGiMLdyamT54YRdGJLfl8TFnLHg==}
     engines: {node: '>=18'}
+
+  '@inquirer/password@5.1.2':
+    resolution: {integrity: sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/prompts@5.5.0':
     resolution: {integrity: sha512-BHDeL0catgHdcHbSFFUddNzvx/imzJMft+tWDPwTm3hfu8/tApk1HrooNngB2Mb4qY+KaRWF+iZqoVUPeslEog==}
     engines: {node: '>=18'}
 
+  '@inquirer/prompts@8.6.0':
+    resolution: {integrity: sha512-WgBVDRy3IQ4v9XMCpQ1YDGpso2PcMUxYJzZdH4Nt4t0eoXhEPmOCh5iZbXbR4GTbdUB9VPWBbJB12rkjbaGDCw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/rawlist@2.3.0':
     resolution: {integrity: sha512-zzfNuINhFF7OLAtGHfhwOW2TlYJyli7lOUoJUXw/uyklcwalV6WRXBXtFIicN8rTRK1XTiPWB4UY+YuW8dsnLQ==}
     engines: {node: '>=18'}
+
+  '@inquirer/rawlist@5.3.2':
+    resolution: {integrity: sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/search@1.1.0':
     resolution: {integrity: sha512-h+/5LSj51dx7hp5xOn4QFnUaKeARwUCLs6mIhtkJ0JYPBLmEYjdHSYh7I6GrLg9LwpJ3xeX0FZgAG1q0QdCpVQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/search@4.3.0':
+    resolution: {integrity: sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/select@2.5.0':
     resolution: {integrity: sha512-YmDobTItPP3WcEI86GvPo+T2sRHkxxOq/kXmsBjHS5BVXUgvgZ5AfJjkvQvZr03T81NnI3KrrRuMzeuYUQRFOA==}
     engines: {node: '>=18'}
+
+  '@inquirer/select@5.2.2':
+    resolution: {integrity: sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/type@1.5.5':
     resolution: {integrity: sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==}
@@ -4861,6 +4851,15 @@ packages:
   '@inquirer/type@2.0.0':
     resolution: {integrity: sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==}
     engines: {node: '>=18'}
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -5583,9 +5582,6 @@ packages:
     resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
     engines: {node: '>=20'}
 
-  '@shikijs/langs@3.23.0':
-    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
-
   '@shikijs/langs@4.4.3':
     resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
     engines: {node: '>=20'}
@@ -5638,6 +5634,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@sveltejs/acorn-typescript@1.0.13':
     resolution: {integrity: sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==}
     peerDependencies:
@@ -5666,20 +5665,12 @@ packages:
     peerDependencies:
       svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.0':
-    resolution: {integrity: sha512-iwQ8Z4ET6ZFSt/gC+tVfcsSBHwsqc6RumSaiLUkAurW3BCpJam65cmHw0oOlDMTO0u+PZi9hilBRYN+LZNHTUQ==}
+  '@sveltejs/vite-plugin-svelte@7.3.0':
+    resolution: {integrity: sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A==}
     engines: {node: ^20.19 || ^22.12 || >=24}
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^6.0.0-next.0
-      svelte: ^5.0.0
-      vite: ^6.3.0 || ^7.0.0
-
-  '@sveltejs/vite-plugin-svelte@6.2.4':
-    resolution: {integrity: sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==}
-    engines: {node: ^20.19 || ^22.12 || >=24}
-    peerDependencies:
-      svelte: ^5.0.0
-      vite: ^6.3.0 || ^7.0.0
+      svelte: ^5.46.4
+      vite: ^8.0.0-beta.7 || ^8.0.0
 
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
@@ -5870,14 +5861,8 @@ packages:
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
 
-  '@types/node@20.19.43':
-    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
-
-  '@types/node@22.20.1':
-    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
-
-  '@types/node@24.3.0':
-    resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/qunit@2.19.14':
     resolution: {integrity: sha512-ou2RMtwyDnW1btrMnDMZeL6V5/yRRbuHKrRC6y8IuzDljjVzw6wPCVFb8p4qJD0NkUkf3BdZeJJIBzjK1BUUDQ==}
@@ -6135,34 +6120,34 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/expect@3.2.7':
-    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@3.2.7':
-    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.7':
-    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@3.2.7':
-    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@3.2.7':
-    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@3.2.7':
-    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@3.2.7':
-    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -6206,26 +6191,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.5.19':
-    resolution: {integrity: sha512-/afpyvlkrSNYbPo94Qu8GtIOWS+g5TRdOvs6XZNw6pWQQmj5pBgSZvEPOIZlqWq0YvoUhDDQaQ2TnzuJdOV4hA==}
-
   '@vue/compiler-core@3.5.41':
     resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
-
-  '@vue/compiler-dom@3.5.19':
-    resolution: {integrity: sha512-Drs6rPHQZx/pN9S6ml3Z3K/TWCIRPvzG2B/o5kFK9X0MNHt8/E+38tiRfojufrYBfA6FQUFB2qBBRXlcSXWtOA==}
 
   '@vue/compiler-dom@3.5.41':
     resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
 
-  '@vue/compiler-sfc@3.5.19':
-    resolution: {integrity: sha512-YWCm1CYaJ+2RvNmhCwI7t3I3nU+hOrWGWMsn+Z/kmm1jy5iinnVtlmkiZwbLlbV1SRizX7vHsc0/bG5dj0zRTg==}
-
   '@vue/compiler-sfc@3.5.41':
     resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
-
-  '@vue/compiler-ssr@3.5.19':
-    resolution: {integrity: sha512-/wx0VZtkWOPdiQLWPeQeqpHWR/LuNC7bHfSX7OayBTtUy8wur6vT6EQIX6Et86aED6J+y8tTw43qo2uoqGg5sw==}
 
   '@vue/compiler-ssr@3.5.41':
     resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
@@ -6256,9 +6229,6 @@ packages:
 
   '@vue/shared@3.5.18':
     resolution: {integrity: sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==}
-
-  '@vue/shared@3.5.19':
-    resolution: {integrity: sha512-IhXCOn08wgKrLQxRFKKlSacWg4Goi1BolrdEeLYn6tgHjJNXVrWJ5nzoxZqNwl5p88aLlQ8LOaoMa3AYvaKJ/Q==}
 
   '@vue/shared@3.5.41':
     resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
@@ -7038,10 +7008,6 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -7096,8 +7062,8 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@2.4.2:
@@ -7131,12 +7097,11 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
   charm@1.0.2:
     resolution: {integrity: sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==}
-
-  check-error@2.1.1:
-    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
-    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -7169,18 +7134,10 @@ packages:
     resolution: {integrity: sha512-XW2Vg+w+L9on9wtwKpyzluIPCWXjaBahI7mTcYjx+BVIYD9c3yqcv/yKC7CmdCZat4rq2yiE1UMSJC5ivKfMtQ==}
     engines: {node: '>= 10'}
 
-  cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
-
-  cli-width@3.0.0:
-    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
-    engines: {node: '>= 10'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -7599,10 +7556,6 @@ packages:
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -7839,8 +7792,8 @@ packages:
     engines: {node: 10.* || 12.* || >= 14}
     hasBin: true
 
-  ember-source@6.12.0:
-    resolution: {integrity: sha512-cApfEKxltl2VWt0o24XISsdkpyqqtT8wG0/EWokjeyqBPRCOIej2PMzRkLAu3A5AWpuWoJ//yq04mDix7axA7w==}
+  ember-source@7.2.0:
+    resolution: {integrity: sha512-pWjYFeM76vAgiFvqrBacAsQh94vTIy8SC1X2S3goULJHJ5/tVWAZ2NtaLFx9oZd3/Lk0gGRdsCMla9rQY58vyw==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
@@ -7927,8 +7880,8 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -7941,11 +7894,6 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
-
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -8188,8 +8136,17 @@ packages:
     resolution: {integrity: sha512-7h9/x25c6AQwdU3mA8MZDUMR3UCy50f237egBrBkuwjnUZSmfu4ptCf91PZSKzON2Uh5VvIHozYKWcPPgcjxIw==}
     engines: {node: 10.* || >= 12.*}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -8208,10 +8165,6 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
-
-  figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -8712,9 +8665,14 @@ packages:
     resolution: {integrity: sha512-tyao/4Vo36XnUItZ7DnUXX4f1jVao2mSrleV/5IPtW/XAEA26hRVsbc68nuTEKWcr5vMP/1mVoT2O7u8H4v1Vg==}
     engines: {node: '>=18'}
 
-  inquirer@7.3.3:
-    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
-    engines: {node: '>=8.0.0'}
+  inquirer@13.4.3:
+    resolution: {integrity: sha512-EPd3IqieHSavSOXh+LZhrIkdQcOELWeRblLT6kslQr+cF9XTh/HxZdSt1YkHH1iq4dvqBnV42uwg2YlorgOy6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': ^26.2.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -8962,9 +8920,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -9194,9 +9149,6 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -9216,6 +9168,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magic-string@1.2.1:
+    resolution: {integrity: sha512-vCfXkt3lIJha02CjPT1igeysyHVfCsEpIeD20O+X9aJ2hML3/kKx8E9Iv1FB+aMSAlDOEAtpRWzuooQCrYwdUg==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -9536,12 +9491,13 @@ packages:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
 
-  mute-stream@0.0.8:
-    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -9824,10 +9780,6 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
-
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -9837,10 +9789,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -9872,10 +9820,6 @@ packages:
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -10187,10 +10131,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
-
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -10264,13 +10204,6 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  router_js@8.0.6:
-    resolution: {integrity: sha512-AjGxRDIpTGoAG8admFmvP/cxn1AlwwuosCclMU4R5oGHGt7ER0XtB3l9O04ToBDdPe4ivM/YcLopgBEpJssJ/Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      route-recognizer: ^0.3.4
-      rsvp: ^4.8.5
-
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -10288,20 +10221,16 @@ packages:
     resolution: {integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==}
     engines: {node: 6.* || >= 7.*}
 
-  run-async@2.4.1:
-    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
-    engines: {node: '>=0.12.0'}
-
   run-async@3.0.0:
     resolution: {integrity: sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==}
     engines: {node: '>=0.12.0'}
 
+  run-async@4.0.6:
+    resolution: {integrity: sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
-  rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -10367,11 +10296,6 @@ packages:
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -10587,8 +10511,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -10665,9 +10589,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   styled_string@0.0.1:
     resolution: {integrity: sha512-DU2KZiB6VbPkO2tGSqQ9n96ZstUPjW7X4sGO6V2m1myIQluX0p1Ol8BrA/l6/EesqhMqXOIXs3cJNOy1UuU2BA==}
@@ -10775,9 +10696,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
   tiny-glob@0.2.9:
     resolution: {integrity: sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==}
 
@@ -10787,31 +10705,16 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -10926,9 +10829,6 @@ packages:
         optional: true
       unrun:
         optional: true
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -11052,11 +10952,8 @@ packages:
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -11204,11 +11101,6 @@ packages:
     resolution: {integrity: sha512-hhy975B+ToseJaSJp3mURHriZUrMgaM2qx0BkP62kN6Yp46rw7EE3dl8ExFWYdn00OIwe7GbsA5PknvstNWG4Q==}
     hasBin: true
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-plugin-compression2@2.5.3:
     resolution: {integrity: sha512-ItPgqQWkcnBbVw7is9OKwiZ8v6+ju9rYROl5Lp6QfQDEx/d55AwJQb/KLpsQqsU9HoigYBsZ8tK6I02UwJNvEw==}
 
@@ -11235,52 +11127,12 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^26.2.0
       '@vitejs/devtools': ^0.4.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
@@ -11318,10 +11170,10 @@ packages:
       yaml:
         optional: true
 
-  vitefu@1.1.1:
-    resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -11356,26 +11208,38 @@ packages:
       postcss:
         optional: true
 
-  vitest@3.2.7:
-    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.7
-      '@vitest/ui': 3.2.7
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^26.2.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -13523,9 +13387,23 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(59c6700aa21e82e91ae748309fb51e5c)':
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(5bcd8248f4ce41e0e79b43bfa10341ea)':
     dependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
+      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      semver: 7.8.5
+    optionalDependencies:
+      '@warp-drive/diagnostic': file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(66ed04ab38cb0b5cd9e920ee3a8b4b64)':
+    dependencies:
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
@@ -13538,29 +13416,15 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(95817422c39a0abe359b889514446aa3)':
+  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(8f001fdc1d041c9e126963fd707428ad)':
     dependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
       semver: 7.8.5
     optionalDependencies:
-      '@warp-drive/diagnostic': file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(9b483ddb925f2432852c0e3262a8c21f)':
-    dependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
-      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
-      semver: 7.8.5
-    optionalDependencies:
-      '@warp-drive/diagnostic': file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)
+      '@warp-drive/diagnostic': file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13568,20 +13432,19 @@ snapshots:
 
   '@ember/edition-utils@1.2.0': {}
 
-  '@ember/optional-features@2.3.0':
+  '@ember/optional-features@3.0.0':
     dependencies:
-      chalk: 4.1.2
       ember-cli-version-checker: 5.1.2
-      glob: 7.2.3
-      inquirer: 7.3.3
-      mkdirp: 1.0.4
+      inquirer: 13.4.3
       silent-error: 1.1.1
+      tinyglobby: 0.2.17
     transitivePeerDependencies:
+      - '@types/node'
       - supports-color
 
   '@ember/string@4.0.1': {}
 
-  '@ember/test-helpers@5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)':
+  '@ember/test-helpers@5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)':
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
@@ -13589,13 +13452,13 @@ snapshots:
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember/test-helpers@5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)':
+  '@ember/test-helpers@5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)':
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
@@ -13603,13 +13466,13 @@ snapshots:
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember/test-helpers@5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(@babel/core@7.29.7)(ember-source@6.12.0)':
+  '@ember/test-helpers@5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(@babel/core@7.29.7)(ember-source@7.2.0)':
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
@@ -13617,7 +13480,7 @@ snapshots:
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
-      ember-source: 6.12.0
+      ember-source: 7.2.0
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13915,84 +13778,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.2':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
-    optional: true
-
   '@eslint-community/eslint-utils@4.7.0(eslint@9.34.0)':
     dependencies:
       eslint: 9.34.0
@@ -14042,7 +13827,7 @@ snapshots:
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
       '@shikijs/engine-oniguruma': 3.23.0
-      '@shikijs/langs': 3.23.0
+      '@shikijs/langs': 4.4.3
       '@shikijs/themes': 3.23.0
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
@@ -14114,7 +13899,7 @@ snapshots:
     dependencies:
       '@glimmer/interfaces': 0.94.6
 
-  '@glint/ember-tsc@1.10.0(0ad543093b401fa16b97ac0160b7f0cc)':
+  '@glint/ember-tsc@1.10.0(8baf6c5115e916f49949be2bc6b560e0)':
     dependencies:
       '@glimmer/syntax': 0.95.0
       '@glint/template': 1.8.0
@@ -14134,15 +13919,15 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@glint/template@1.8.0': {}
 
-  '@glint/tsserver-plugin@2.7.0(9bad86862166aa7da316d34858a7a4f6)':
+  '@glint/tsserver-plugin@2.7.0(cc8cad6b2644672ec8a53791bfc61df2)':
     dependencies:
-      '@glint/ember-tsc': 1.10.0(0ad543093b401fa16b97ac0160b7f0cc)
+      '@glint/ember-tsc': 1.10.0(8baf6c5115e916f49949be2bc6b560e0)
       '@volar/language-core': 2.4.28
       '@volar/typescript': 2.4.28
       jiti: 2.7.0
@@ -14305,6 +14090,8 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
+  '@inquirer/ansi@2.0.7': {}
+
   '@inquirer/checkbox@2.5.0':
     dependencies:
       '@inquirer/core': 9.2.1
@@ -14313,17 +14100,49 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/checkbox@5.2.2':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
+
   '@inquirer/confirm@3.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
+
+  '@inquirer/confirm@6.2.0':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/core@11.2.1':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+
+  '@inquirer/core@12.0.0':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
 
   '@inquirer/core@9.2.1':
     dependencies:
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.20.1
+      '@types/node': 26.2.0
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -14339,29 +14158,63 @@ snapshots:
       '@inquirer/type': 1.5.5
       external-editor: 3.1.0
 
+  '@inquirer/editor@5.3.0':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/external-editor': 3.0.4
+      '@inquirer/type': 4.0.7
+
   '@inquirer/expand@2.3.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/expand@5.1.2':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
+
+  '@inquirer/external-editor@3.0.4':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.2
+
   '@inquirer/figures@1.0.11': {}
+
+  '@inquirer/figures@2.0.8': {}
 
   '@inquirer/input@2.3.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
 
+  '@inquirer/input@5.1.3':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
+
   '@inquirer/number@1.1.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
+
+  '@inquirer/number@4.2.0':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
   '@inquirer/password@2.2.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
       ansi-escapes: 4.3.2
+
+  '@inquirer/password@5.1.2':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
   '@inquirer/prompts@5.5.0':
     dependencies:
@@ -14376,11 +14229,29 @@ snapshots:
       '@inquirer/search': 1.1.0
       '@inquirer/select': 2.5.0
 
+  '@inquirer/prompts@8.6.0':
+    dependencies:
+      '@inquirer/checkbox': 5.2.2
+      '@inquirer/confirm': 6.2.0
+      '@inquirer/editor': 5.3.0
+      '@inquirer/expand': 5.1.2
+      '@inquirer/input': 5.1.3
+      '@inquirer/number': 4.2.0
+      '@inquirer/password': 5.1.2
+      '@inquirer/rawlist': 5.3.2
+      '@inquirer/search': 4.3.0
+      '@inquirer/select': 5.2.2
+
   '@inquirer/rawlist@2.3.0':
     dependencies:
       '@inquirer/core': 9.2.1
       '@inquirer/type': 1.5.5
       yoctocolors-cjs: 2.1.2
+
+  '@inquirer/rawlist@5.3.2':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/type': 4.0.7
 
   '@inquirer/search@1.1.0':
     dependencies:
@@ -14388,6 +14259,12 @@ snapshots:
       '@inquirer/figures': 1.0.11
       '@inquirer/type': 1.5.5
       yoctocolors-cjs: 2.1.2
+
+  '@inquirer/search@4.3.0':
+    dependencies:
+      '@inquirer/core': 12.0.0
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
 
   '@inquirer/select@2.5.0':
     dependencies:
@@ -14397,6 +14274,13 @@ snapshots:
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
 
+  '@inquirer/select@5.2.2':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 12.0.0
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.0.7
+
   '@inquirer/type@1.5.5':
     dependencies:
       mute-stream: 1.0.0
@@ -14404,6 +14288,8 @@ snapshots:
   '@inquirer/type@2.0.0':
     dependencies:
       mute-stream: 1.0.0
+
+  '@inquirer/type@4.0.7': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -14994,12 +14880,12 @@ snapshots:
       '@babel/core': 7.29.7
       picomatch: 4.0.5
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(vite@7.3.1)':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(vite@8.2.1)':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.5
     optionalDependencies:
-      vite: 7.3.1
+      vite: 8.2.1
 
   '@rolldown/plugin-babel@0.2.3(e67aa5d3e8c925af4c7fa907efe2a5b3)':
     dependencies:
@@ -15203,10 +15089,6 @@ snapshots:
       '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@3.23.0':
-    dependencies:
-      '@shikijs/types': 3.23.0
-
   '@shikijs/langs@4.4.3':
     dependencies:
       '@shikijs/types': 4.4.3
@@ -15261,15 +15143,17 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@sveltejs/acorn-typescript@1.0.13(acorn@8.18.0)':
     dependencies:
       acorn: 8.18.0
 
-  '@sveltejs/kit@2.70.3(1221461afa37aa850757d50ac80114fe)':
+  '@sveltejs/kit@2.70.3(42943648dd27b815df9ecd6cc0da8c47)':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.13(acorn@8.18.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.9)(vite@7.3.1)
+      '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9)(vite@8.2.1)
       '@types/cookie': 0.6.0
       acorn: 8.18.0
       cookie: 0.6.0
@@ -15281,7 +15165,7 @@ snapshots:
       set-cookie-parser: 3.1.2
       sirv: 3.0.1
       svelte: 5.56.9
-      vite: 7.3.1
+      vite: 8.2.1
     optionalDependencies:
       typescript: 5.9.3
 
@@ -15296,26 +15180,14 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.0(51ffad1164e1546a6dc38c0d7cf157f7)':
+  '@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.9)(vite@8.2.1)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.9)(vite@7.3.1)
-      debug: 4.4.3
-      svelte: 5.56.9
-      vite: 7.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.9)(vite@7.3.1)':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.0(51ffad1164e1546a6dc38c0d7cf157f7)
       deepmerge: 4.3.1
-      magic-string: 0.30.21
+      magic-string: 1.2.1
       obug: 2.1.4
       svelte: 5.56.9
-      vite: 7.3.1
-      vitefu: 1.1.1(vite@7.3.1)
-    transitivePeerDependencies:
-      - supports-color
+      vite: 8.2.1
+      vitefu: 1.1.3(vite@8.2.1)
 
   '@tootallnate/once@1.1.2': {}
 
@@ -15385,7 +15257,7 @@ snapshots:
 
   '@types/cors@2.8.18':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
 
   '@types/debug@4.1.13':
     dependencies:
@@ -15577,25 +15449,17 @@ snapshots:
 
   '@types/morgan@1.9.10':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
 
   '@types/ms@2.1.0': {}
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
 
-  '@types/node@20.19.43':
+  '@types/node@26.2.0':
     dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.20.1':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@24.3.0':
-    dependencies:
-      undici-types: 7.10.0
+      undici-types: 8.3.0
 
   '@types/qunit@2.19.14': {}
 
@@ -15617,13 +15481,13 @@ snapshots:
 
   '@types/ssri@7.1.5':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
 
   '@types/symlink-or-copy@1.2.2': {}
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
 
   '@types/triple-beam@1.3.5': {}
 
@@ -15818,47 +15682,46 @@ snapshots:
       vite: 8.2.1
       vue: 3.5.41(typescript@5.9.3)
 
-  '@vitest/expect@3.2.7':
+  '@vitest/expect@4.1.11':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@3.2.7(vite@7.3.1)':
+  '@vitest/mocker@4.1.11(vite@8.2.1)':
     dependencies:
-      '@vitest/spy': 3.2.7
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1
+      vite: 8.2.1
 
-  '@vitest/pretty-format@3.2.7':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/runner@3.2.7':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 3.2.7
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.7':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 3.2.7
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.7':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@3.2.7':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 3.2.7
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -15934,17 +15797,9 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/parser': 7.29.8
-      '@vue/compiler-sfc': 3.5.19
+      '@vue/compiler-sfc': 3.5.41
     transitivePeerDependencies:
       - supports-color
-
-  '@vue/compiler-core@3.5.19':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@vue/shared': 3.5.19
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
 
   '@vue/compiler-core@3.5.41':
     dependencies:
@@ -15954,27 +15809,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.19':
-    dependencies:
-      '@vue/compiler-core': 3.5.19
-      '@vue/shared': 3.5.19
-
   '@vue/compiler-dom@3.5.41':
     dependencies:
       '@vue/compiler-core': 3.5.41
       '@vue/shared': 3.5.41
-
-  '@vue/compiler-sfc@3.5.19':
-    dependencies:
-      '@babel/parser': 7.29.8
-      '@vue/compiler-core': 3.5.19
-      '@vue/compiler-dom': 3.5.19
-      '@vue/compiler-ssr': 3.5.19
-      '@vue/shared': 3.5.19
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.26
-      source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.41':
     dependencies:
@@ -15987,11 +15825,6 @@ snapshots:
       magic-string: 0.30.21
       postcss: 8.5.26
       source-map-js: 1.2.1
-
-  '@vue/compiler-ssr@3.5.19':
-    dependencies:
-      '@vue/compiler-dom': 3.5.19
-      '@vue/shared': 3.5.19
 
   '@vue/compiler-ssr@3.5.41':
     dependencies:
@@ -16045,8 +15878,6 @@ snapshots:
 
   '@vue/shared@3.5.18': {}
 
-  '@vue/shared@3.5.19': {}
-
   '@vue/shared@3.5.41': {}
 
   '@vueuse/core@14.4.0(vue@3.5.41(typescript@5.9.3))':
@@ -16070,6 +15901,32 @@ snapshots:
     dependencies:
       vue: 3.5.41(typescript@5.9.3)
 
+  '@warp-drive-internal/specs@file:specs(033f70491bbd67195f7939017eb7ebc8)':
+    dependencies:
+      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/diagnostic': file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
+      '@warp-drive/holodeck': file:packages/holodeck(26310aaa3e223322510bb82c0db267c5)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@warp-drive-internal/specs@file:specs(06a36ace3198fd3ead09eac8cef30b30)':
+    dependencies:
+      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/diagnostic': file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
+      '@warp-drive/holodeck': file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
   '@warp-drive-internal/specs@file:specs(2e97ca8f9593bbf07ae9f0b77cb834c4)':
     dependencies:
       '@embroider/macros': 1.20.6(@babel/core@7.29.7)
@@ -16083,19 +15940,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive-internal/specs@file:specs(3c5f3288a7098380bb4dfb9c47a538cd)':
-    dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/diagnostic': file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
-      '@warp-drive/holodeck': file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
   '@warp-drive-internal/specs@file:specs(bd118ae088fcc20826fce3e71f2b20cb)':
     dependencies:
       '@embroider/macros': 1.20.6(@babel/core@7.29.7)
@@ -16104,19 +15948,6 @@ snapshots:
       '@warp-drive/holodeck': file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
       '@warp-drive/json-api': file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
       '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@warp-drive-internal/specs@file:specs(fdddd2ec5fd75e3981a5eb92313131b0)':
-    dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/diagnostic': file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)
-      '@warp-drive/holodeck': file:packages/holodeck(26310aaa3e223322510bb82c0db267c5)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -16203,16 +16034,16 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/diagnostic@file:packages/diagnostic(5600f034a0ccc48d850b2335db56f886)':
+  '@warp-drive/diagnostic@file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/react': file:warp-drive-packages/react(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
+      '@warp-drive/react': file:warp-drive-packages/react(@babel/core@7.29.7)
       debug: 4.4.3
       dom-element-descriptors: 0.5.1
       qunit-dom: 3.6.0
     optionalDependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -16247,16 +16078,16 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/diagnostic@file:packages/diagnostic(f6b262eaee8283d40c902f65293e183f)':
+  '@warp-drive/diagnostic@file:packages/diagnostic(e49db713e81539b1909af76f9327417c)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
-      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/react': file:warp-drive-packages/react(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/react': file:warp-drive-packages/react(40bc2c5d5662a5666eb0d917619838cd)
       debug: 4.4.3
       dom-element-descriptors: 0.5.1
       qunit-dom: 3.6.0
     optionalDependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(626258a2b944315d0e609be46e795314)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -16925,14 +16756,14 @@ snapshots:
       - vite
       - vue-tsc
 
-  '@warp-drive/internal-config@file:tools/internal-config(vite@7.3.1)':
+  '@warp-drive/internal-config@file:tools/internal-config(vite@8.2.1)':
     dependencies:
       '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
       '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(vite@7.3.1)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(vite@8.2.1)
       '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
@@ -17035,10 +16866,10 @@ snapshots:
       - universal-cookie
       - yaml
 
-  '@warp-drive/internal-exam@file:packages/internal-exam(01438fb5fe999c266963b6564656994a)':
+  '@warp-drive/internal-exam@file:packages/internal-exam(a07f33e34e936c810c3a2a08ed5dde16)':
     dependencies:
-      ember-qunit: 9.1.0(3dff9a29fe67c87ca679d2dadb026fc7)
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-qunit: 9.1.0(ce2d83ff26ef0a53f073c9c9088e5c9f)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
       fs-extra: 11.3.3
       qunit: 2.26.0
       testem: 3.20.1(@babel/core@7.29.7)
@@ -17966,11 +17797,9 @@ snapshots:
 
   bun-types@1.3.14:
     dependencies:
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
 
   bytes@3.1.2: {}
-
-  cac@6.7.14: {}
 
   cac@7.0.0: {}
 
@@ -18042,13 +17871,7 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.1
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -18077,11 +17900,11 @@ snapshots:
 
   chardet@0.7.0: {}
 
+  chardet@2.2.0: {}
+
   charm@1.0.2:
     dependencies:
       inherits: 2.0.4
-
-  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -18117,10 +17940,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  cli-cursor@3.1.0:
-    dependencies:
-      restore-cursor: 3.1.0
-
   cli-highlight@2.1.11:
     dependencies:
       chalk: 4.1.2
@@ -18129,8 +17948,6 @@ snapshots:
       parse5: 5.1.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       yargs: 16.2.0
-
-  cli-width@3.0.0: {}
 
   cli-width@4.1.0: {}
 
@@ -18395,8 +18212,6 @@ snapshots:
 
   dedent-js@1.0.1: {}
 
-  deep-eql@5.0.2: {}
-
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -18490,7 +18305,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(29e34a527242ddfe346e9f269dcccb98):
+  ember-cached-decorator-polyfill@1.0.2(5f449f6cf81f8a9eee2138210a1258e0):
     dependencies:
       '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
       '@glimmer/tracking': 1.1.2
@@ -18498,7 +18313,7 @@ snapshots:
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.29.7)
       ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -18649,7 +18464,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-data@file:packages/-ember-data(1d338695d99eae50046a37fa15dadf01):
+  ember-data@file:packages/-ember-data(af46dc02664d662116157571e70adacf):
     dependencies:
       '@ember-data/adapter': file:packages/adapter(40bc2c5d5662a5666eb0d917619838cd)
       '@ember-data/debug': file:packages/debug(40bc2c5d5662a5666eb0d917619838cd)
@@ -18672,7 +18487,7 @@ snapshots:
       '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
       '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
     optionalDependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       qunit: 2.26.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -18761,27 +18576,27 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-page-title@9.0.3(f607f93339c6e406b031c8f1798ad8d2):
+  ember-page-title@9.0.3(b7878531927745129b4f7f52f1c24ed8):
     dependencies:
       '@embroider/addon-shim': 1.10.3
       '@glimmer/component': 2.1.1
       '@simple-dom/document': 1.4.0
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-provide-consume-context@0.8.0(44dc2e23d3b502fe1b7cb6f8457bf31b):
+  ember-provide-consume-context@0.8.0(5e5deff66abd2d48ecaa53fbd2988501):
     dependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@embroider/addon-shim': 1.10.3
       '@glimmer/component': 2.1.1
-      ember-source: 6.12.0(@glimmer/component@2.1.1)
+      ember-source: 7.2.0(@glimmer/component@2.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  ember-qunit@9.1.0(3dff9a29fe67c87ca679d2dadb026fc7):
+  ember-qunit@9.1.0(ce2d83ff26ef0a53f073c9c9088e5c9f):
     dependencies:
-      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(29e34a527242ddfe346e9f269dcccb98)
+      '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       '@embroider/addon-shim': 1.10.3
       qunit: 2.26.0
       qunit-theme-ember: 1.0.0
@@ -18825,65 +18640,51 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  ember-source@6.12.0:
+  ember-source@7.2.0:
     dependencies:
       '@babel/core': 7.29.7
-      '@ember/edition-utils': 1.2.0
-      '@embroider/addon-shim': 1.10.2
+      '@embroider/addon-shim': 1.10.3
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-get-component-path-option: 1.0.0
-      ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
       ember-router-generator: 2.0.0
       inflection: 2.0.1
       route-recognizer: 0.3.4
-      router_js: 8.0.6(route-recognizer@0.3.4)
-      semver: 7.7.3
+      semver: 7.8.5
       silent-error: 1.1.1
       simple-html-tokenizer: 0.5.11
     transitivePeerDependencies:
-      - rsvp
       - supports-color
 
-  ember-source@6.12.0(@glimmer/component@2.1.1):
+  ember-source@7.2.0(@glimmer/component@2.1.1):
     dependencies:
       '@babel/core': 7.29.7
-      '@ember/edition-utils': 1.2.0
-      '@embroider/addon-shim': 1.10.2
+      '@embroider/addon-shim': 1.10.3
       '@glimmer/component': 2.1.1
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-get-component-path-option: 1.0.0
-      ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
       ember-router-generator: 2.0.0
       inflection: 2.0.1
       route-recognizer: 0.3.4
-      router_js: 8.0.6(route-recognizer@0.3.4)
-      semver: 7.7.3
+      semver: 7.8.5
       silent-error: 1.1.1
       simple-html-tokenizer: 0.5.11
     transitivePeerDependencies:
-      - rsvp
       - supports-color
 
   ember-strict-application-resolver@0.1.1(@babel/core@7.29.7):
@@ -18926,7 +18727,7 @@ snapshots:
   engine.io@6.6.4:
     dependencies:
       '@types/cors': 2.8.18
-      '@types/node': 24.3.0
+      '@types/node': 26.2.0
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -19023,7 +18824,7 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -19041,35 +18842,6 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
-
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
 
   escalade@3.2.0: {}
 
@@ -19391,7 +19163,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.0.6: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.19.1:
     dependencies:
@@ -19401,19 +19183,11 @@ snapshots:
     dependencies:
       format: 0.2.2
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
 
   fecha@4.2.3: {}
-
-  figures@3.2.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
 
   figures@6.1.0:
     dependencies:
@@ -19976,21 +19750,15 @@ snapshots:
       run-async: 3.0.0
       rxjs: 7.8.2
 
-  inquirer@7.3.3:
+  inquirer@13.4.3:
     dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-width: 3.0.0
-      external-editor: 3.1.0
-      figures: 3.2.0
-      lodash: 4.18.1
-      mute-stream: 0.0.8
-      run-async: 2.4.1
-      rxjs: 6.6.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      through: 2.3.8
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1
+      '@inquirer/prompts': 8.6.0
+      '@inquirer/type': 4.0.7
+      mute-stream: 3.0.0
+      run-async: 4.0.6
+      rxjs: 7.8.2
 
   internal-slot@1.1.0:
     dependencies:
@@ -20212,8 +19980,6 @@ snapshots:
   js-string-escape@1.0.1: {}
 
   js-tokens@4.0.0: {}
-
-  js-tokens@9.0.1: {}
 
   js-yaml@3.14.1:
     dependencies:
@@ -20450,8 +20216,6 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
-  loupe@3.2.1: {}
-
   lru-cache@10.4.3: {}
 
   lru-cache@11.1.0: {}
@@ -20467,6 +20231,10 @@ snapshots:
   lunr@2.3.9: {}
 
   magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magic-string@1.2.1:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -20916,9 +20684,9 @@ snapshots:
 
   mustache@4.2.0: {}
 
-  mute-stream@0.0.8: {}
-
   mute-stream@1.0.0: {}
+
+  mute-stream@3.0.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -21171,15 +20939,11 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pathval@2.0.1: {}
-
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.5: {}
 
@@ -21200,12 +20964,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.5.26:
-    dependencies:
-      nanoid: 3.3.18
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.18
       picocolors: 1.1.1
@@ -21494,7 +21252,7 @@ snapshots:
   remove-types@1.0.0:
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       prettier: 3.8.1
     transitivePeerDependencies:
@@ -21543,11 +21301,6 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
 
   retry@0.12.0: {}
 
@@ -21681,11 +21434,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  router_js@8.0.6(route-recognizer@0.3.4):
-    dependencies:
-      '@glimmer/env': 0.1.7
-      route-recognizer: 0.3.4
-
   rrweb-cssom@0.7.1: {}
 
   rrweb-cssom@0.8.0: {}
@@ -21696,17 +21444,13 @@ snapshots:
 
   rsvp@4.8.5: {}
 
-  run-async@2.4.1: {}
-
   run-async@3.0.0: {}
+
+  run-async@4.0.6: {}
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  rxjs@6.6.7:
-    dependencies:
-      tslib: 1.14.1
 
   rxjs@7.8.2:
     dependencies:
@@ -21769,8 +21513,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
-
-  semver@7.7.3: {}
 
   semver@7.8.5: {}
 
@@ -22059,7 +21801,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.9.0: {}
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -22158,10 +21900,6 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
-
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
 
   styled_string@0.0.1: {}
 
@@ -22452,8 +22190,6 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  through@2.3.8: {}
-
   tiny-glob@0.2.9:
     dependencies:
       globalyzer: 0.1.0
@@ -22463,25 +22199,14 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.3.0: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.1: {}
 
   tldts-core@6.1.86: {}
 
@@ -22631,8 +22356,6 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tslib@1.14.1: {}
-
   tslib@2.8.1: {}
 
   turbo@2.9.14:
@@ -22768,9 +22491,7 @@ snapshots:
 
   underscore@1.13.7: {}
 
-  undici-types@6.21.0: {}
-
-  undici-types@7.10.0: {}
+  undici-types@8.3.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -22947,27 +22668,6 @@ snapshots:
 
   vite-bundle-analyzer@1.3.9: {}
 
-  vite-node@3.2.4:
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-plugin-compression2@2.5.3:
     dependencies:
       '@rollup/pluginutils': 5.1.4
@@ -22996,17 +22696,6 @@ snapshots:
       - '@types/babel__core'
       - supports-color
 
-  vite@7.3.1:
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.62.4
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      fsevents: 2.3.3
-
   vite@8.2.1:
     dependencies:
       lightningcss: 1.33.0
@@ -23028,9 +22717,9 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.43.1
 
-  vitefu@1.1.1(vite@7.3.1):
+  vitefu@1.1.3(vite@8.2.1):
     optionalDependencies:
-      vite: 7.3.1
+      vite: 8.2.1
 
   vitepress-plugin-group-icons@1.7.6(vite@8.2.1):
     dependencies:
@@ -23111,41 +22800,38 @@ snapshots:
       - universal-cookie
       - yaml
 
-  vitest@3.2.7:
+  vitest@4.1.11:
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.3.1)
-      '@vitest/pretty-format': 3.2.7
-      '@vitest/runner': 3.2.7
-      '@vitest/snapshot': 3.2.7
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.1)
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
       expect-type: 1.4.0
       magic-string: 0.30.21
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
-      std-env: 3.9.0
+      std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1
-      vite-node: 3.2.4
+      tinyrainbow: 3.1.1
+      vite: 8.2.1
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - msw
       - sass
       - sass-embedded
       - stylus
       - sugarss
-      - supports-color
       - terser
       - tsx
       - yaml

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,3 +128,13 @@ packages:
   - "!docs-viewer/projects/*"
   - "tests/*"
   - "specs"
+
+## Single source of truth for devDependency versions that are duplicated
+## across many workspace packages. Package.json entries reference these via
+## "catalog:" instead of a hardcoded version so there's only one place to
+## bump, and pnpm resolves every consumer to the exact same version instead
+## of letting per-package ranges drift apart.
+catalog:
+  ember-source: ~7.2.0
+  vite: ^8.2.1
+  "@types/node": ^26.2.0

--- a/tests/codemods/package.json
+++ b/tests/codemods/package.json
@@ -42,7 +42,7 @@
     "@warp-drive/internal-config": "workspace:*",
     "eslint": "^9.34.0",
     "qunit": "^2.26.0",
-    "vitest": "^3.2.7"
+    "vitest": "^4.1.11"
   },
   "volta": {
     "extends": "../../package.json"

--- a/tests/core/package.json
+++ b/tests/core/package.json
@@ -50,12 +50,12 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "eslint-plugin-warp-drive": "workspace:*",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/dont-write-new-tests-here/package.json
+++ b/tests/dont-write-new-tests-here/package.json
@@ -44,7 +44,7 @@
     "@ember-data/store": "workspace:*",
     "@ember-data/unpublished-test-infra": "workspace:*",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/optional-features": "^2.3.0",
+    "@ember/optional-features": "^3.0.0",
     "@ember/string": "^4.0.1",
     "@ember/test-helpers": "5.2.0",
     "@ember/test-waiters": "^4.1.2",
@@ -78,7 +78,7 @@
     "ember-maybe-import-regenerator": "^1.0.0",
     "ember-qunit": "9.1.0",
     "ember-route-template": "^1.0.3",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-source-channel-url": "^3.0.0",
     "ember-strict-application-resolver": "^0.1.1",
     "ember-template-imports": "4.4.0",
@@ -87,7 +87,7 @@
     "qunit-dom": "^3.6.0",
     "testem": "^3.20.1",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__adapter/package.json
+++ b/tests/ember-data__adapter/package.json
@@ -56,11 +56,11 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__graph/package.json
+++ b/tests/ember-data__graph/package.json
@@ -46,11 +46,11 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__model/package.json
+++ b/tests/ember-data__model/package.json
@@ -52,11 +52,11 @@
     "@warp-drive/internal-config": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/ember-data__request/package.json
+++ b/tests/ember-data__request/package.json
@@ -47,11 +47,11 @@
     "@warp-drive/internal-config": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/example-app-ember/package.json
+++ b/tests/example-app-ember/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-transform-typescript": "^7.29.7",
     "@babel/runtime": "^7.29.7",
     "@ember/edition-utils": "^1.2.0",
-    "@ember/optional-features": "^2.3.0",
+    "@ember/optional-features": "^3.0.0",
     "@ember/test-helpers": "5.2.0",
     "@ember/test-waiters": "^4.1.2",
     "@embroider/core": "^4.6.3",
@@ -61,7 +61,7 @@
     "decorator-transforms": "^2.4.0",
     "ember-page-title": "^9.0.3",
     "ember-qunit": "^9.1.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "express": "^5.2.1",
     "morgan": "^1.11.0",
@@ -70,7 +70,7 @@
     "qunit-dom": "^3.6.0",
     "testem": "^3.20.1",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/experiments/package.json
+++ b/tests/experiments/package.json
@@ -60,11 +60,11 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.43.1",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/framework-ember/package.json
+++ b/tests/framework-ember/package.json
@@ -49,11 +49,11 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.43.1",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/framework-react/package.json
+++ b/tests/framework-react/package.json
@@ -46,7 +46,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/tests/framework-svelte/package.json
+++ b/tests/framework-svelte/package.json
@@ -42,7 +42,7 @@
     "decorator-transforms": "^2.4.0",
     "svelte": "^5.56.9",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"

--- a/tests/framework-vue/package.json
+++ b/tests/framework-vue/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-debug-macros": "^2.0.0",
     "decorator-transforms": "^2.4.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1",
+    "vite": "catalog:",
     "vue": "^3.5.41",
     "vue-tsc": "^3.3.10"
   },

--- a/tests/json-api/package.json
+++ b/tests/json-api/package.json
@@ -48,11 +48,11 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/legacy/package.json
+++ b/tests/legacy/package.json
@@ -50,12 +50,12 @@
     "@warp-drive/utilities": "workspace:*",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "eslint-plugin-warp-drive": "workspace:*",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/tests/performance/package.json
+++ b/tests/performance/package.json
@@ -41,10 +41,10 @@
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "bun-types": "^1.4.0",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.43.1",
-    "vite": "^8.2.1",
+    "vite": "catalog:",
     "vite-bundle-analyzer": "^1.3.9",
     "vite-plugin-compression2": "^2.5.3"
   },

--- a/tests/utilities/package.json
+++ b/tests/utilities/package.json
@@ -56,11 +56,11 @@
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
     "ember-inflector": "^6.0.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.39.0",
     "typescript": "^5.9.3",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   },
   "ember": {
     "edition": "octane"

--- a/warp-drive-packages/build-config/package.json
+++ b/warp-drive-packages/build-config/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-transform-typescript": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@types/babel__core": "^7.20.5",
-    "@types/node": "^20.19.43",
+    "@types/node": "catalog:",
     "@types/semver": "^7.8.0",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",

--- a/warp-drive-packages/core/package.json
+++ b/warp-drive-packages/core/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"

--- a/warp-drive-packages/ember/package.json
+++ b/warp-drive-packages/ember/package.json
@@ -70,7 +70,7 @@
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "decorator-transforms": "^2.4.0",
     "ember-provide-consume-context": "^0.8.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "ember-template-imports": "^4.4.0",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"

--- a/warp-drive-packages/legacy/package.json
+++ b/warp-drive-packages/legacy/package.json
@@ -54,7 +54,7 @@
     "@warp-drive/internal-config": "workspace:*",
     "@warp-drive/utilities": "workspace:*",
     "decorator-transforms": "^2.4.0",
-    "ember-source": "~6.12.0",
+    "ember-source": "catalog:",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"

--- a/warp-drive-packages/svelte/package.json
+++ b/warp-drive-packages/svelte/package.json
@@ -47,12 +47,12 @@
   "devDependencies": {
     "@sveltejs/kit": "^2.70.3",
     "@sveltejs/package": "^2.5.8",
-    "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@warp-drive/internal-config": "workspace:*",
     "@warp-drive/core": "workspace:*",
     "svelte": "^5.56.9",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "vite": "catalog:"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
## Summary
Follow-up to the node_modules dedup audit. Fixes the remaining top-level dupes not covered by #10773 / #10800-ish prettier/zlib cleanup:

- **pnpm catalog** introduced for `ember-source`, `vite`, `@types/node` — every workspace package now references `catalog:` instead of an independent range, so there's one place to bump.
- **ember-source**: `~6.12.0` → `~7.2.0` (major bump, per explicit direction — this was already latest on the 6.x line, so there was no in-range fix available).
- **@types/node**: unified to `^26.2.0` (newest release clearing the 7-day `minimumReleaseAge` gate) via catalog + a `pnpm.overrides` entry, so transitive consumers (testem/socket.io, `@inquirer/*`, `@pnpm/*` tooling, `bun-types`) resolve to the same version too. This surfaced one real type regression — `util.styleText('grey', ...)` — fixed in `packages/-warp-drive` (only `'gray'` is a valid `InspectColor` in current `@types/node`).
- **@vue/compiler-sfc**: forced to `3.5.41` via override (the stray `3.5.19` came from `@vue/babel-plugin-resolve-type`, whose own declared range `^3.5.18` is satisfied).
- **@shikijs/langs**: forced to `4.4.3` via override, unifying typedoc's bundled `@gerrit0/mini-shiki` (previously pinned to the 3.23.0 line) with vitepress's `shiki`. Verified by running the full docs build end-to-end (`pnpm --filter docs-viewer build`) — completes clean, 0 typedoc errors.
- **rxjs**: not overridden (would have violated `inquirer@7.3.3`'s declared `^6.6.0` peer range). Instead bumped `@ember/optional-features` `^2.3.0` → `^3.0.0` in the two consuming test apps, which drops its old `inquirer@7`/`rxjs@6` chain entirely in favor of a modern, rxjs-free `inquirer@13`.
- **vite**: `warp-drive-packages/svelte` was pinned to `^7.3.1` because `@sveltejs/vite-plugin-svelte@6.2.4` doesn't support vite 8 — bumped that plugin to `^7.3.0` (supports vite 8) and moved onto the catalog. The last remaining instance came from `vitest@3.2.7` in `tests/codemods` (whose vite range tops out at `^7.0.0-0`) — bumped to `vitest@^4.1.11`, which supports vite 8 and fully dedupes it.

ember-source and vite still show up as 2 "instances" apiece in `node_modules` — that's pnpm isolating peer-dependency variations (`@ember/test-helpers`, `@rolldown/plugin-babel`, etc.), not a version mismatch, and isn't fixable by a version bump or override.

## Test plan
- [x] `pnpm install` succeeds with no unexpected peer/maturity errors
- [x] `pnpm why <pkg> -r` confirms a single resolved version for all six targets
- [x] `pnpm check:types` passes across the full workspace (turbo, all packages)
- [x] `pnpm --filter docs-viewer build` completes successfully (validates the shikijs override)
- [ ] Full CI test suite (ember-source 7.x and vitest 4.x are major bumps — relying on CI rather than local runs to confirm no runtime regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)