### PR TITLE
chore(deps): drop dead ember-cli-babel edges from ember-source and @embroider/macros

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
       "@glint/template": "1.8.0",
       "@glint/tsserver-plugin": "2.7.0",
       "ember-cli-babel": "^8.3.1",
+      "@embroider/macros>ember-cli-babel": "-",
+      "ember-source>ember-cli-babel": "-",
       "ember-cli-htmlbars": "^7.0.1",
       "ember-cli-typescript": "^5.3.0",
       "qunit": "2.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,8 @@ overrides:
   '@glint/template': 1.8.0
   '@glint/tsserver-plugin': 2.7.0
   ember-cli-babel: ^8.3.1
+  '@embroider/macros>ember-cli-babel': '-'
+  ember-source>ember-cli-babel: '-'
   ember-cli-htmlbars: ^7.0.1
   ember-cli-typescript: ^5.3.0
   qunit: 2.26.0
@@ -253,7 +255,7 @@ importers:
         version: 1.2.0
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -265,13 +267,13 @@ importers:
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -317,7 +319,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@manypkg/get-packages':
         specifier: ^3.1.0
         version: 3.1.0
@@ -369,13 +371,13 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -400,16 +402,16 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       warp-drive:
         specifier: workspace:*
         version: file:packages/-warp-drive(@babel/core@7.29.7)
@@ -483,7 +485,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -514,13 +516,13 @@ importers:
         version: 1.2.0
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -554,7 +556,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -627,7 +629,7 @@ importers:
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       ember-eslint-parser:
         specifier: ^0.14.5
         version: 0.14.5(855c0f8a9624c67993aff9e8e4964158)
@@ -658,7 +660,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -717,10 +719,10 @@ importers:
         version: file:tools/internal-config(@babel/runtime@7.29.7)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14
@@ -751,16 +753,16 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -788,16 +790,16 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -825,16 +827,16 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       warp-drive:
         specifier: workspace:*
         version: file:packages/-warp-drive(@babel/core@7.29.7)
@@ -868,7 +870,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -896,13 +898,13 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -936,13 +938,13 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -973,7 +975,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -1001,16 +1003,16 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       warp-drive:
         specifier: workspace:*
         version: file:packages/-warp-drive(@babel/core@7.29.7)
@@ -1041,7 +1043,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -1081,7 +1083,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -1120,13 +1122,13 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       semver:
         specifier: ^7.8.5
         version: 7.8.5
@@ -1181,7 +1183,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -1200,16 +1202,16 @@ importers:
         version: file:packages/diagnostic(@babel/core@7.29.7)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
+        version: file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       decorator-transforms:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
@@ -1291,7 +1293,7 @@ importers:
         version: 4.6.3(@glint/template@1.8.0)
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(d76eac855dabb3f1c4be79937dc8f0ec)
@@ -1309,7 +1311,7 @@ importers:
         version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(033f70491bbd67195f7939017eb7ebc8)
+        version: file:specs(16f6e484b66d66a958c8b10203ed6dfe)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
@@ -1321,19 +1323,19 @@ importers:
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(26310aaa3e223322510bb82c0db267c5)
+        version: file:packages/holodeck(a1118444cd056e913201e1864a1927c2)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(2ace520979813bc28a1da2ed416b8a6f)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/schema-dsl':
         specifier: workspace:*
         version: file:warp-drive-packages/schema-dsl(a5e16c41453d1d0aa85621754055aa4f)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1429,7 +1431,7 @@ importers:
         version: 4.6.3(@glint/template@1.8.0)
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(f2d9140a48123d3212894e4b67e2704b)
@@ -1462,7 +1464,7 @@ importers:
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)
+        version: file:packages/holodeck(8bc80b710913e6e758e65e61e6c7db83)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(7d28fa5cc489b7c9fe2c5ae481fc97f1)
@@ -1471,16 +1473,16 @@ importers:
         version: file:packages/internal-exam(a07f33e34e936c810c3a2a08ed5dde16)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
+        version: file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
       '@warp-drive/schema-record':
         specifier: workspace:*
         version: file:packages/schema-record(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1585,7 +1587,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -1612,10 +1614,10 @@ importers:
         version: file:tools/internal-config(811209bf6762a9674e8f151cca7c5169)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1666,7 +1668,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -1687,13 +1689,13 @@ importers:
         version: file:tools/internal-config(811209bf6762a9674e8f151cca7c5169)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -1765,7 +1767,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -1843,7 +1845,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -1924,7 +1926,7 @@ importers:
         version: 4.6.3(@glint/template@1.8.0)
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(f2d9140a48123d3212894e4b67e2704b)
@@ -1957,13 +1959,13 @@ importers:
         version: file:tools/internal-config(7d28fa5cc489b7c9fe2c5ae481fc97f1)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
+        version: file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2056,7 +2058,7 @@ importers:
         version: 4.6.3(@glint/template@1.8.0)
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(d76eac855dabb3f1c4be79937dc8f0ec)
@@ -2089,22 +2091,22 @@ importers:
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
       '@warp-drive/experiments':
         specifier: workspace:*
-        version: file:warp-drive-packages/experiments(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/experiments(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(26310aaa3e223322510bb82c0db267c5)
+        version: file:packages/holodeck(a1118444cd056e913201e1864a1927c2)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(2ace520979813bc28a1da2ed416b8a6f)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/schema-record':
         specifier: workspace:*
         version: file:packages/schema-record(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2149,7 +2151,7 @@ importers:
         version: 4.6.3(@glint/template@1.8.0)
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(d76eac855dabb3f1c4be79937dc8f0ec)
@@ -2167,7 +2169,7 @@ importers:
         version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(06a36ace3198fd3ead09eac8cef30b30)
+        version: file:specs(4e655989c8af9ea4961abd95444c92fd)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
@@ -2179,19 +2181,19 @@ importers:
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)
+        version: file:packages/holodeck(8bc80b710913e6e758e65e61e6c7db83)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(2ace520979813bc28a1da2ed416b8a6f)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
+        version: file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2230,7 +2232,7 @@ importers:
         version: 7.29.7
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -2239,7 +2241,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(2e97ca8f9593bbf07ae9f0b77cb834c4)
+        version: file:specs(68d6cc8ec332d7efeb52ea97b5bbec0b)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -2248,19 +2250,19 @@ importers:
         version: file:packages/diagnostic(a1d731b3ac87b6eb45f39e08a20591fd)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
+        version: file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(@babel/runtime@7.29.7)(vite@8.2.1)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/react':
         specifier: workspace:*
         version: file:warp-drive-packages/react(@babel/core@7.29.7)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       babel-plugin-debug-macros:
         specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.29.7)
@@ -2293,10 +2295,10 @@ importers:
         version: 7.29.7
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(bd118ae088fcc20826fce3e71f2b20cb)
+        version: file:specs(57c2a615a99eff1b5c43b9c5e23c4058)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -2305,19 +2307,19 @@ importers:
         version: file:packages/diagnostic(@babel/core@7.29.7)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
+        version: file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(@babel/runtime@7.29.7)(vite@8.2.1)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/svelte':
         specifier: workspace:*
         version: file:warp-drive-packages/svelte(@babel/core@7.29.7)(svelte@5.56.9)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       babel-plugin-debug-macros:
         specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.29.7)
@@ -2347,7 +2349,7 @@ importers:
         version: 7.29.7
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@8.2.1)(vue@3.5.41(typescript@5.9.3))
@@ -2356,7 +2358,7 @@ importers:
         version: 1.5.0(@babel/core@7.29.7)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(bd118ae088fcc20826fce3e71f2b20cb)
+        version: file:specs(57c2a615a99eff1b5c43b9c5e23c4058)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -2365,16 +2367,16 @@ importers:
         version: file:packages/diagnostic(@babel/core@7.29.7)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
+        version: file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(e8dce4ef0fa5851dc3a702940d6c0e66)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/vue':
         specifier: workspace:*
         version: file:warp-drive-packages/vue(71399089a5b134f41cc0f997be4221cf)
@@ -2425,7 +2427,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -2446,19 +2448,19 @@ importers:
         version: file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(9e42da9e01238c6255d70a6aa7ac3829)
+        version: file:packages/holodeck(2eeb0baf24a3535528995f8bc8048cb9)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(811209bf6762a9674e8f151cca7c5169)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2506,7 +2508,7 @@ importers:
         version: 4.6.3(@glint/template@1.8.0)
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(d76eac855dabb3f1c4be79937dc8f0ec)
@@ -2524,7 +2526,7 @@ importers:
         version: 2.7.0(cc8cad6b2644672ec8a53791bfc61df2)
       '@warp-drive-internal/specs':
         specifier: workspace:*
-        version: file:specs(06a36ace3198fd3ead09eac8cef30b30)
+        version: file:specs(4e655989c8af9ea4961abd95444c92fd)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
@@ -2536,19 +2538,19 @@ importers:
         version: file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
       '@warp-drive/holodeck':
         specifier: workspace:*
-        version: file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)
+        version: file:packages/holodeck(8bc80b710913e6e758e65e61e6c7db83)
       '@warp-drive/internal-config':
         specifier: workspace:*
         version: file:tools/internal-config(2ace520979813bc28a1da2ed416b8a6f)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
+        version: file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+        version: file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2599,7 +2601,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -2617,13 +2619,13 @@ importers:
         version: file:tools/internal-config(81335d813583fd6ff6735a432deb9a38)
       '@warp-drive/json-api':
         specifier: workspace:*
-        version: file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
       '@warp-drive/legacy':
         specifier: workspace:*
-        version: file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
+        version: file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       babel-plugin-ember-template-compilation:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2710,7 +2712,7 @@ importers:
         version: 4.6.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@embroider/vite':
         specifier: ^1.7.9
         version: 1.7.9(b67b0bcab1bc56936fb1c8ecc3985dd6)
@@ -2903,7 +2905,7 @@ importers:
         version: 1.10.3
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       babel-import-util:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2946,7 +2948,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/build-config':
         specifier: workspace:*
         version: file:warp-drive-packages/build-config(@babel/core@7.29.7)
@@ -2983,7 +2985,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+        version: 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
@@ -3053,7 +3055,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -3087,7 +3089,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       fuse.js:
         specifier: 7.5.0
         version: 7.5.0
@@ -3130,7 +3132,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -3152,7 +3154,7 @@ importers:
         version: file:tools/internal-config
       '@warp-drive/utilities':
         specifier: workspace:*
-        version: file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+        version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       decorator-transforms:
         specifier: ^2.4.0
         version: 2.4.0(@babel/core@7.29.7)
@@ -3173,7 +3175,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -3284,7 +3286,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -3321,7 +3323,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -3355,7 +3357,7 @@ importers:
     dependencies:
       '@embroider/macros':
         specifier: ^1.20.6
-        version: 1.20.6(@babel/core@7.29.7)
+        version: 1.20.6
       '@warp-drive/core':
         specifier: workspace:*
         version: file:warp-drive-packages/core(@babel/core@7.29.7)
@@ -11546,18 +11548,6 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/traverse': 7.29.8
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11571,23 +11561,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      regexpu-core: 6.2.0
-      semver: 6.3.1
-
   '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.2.0
-      semver: 6.3.1
-
-  '@babel/helper-create-regexp-features-plugin@7.29.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      regexpu-core: 6.4.0
       semver: 6.3.1
 
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
@@ -11597,29 +11575,9 @@ snapshots:
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3
-      lodash.debounce: 4.0.8
-      resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      debug: 4.4.3
-      lodash.debounce: 4.0.8
-      resolve: 1.22.11
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-define-polyfill-provider@0.6.8':
-    dependencies:
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3
@@ -11662,14 +11620,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7':
-    dependencies:
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11687,27 +11637,11 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-remap-async-to-generator@7.29.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-wrap-function': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-wrap-function': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-replace-supers@7.29.7':
-    dependencies:
-      '@babel/helper-member-expression-to-functions': 7.29.7
-      '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
@@ -11751,13 +11685,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11766,17 +11693,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7)':
@@ -11784,26 +11703,11 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-transform-optional-chaining': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -11816,26 +11720,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-proposal-decorators@7.29.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-decorators': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -11848,8 +11737,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2': {}
-
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11857,10 +11744,6 @@ snapshots:
   '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-decorators@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
@@ -11873,17 +11756,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-assertions@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-import-attributes@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
@@ -11901,18 +11776,9 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-typescript@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.27.1
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
@@ -11921,22 +11787,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-async-generator-functions@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -11944,14 +11798,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-to-generator@7.29.7':
-    dependencies:
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-remap-async-to-generator': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -11964,30 +11810,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoped-functions@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-block-scoping@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-class-properties@7.29.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -11997,29 +11828,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.29.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-classes@7.29.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-globals': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7
-      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -12035,23 +11848,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/template': 7.29.7
-
   '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
-
-  '@babel/plugin-transform-destructuring@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12061,29 +11862,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-dotall-regex@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-duplicate-keys@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
@@ -12092,21 +11879,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-dynamic-import@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-explicit-resource-management@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12116,17 +11892,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-exponentiation-operator@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-export-namespace-from@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
@@ -12140,26 +11908,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.29.7)
 
-  '@babel/plugin-transform-for-of@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-function-name@7.29.7':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -12172,17 +11925,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-json-strings@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-literals@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
@@ -12190,30 +11935,15 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-member-expression-literals@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-modules-amd@7.29.7':
-    dependencies:
-      '@babel/helper-module-transforms': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12223,27 +11953,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.29.7':
-    dependencies:
-      '@babel/helper-module-transforms': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-systemjs@7.29.8':
-    dependencies:
-      '@babel/helper-module-transforms': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -12257,13 +11971,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-umd@7.29.7':
-    dependencies:
-      '@babel/helper-module-transforms': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -12272,19 +11979,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-new-target@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7)':
@@ -12292,33 +11990,15 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-numeric-separator@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-object-rest-spread@7.29.7':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7
-      '@babel/plugin-transform-parameters': 7.29.7
-      '@babel/traverse': 7.29.8
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12331,13 +12011,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -12346,21 +12019,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-optional-chaining@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12370,34 +12032,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-private-methods@7.29.7':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.29.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -12410,10 +12053,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-property-literals@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12449,18 +12088,9 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.8':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-regenerator@7.29.8(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-regexp-modifiers@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7)':
@@ -12469,25 +12099,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-reserved-words@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-runtime@7.29.7':
-    dependencies:
-      '@babel/helper-module-imports': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.14
-      babel-plugin-polyfill-corejs3: 0.13.0
-      babel-plugin-polyfill-regenerator: 0.6.5
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12501,21 +12116,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-spread@7.29.8':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-spread@7.29.8(@babel/core@7.29.7)':
     dependencies:
@@ -12525,17 +12129,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-template-literals@7.29.7':
-    dependencies:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
@@ -12543,24 +12139,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typeof-symbol@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-typescript@7.29.7':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-create-class-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-      '@babel/plugin-syntax-typescript': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12573,18 +12155,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.29.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-unicode-property-regex@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7)':
@@ -12593,20 +12166,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-unicode-regex@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-unicode-sets-regex@7.29.7':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7)':
@@ -12614,82 +12177,6 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/preset-env@7.29.7':
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.29.7
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7
-      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2
-      '@babel/plugin-syntax-import-assertions': 7.29.7
-      '@babel/plugin-syntax-import-attributes': 7.29.7
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6
-      '@babel/plugin-transform-arrow-functions': 7.29.7
-      '@babel/plugin-transform-async-generator-functions': 7.29.7
-      '@babel/plugin-transform-async-to-generator': 7.29.7
-      '@babel/plugin-transform-block-scoped-functions': 7.29.7
-      '@babel/plugin-transform-block-scoping': 7.29.7
-      '@babel/plugin-transform-class-properties': 7.29.7
-      '@babel/plugin-transform-class-static-block': 7.29.7
-      '@babel/plugin-transform-classes': 7.29.7
-      '@babel/plugin-transform-computed-properties': 7.29.7
-      '@babel/plugin-transform-destructuring': 7.29.7
-      '@babel/plugin-transform-dotall-regex': 7.29.7
-      '@babel/plugin-transform-duplicate-keys': 7.29.7
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7
-      '@babel/plugin-transform-dynamic-import': 7.29.7
-      '@babel/plugin-transform-explicit-resource-management': 7.29.7
-      '@babel/plugin-transform-exponentiation-operator': 7.29.7
-      '@babel/plugin-transform-export-namespace-from': 7.29.7
-      '@babel/plugin-transform-for-of': 7.29.7
-      '@babel/plugin-transform-function-name': 7.29.7
-      '@babel/plugin-transform-json-strings': 7.29.7
-      '@babel/plugin-transform-literals': 7.29.7
-      '@babel/plugin-transform-logical-assignment-operators': 7.29.7
-      '@babel/plugin-transform-member-expression-literals': 7.29.7
-      '@babel/plugin-transform-modules-amd': 7.29.7
-      '@babel/plugin-transform-modules-commonjs': 7.29.7
-      '@babel/plugin-transform-modules-systemjs': 7.29.8
-      '@babel/plugin-transform-modules-umd': 7.29.7
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7
-      '@babel/plugin-transform-new-target': 7.29.7
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7
-      '@babel/plugin-transform-numeric-separator': 7.29.7
-      '@babel/plugin-transform-object-rest-spread': 7.29.7
-      '@babel/plugin-transform-object-super': 7.29.7
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7
-      '@babel/plugin-transform-optional-chaining': 7.29.7
-      '@babel/plugin-transform-parameters': 7.29.7
-      '@babel/plugin-transform-private-methods': 7.29.7
-      '@babel/plugin-transform-private-property-in-object': 7.29.7
-      '@babel/plugin-transform-property-literals': 7.29.7
-      '@babel/plugin-transform-regenerator': 7.29.8
-      '@babel/plugin-transform-regexp-modifiers': 7.29.7
-      '@babel/plugin-transform-reserved-words': 7.29.7
-      '@babel/plugin-transform-shorthand-properties': 7.29.7
-      '@babel/plugin-transform-spread': 7.29.8
-      '@babel/plugin-transform-sticky-regex': 7.29.7
-      '@babel/plugin-transform-template-literals': 7.29.7
-      '@babel/plugin-transform-typeof-symbol': 7.29.7
-      '@babel/plugin-transform-unicode-escapes': 7.29.7
-      '@babel/plugin-transform-unicode-property-regex': 7.29.7
-      '@babel/plugin-transform-unicode-regex': 7.29.7
-      '@babel/plugin-transform-unicode-sets-regex': 7.29.7
-      '@babel/preset-modules': 0.1.6-no-external-plugins
-      babel-plugin-polyfill-corejs2: 0.4.17
-      babel-plugin-polyfill-corejs3: 0.14.2
-      babel-plugin-polyfill-regenerator: 0.6.8
-      core-js-compat: 3.50.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-env@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -12774,12 +12261,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.7)
-
-  '@babel/preset-modules@0.1.6-no-external-plugins':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/types': 7.29.8
-      esutils: 2.0.3
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
@@ -12891,9 +12372,9 @@ snapshots:
 
   '@ember-data/active-record@file:packages/active-record(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -12901,10 +12382,10 @@ snapshots:
 
   '@ember-data/adapter@file:packages/adapter(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       warp-drive: file:packages/-warp-drive(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -12913,10 +12394,10 @@ snapshots:
 
   '@ember-data/adapter@file:packages/adapter(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       warp-drive: file:packages/-warp-drive(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -12940,9 +12421,9 @@ snapshots:
   '@ember-data/debug@file:packages/debug(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -12951,9 +12432,9 @@ snapshots:
   '@ember-data/debug@file:packages/debug(@babel/core@7.29.7)':
     dependencies:
       '@ember/edition-utils': 1.2.0
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -12961,7 +12442,7 @@ snapshots:
 
   '@ember-data/graph@file:packages/graph(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -12970,7 +12451,7 @@ snapshots:
 
   '@ember-data/graph@file:packages/graph(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -12979,10 +12460,10 @@ snapshots:
 
   '@ember-data/json-api@file:packages/json-api(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -12990,10 +12471,10 @@ snapshots:
 
   '@ember-data/json-api@file:packages/json-api(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13001,10 +12482,10 @@ snapshots:
 
   '@ember-data/legacy-compat@file:packages/legacy-compat(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13012,10 +12493,10 @@ snapshots:
 
   '@ember-data/legacy-compat@file:packages/legacy-compat(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13023,10 +12504,10 @@ snapshots:
 
   '@ember-data/model@file:packages/model(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       warp-drive: file:packages/-warp-drive(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13035,10 +12516,10 @@ snapshots:
 
   '@ember-data/model@file:packages/model(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       warp-drive: file:packages/-warp-drive(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13047,9 +12528,9 @@ snapshots:
 
   '@ember-data/request-utils@file:packages/request-utils(3a23d15216661fdc31ba79ef395bed77)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     optionalDependencies:
       ember-inflector: 6.0.0(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -13059,9 +12540,9 @@ snapshots:
 
   '@ember-data/request-utils@file:packages/request-utils(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13069,9 +12550,9 @@ snapshots:
 
   '@ember-data/request-utils@file:packages/request-utils(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13079,9 +12560,9 @@ snapshots:
 
   '@ember-data/request-utils@file:packages/request-utils(f595c3000cd807fefd516d2057e1f374)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     optionalDependencies:
       ember-inflector: 6.0.0(@babel/core@7.29.7)
     transitivePeerDependencies:
@@ -13091,7 +12572,7 @@ snapshots:
 
   '@ember-data/request@file:packages/request(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13100,7 +12581,7 @@ snapshots:
 
   '@ember-data/request@file:packages/request(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13109,9 +12590,9 @@ snapshots:
 
   '@ember-data/rest@file:packages/rest(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -13121,10 +12602,10 @@ snapshots:
 
   '@ember-data/serializer@file:packages/serializer(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       warp-drive: file:packages/-warp-drive(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13133,10 +12614,10 @@ snapshots:
 
   '@ember-data/serializer@file:packages/serializer(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       warp-drive: file:packages/-warp-drive(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13145,7 +12626,7 @@ snapshots:
 
   '@ember-data/store@file:packages/store(2fac7a87d207b317b942783043977b8e)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     optionalDependencies:
       '@ember/test-waiters': 4.1.2
@@ -13156,7 +12637,7 @@ snapshots:
 
   '@ember-data/store@file:packages/store(42e7c21b33582bbcca55b50012dc7e09)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     optionalDependencies:
       '@ember-data/tracking': file:packages/tracking(55de178235eb5990a078df764e61b44e)
@@ -13168,7 +12649,7 @@ snapshots:
 
   '@ember-data/store@file:packages/store(55de178235eb5990a078df764e61b44e)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     optionalDependencies:
       '@ember/test-waiters': 4.1.2
@@ -13179,7 +12660,7 @@ snapshots:
 
   '@ember-data/store@file:packages/store(e0d76382b2473f4af10a55c904505031)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     optionalDependencies:
       '@ember-data/tracking': file:packages/tracking(2fac7a87d207b317b942783043977b8e)
@@ -13192,7 +12673,7 @@ snapshots:
   '@ember-data/tracking@file:packages/tracking(2fac7a87d207b317b942783043977b8e)':
     dependencies:
       '@ember/test-waiters': 4.1.2
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13202,7 +12683,7 @@ snapshots:
   '@ember-data/tracking@file:packages/tracking(55de178235eb5990a078df764e61b44e)':
     dependencies:
       '@ember/test-waiters': 4.1.2
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -13212,9 +12693,9 @@ snapshots:
   '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(5bcd8248f4ce41e0e79b43bfa10341ea)':
     dependencies:
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(6d2b9c79c4be156244901d621fdf120b)
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       semver: 7.8.5
     optionalDependencies:
       '@warp-drive/diagnostic': file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)
@@ -13226,9 +12707,9 @@ snapshots:
   '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(66ed04ab38cb0b5cd9e920ee3a8b4b64)':
     dependencies:
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       semver: 7.8.5
     optionalDependencies:
       qunit: 2.26.0
@@ -13241,9 +12722,9 @@ snapshots:
   '@ember-data/unpublished-test-infra@file:packages/unpublished-test-infra(8f001fdc1d041c9e126963fd707428ad)':
     dependencies:
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       semver: 7.8.5
     optionalDependencies:
       '@warp-drive/diagnostic': file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
@@ -13270,7 +12751,7 @@ snapshots:
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
@@ -13284,7 +12765,7 @@ snapshots:
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
@@ -13298,7 +12779,7 @@ snapshots:
     dependencies:
       '@ember/test-waiters': 4.1.2
       '@embroider/addon-shim': 1.10.0
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@simple-dom/interface': 1.4.0
       decorator-transforms: 2.3.0(@babel/core@7.29.7)
       dom-element-descriptors: 0.5.1
@@ -13367,7 +12848,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@embroider/reverse-exports': 0.2.0
       '@embroider/shared-internals': 3.1.1
       assert-never: 1.4.0
@@ -13403,7 +12884,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@embroider/reverse-exports': 0.2.0
       '@embroider/shared-internals': 3.1.1
       assert-never: 1.4.0
@@ -13439,21 +12920,18 @@ snapshots:
       '@embroider/shared-internals': 3.1.1
       assert-never: 1.4.0
       babel-import-util: 3.0.1
-      ember-cli-babel: 8.3.1
       find-up: 5.0.0
       lodash: 4.18.1
       resolve: 1.22.10
       semver: 7.7.2
     transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
-  '@embroider/macros@1.20.6(40bc2c5d5662a5666eb0d917619838cd)':
+  '@embroider/macros@1.20.6(@glint/template@1.8.0)':
     dependencies:
       '@embroider/shared-internals': 3.1.1
       assert-never: 1.4.0
       babel-import-util: 3.0.1
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       find-up: 5.0.0
       lodash: 4.18.1
       resolve: 1.22.10
@@ -13461,21 +12939,6 @@ snapshots:
     optionalDependencies:
       '@glint/template': 1.8.0
     transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  '@embroider/macros@1.20.6(@babel/core@7.29.7)':
-    dependencies:
-      '@embroider/shared-internals': 3.1.1
-      assert-never: 1.4.0
-      babel-import-util: 3.0.1
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
-      find-up: 5.0.0
-      lodash: 4.18.1
-      resolve: 1.22.10
-      semver: 7.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   '@embroider/reverse-exports@0.2.0':
@@ -13505,7 +12968,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/core': 4.6.3
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@embroider/reverse-exports': 0.2.0
       assert-never: 1.4.0
       browserslist: 4.28.8
@@ -13531,7 +12994,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/core': 4.6.3(@glint/template@1.8.0)
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@embroider/reverse-exports': 0.2.0
       assert-never: 1.4.0
       browserslist: 4.28.8
@@ -13557,7 +13020,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@embroider/core': 4.6.3(@glint/template@1.8.0)
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@embroider/reverse-exports': 0.2.0
       assert-never: 1.4.0
       browserslist: 4.28.8
@@ -15550,55 +15013,51 @@ snapshots:
     dependencies:
       vue: 3.5.41(typescript@5.9.3)
 
-  '@warp-drive-internal/specs@file:specs(033f70491bbd67195f7939017eb7ebc8)':
+  '@warp-drive-internal/specs@file:specs(16f6e484b66d66a958c8b10203ed6dfe)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/diagnostic': file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
-      '@warp-drive/holodeck': file:packages/holodeck(26310aaa3e223322510bb82c0db267c5)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/holodeck': file:packages/holodeck(a1118444cd056e913201e1864a1927c2)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive-internal/specs@file:specs(06a36ace3198fd3ead09eac8cef30b30)':
+  '@warp-drive-internal/specs@file:specs(4e655989c8af9ea4961abd95444c92fd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/diagnostic': file:packages/diagnostic(e49db713e81539b1909af76f9327417c)
-      '@warp-drive/holodeck': file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/holodeck': file:packages/holodeck(8bc80b710913e6e758e65e61e6c7db83)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive-internal/specs@file:specs(2e97ca8f9593bbf07ae9f0b77cb834c4)':
+  '@warp-drive-internal/specs@file:specs(57c2a615a99eff1b5c43b9c5e23c4058)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
-      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/diagnostic': file:packages/diagnostic(a1d731b3ac87b6eb45f39e08a20591fd)
-      '@warp-drive/holodeck': file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - supports-color
-
-  '@warp-drive-internal/specs@file:specs(bd118ae088fcc20826fce3e71f2b20cb)':
-    dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/diagnostic': file:packages/diagnostic(@babel/core@7.29.7)
-      '@warp-drive/holodeck': file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/holodeck': file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
-      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@warp-drive-internal/specs@file:specs(68d6cc8ec332d7efeb52ea97b5bbec0b)':
+    dependencies:
+      '@embroider/macros': 1.20.6
+      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
+      '@warp-drive/diagnostic': file:packages/diagnostic(a1d731b3ac87b6eb45f39e08a20591fd)
+      '@warp-drive/holodeck': file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
+    transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
@@ -15617,7 +15076,7 @@ snapshots:
   '@warp-drive/build-config@file:warp-drive-packages/build-config(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
       '@embroider/addon-shim': 1.10.3
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       babel-import-util: 2.1.1
       babel-plugin-debug-macros: 2.0.0(@babel/core@7.29.7)
       semver: 7.8.5
@@ -15629,7 +15088,7 @@ snapshots:
   '@warp-drive/build-config@file:warp-drive-packages/build-config(@babel/core@7.29.7)':
     dependencies:
       '@embroider/addon-shim': 1.10.3
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       babel-import-util: 2.1.1
       babel-plugin-debug-macros: 2.0.0(@babel/core@7.29.7)
       semver: 7.8.5
@@ -15640,7 +15099,7 @@ snapshots:
 
   '@warp-drive/core-types@file:packages/core-types(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15649,7 +15108,7 @@ snapshots:
 
   '@warp-drive/core-types@file:packages/core-types(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15667,7 +15126,7 @@ snapshots:
 
   '@warp-drive/core@file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/build-config': file:warp-drive-packages/build-config(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15676,7 +15135,7 @@ snapshots:
 
   '@warp-drive/core@file:warp-drive-packages/core(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/build-config': file:warp-drive-packages/build-config(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15685,7 +15144,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(4495b539945ad74290cbeb6aa151c8a9)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/react': file:warp-drive-packages/react(@babel/core@7.29.7)
       debug: 4.4.3
@@ -15700,7 +15159,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/react': file:warp-drive-packages/react(@babel/core@7.29.7)
       debug: 4.4.3
@@ -15713,7 +15172,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(a1d731b3ac87b6eb45f39e08a20591fd)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/react': file:warp-drive-packages/react(@babel/core@7.29.7)
       debug: 4.4.3
@@ -15729,7 +15188,7 @@ snapshots:
 
   '@warp-drive/diagnostic@file:packages/diagnostic(e49db713e81539b1909af76f9327417c)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/react': file:warp-drive-packages/react(40bc2c5d5662a5666eb0d917619838cd)
       debug: 4.4.3
@@ -15745,7 +15204,7 @@ snapshots:
   '@warp-drive/ember@file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)':
     dependencies:
       '@ember/test-waiters': 4.1.2
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -15755,29 +15214,29 @@ snapshots:
   '@warp-drive/ember@file:warp-drive-packages/ember(55de178235eb5990a078df764e61b44e)':
     dependencies:
       '@ember/test-waiters': 4.1.2
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/experiments@file:warp-drive-packages/experiments(308f337ee79a3c601a0134b4ff5387a8)':
+  '@warp-drive/experiments@file:warp-drive-packages/experiments(1c531ff0d42b5d585fbdc4d6d901c6a4)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/holodeck@file:packages/holodeck(26310aaa3e223322510bb82c0db267c5)':
+  '@warp-drive/holodeck@file:packages/holodeck(2eeb0baf24a3535528995f8bc8048cb9)':
     dependencies:
       '@hono/node-server': 1.19.0(hono@4.13.3)
-      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
+      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       hono: 4.13.3
     optionalDependencies:
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
 
   '@warp-drive/holodeck@file:packages/holodeck(4ded94bf05a058c4d301833388abca58)':
     dependencies:
@@ -15785,31 +15244,30 @@ snapshots:
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       hono: 4.13.3
 
-  '@warp-drive/holodeck@file:packages/holodeck(9e42da9e01238c6255d70a6aa7ac3829)':
-    dependencies:
-      '@hono/node-server': 1.19.0(hono@4.13.3)
-      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      hono: 4.13.3
-    optionalDependencies:
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
-
-  '@warp-drive/holodeck@file:packages/holodeck(faea43ed3bc42f373ef867b67f0f1952)':
-    dependencies:
-      '@hono/node-server': 1.19.0(hono@4.13.3)
-      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      hono: 4.13.3
-    optionalDependencies:
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
-
-  '@warp-drive/holodeck@file:packages/holodeck(fcbb7027ca4650034b89b08d92ded0f2)':
+  '@warp-drive/holodeck@file:packages/holodeck(8bc80b710913e6e758e65e61e6c7db83)':
     dependencies:
       '@hono/node-server': 1.19.0(hono@4.13.3)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       hono: 4.13.3
     optionalDependencies:
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
+
+  '@warp-drive/holodeck@file:packages/holodeck(a1118444cd056e913201e1864a1927c2)':
+    dependencies:
+      '@hono/node-server': 1.19.0(hono@4.13.3)
+      '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
+      hono: 4.13.3
+    optionalDependencies:
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
+
+  '@warp-drive/holodeck@file:packages/holodeck(a510bc545ed25bc6a53fefeb5da03d5b)':
+    dependencies:
+      '@hono/node-server': 1.19.0(hono@4.13.3)
+      '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
+      hono: 4.13.3
+    optionalDependencies:
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
 
   '@warp-drive/internal-config@file:tools/internal-config':
     dependencies:
@@ -16589,51 +16047,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@warp-drive/json-api@file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)':
+  '@warp-drive/json-api@file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       fuse.js: 7.5.0
       json-to-ast: 2.1.0
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/json-api@file:warp-drive-packages/json-api(da83bc0b1ea108dc5be8f251a76f6440)':
+  '@warp-drive/json-api@file:warp-drive-packages/json-api(4ded94bf05a058c4d301833388abca58)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       fuse.js: 7.5.0
       json-to-ast: 2.1.0
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/legacy@file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)':
+  '@warp-drive/legacy@file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/legacy@file:warp-drive-packages/legacy(eb285543f9d9812c91771fcfa7474918)':
+  '@warp-drive/legacy@file:warp-drive-packages/legacy(a510bc545ed25bc6a53fefeb5da03d5b)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
   '@warp-drive/react@file:warp-drive-packages/react(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/tc39-proposal-signals': file:warp-drive-packages/tc39-proposal-signals(40bc2c5d5662a5666eb0d917619838cd)
       react: 19.2.8
@@ -16645,7 +16099,7 @@ snapshots:
 
   '@warp-drive/react@file:warp-drive-packages/react(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       '@warp-drive/tc39-proposal-signals': file:warp-drive-packages/tc39-proposal-signals(@babel/core@7.29.7)
       react: 19.2.8
@@ -16665,7 +16119,7 @@ snapshots:
 
   '@warp-drive/schema-record@file:packages/schema-record(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
       - '@babel/core'
@@ -16683,7 +16137,7 @@ snapshots:
 
   '@warp-drive/tc39-proposal-signals@file:warp-drive-packages/tc39-proposal-signals(40bc2c5d5662a5666eb0d917619838cd)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       signal-polyfill: 0.2.2
     transitivePeerDependencies:
@@ -16693,7 +16147,7 @@ snapshots:
 
   '@warp-drive/tc39-proposal-signals@file:warp-drive-packages/tc39-proposal-signals(@babel/core@7.29.7)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       signal-polyfill: 0.2.2
     transitivePeerDependencies:
@@ -16701,27 +16155,25 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/utilities@file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)':
+  '@warp-drive/utilities@file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)':
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@warp-drive/utilities@file:warp-drive-packages/utilities(da83bc0b1ea108dc5be8f251a76f6440)':
+  '@warp-drive/utilities@file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
 
   '@warp-drive/vue@file:warp-drive-packages/vue(71399089a5b134f41cc0f997be4221cf)':
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       vue: 3.5.41(typescript@5.9.3)
     transitivePeerDependencies:
@@ -17010,10 +16462,6 @@ snapshots:
 
   babel-import-util@3.0.1: {}
 
-  babel-plugin-debug-macros@0.3.4:
-    dependencies:
-      semver: 5.7.2
-
   babel-plugin-debug-macros@0.3.4(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -17058,27 +16506,11 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.11
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.5
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-corejs2@0.4.17:
-    dependencies:
-      '@babel/compat-data': 7.29.7
-      '@babel/helper-define-polyfill-provider': 0.6.8
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -17092,25 +16524,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.5
-      core-js-compat: 3.45.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
       core-js-compat: 3.45.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-corejs3@0.14.2:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.8
-      core-js-compat: 3.50.0
     transitivePeerDependencies:
       - supports-color
 
@@ -17122,22 +16540,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.5:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.5
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7)
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.6.8:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.8
     transitivePeerDependencies:
       - supports-color
 
@@ -17239,19 +16645,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  broccoli-babel-transpiler@8.0.2:
-    dependencies:
-      broccoli-persistent-filter: 3.1.3
-      clone: 2.1.2
-      hash-for-dep: 1.5.1
-      heimdalljs: 0.2.6
-      heimdalljs-logger: 0.1.10
-      json-stable-stringify: 1.3.0
-      rsvp: 4.8.5
-      workerpool: 6.5.1
-    transitivePeerDependencies:
-      - supports-color
 
   broccoli-babel-transpiler@8.0.2(@babel/core@7.29.7):
     dependencies:
@@ -17929,38 +17322,6 @@ snapshots:
 
   ember-cli-babel-plugin-helpers@1.1.1: {}
 
-  ember-cli-babel@8.3.1:
-    dependencies:
-      '@babel/helper-compilation-targets': 7.29.7
-      '@babel/plugin-proposal-decorators': 7.29.7
-      '@babel/plugin-transform-class-properties': 7.29.7
-      '@babel/plugin-transform-class-static-block': 7.29.7
-      '@babel/plugin-transform-modules-amd': 7.29.7
-      '@babel/plugin-transform-private-methods': 7.29.7
-      '@babel/plugin-transform-private-property-in-object': 7.29.7
-      '@babel/plugin-transform-runtime': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7
-      '@babel/preset-env': 7.29.7
-      '@babel/runtime': 7.12.18
-      amd-name-resolver: 1.3.1
-      babel-plugin-debug-macros: 0.3.4
-      babel-plugin-ember-data-packages-polyfill: 0.1.2
-      babel-plugin-ember-modules-api-polyfill: 3.5.0
-      babel-plugin-module-resolver: 5.0.2
-      broccoli-babel-transpiler: 8.0.2
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      broccoli-source: 3.0.1
-      calculate-cache-key-for-tree: 2.0.0
-      clone: 2.1.2
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-version-checker: 5.1.2
-      ensure-posix-path: 1.1.1
-      resolve-package-path: 4.0.3
-      semver: 7.8.5
-    transitivePeerDependencies:
-      - supports-color
-
   ember-cli-babel@8.3.1(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -18043,13 +17404,13 @@ snapshots:
       '@ember-data/tracking': file:packages/tracking(2fac7a87d207b317b942783043977b8e)
       '@ember/edition-utils': 1.2.0
       '@ember/test-waiters': 4.1.2
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/core-types': file:packages/core-types(40bc2c5d5662a5666eb0d917619838cd)
       '@warp-drive/ember': file:warp-drive-packages/ember(2fac7a87d207b317b942783043977b8e)
-      '@warp-drive/json-api': file:warp-drive-packages/json-api(308f337ee79a3c601a0134b4ff5387a8)
-      '@warp-drive/legacy': file:warp-drive-packages/legacy(7814d4749341b491ab21a95ea6eadac9)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/json-api': file:warp-drive-packages/json-api(1c531ff0d42b5d585fbdc4d6d901c6a4)
+      '@warp-drive/legacy': file:warp-drive-packages/legacy(8f545e4aa3e427080f63ed8d664f6977)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
     optionalDependencies:
       '@ember/test-helpers': 5.2.0(patch_hash=a1670a4e3977c846a5c2454f317f5a17cbd284aef3a676b190c98141536afb04)(5f449f6cf81f8a9eee2138210a1258e0)
       qunit: 2.26.0
@@ -18191,7 +17552,6 @@ snapshots:
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
       chalk: 4.1.2
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
@@ -18215,7 +17575,6 @@ snapshots:
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
       chalk: 4.1.2
-      ember-cli-babel: 8.3.1(@babel/core@7.29.7)
       ember-cli-get-component-path-option: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
@@ -18463,7 +17822,7 @@ snapshots:
   eslint-plugin-warp-drive@file:packages/eslint-plugin-warp-drive(eb246e80e8bbac6d1f01f509def34a2d):
     dependencies:
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
-      '@warp-drive/utilities': file:warp-drive-packages/utilities(308f337ee79a3c601a0134b4ff5387a8)
+      '@warp-drive/utilities': file:warp-drive-packages/utilities(1c531ff0d42b5d585fbdc4d6d901c6a4)
       ember-eslint-parser: 0.14.5(typescript@5.9.3)
       requireindex: 1.2.0
     transitivePeerDependencies:
@@ -22450,7 +21809,7 @@ snapshots:
 
   warp-drive@file:packages/-warp-drive(40bc2c5d5662a5666eb0d917619838cd):
     dependencies:
-      '@embroider/macros': 1.20.6(40bc2c5d5662a5666eb0d917619838cd)
+      '@embroider/macros': 1.20.6(@glint/template@1.8.0)
       '@manypkg/get-packages': 3.1.0
       '@warp-drive/core': file:warp-drive-packages/core(40bc2c5d5662a5666eb0d917619838cd)
       comment-json: 4.6.2
@@ -22464,7 +21823,7 @@ snapshots:
 
   warp-drive@file:packages/-warp-drive(@babel/core@7.29.7):
     dependencies:
-      '@embroider/macros': 1.20.6(@babel/core@7.29.7)
+      '@embroider/macros': 1.20.6
       '@manypkg/get-packages': 3.1.0
       '@warp-drive/core': file:warp-drive-packages/core(@babel/core@7.29.7)
       comment-json: 4.6.2


### PR DESCRIPTION
## Summary
- `@embroider/macros@1.20.6` declares `ember-cli-babel` as a real dependency but never requires it anywhere in its shipped code (`src/index.js`, the entry used everywhere, and `src/ember-addon-main.js`, its classic-only entry — neither references it). Dead dependency.
- `ember-source` only reaches `ember-cli-babel` through its classic `treeForVendor` addon hook (`this.addons.find(a => a.name === 'ember-cli-babel')`), which is part of the broccoli-tree build pipeline. `@embroider/vite`'s native pipeline never runs it.
- Using pnpm's `overrides` edge-deletion syntax (`"parent>child": "-"`) to remove both edges: [package.json](package.json)
- This collapses the whole `broccoli-babel-transpiler` / `broccoli-persistent-filter` / `hash-for-dep` chain that rode in on `ember-cli-babel`.
- The one remaining `ember-cli-babel` edge, via `ember-cli-test-loader` (an explicit optional `peerDependency` of `@warp-drive/diagnostic`), is left alone — that's a deliberate compat surface, not dead weight.

## Impact
- `pnpm-lock.yaml`: 911 deletions / 272 insertions
- `node_modules`: ~633MB → ~556MB (~77MB smaller)

## Test plan
- [x] `pnpm install` — only the target edges and their now-orphaned sub-dependencies removed
- [x] `pnpm --filter main-test-app build:tests` (real `vite build` through the Embroider-native pipeline) — succeeds, confirming `treeForVendor` is never invoked
- [x] `pnpm --filter main-test-app test` — full suite: 5349 tests, 5344 passed, 5 skipped (pre-existing), **0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)