### PR TITLE
chore(deps): drop unused @babel/cli and rollup from internal-config

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2767,9 +2767,6 @@ importers:
 
   tools/internal-config:
     dependencies:
-      '@babel/cli':
-        specifier: ^7.29.7
-        version: 7.29.7(@babel/core@7.29.7)
       '@babel/core':
         specifier: ^7.29.7
         version: 7.29.7
@@ -2781,13 +2778,13 @@ importers:
         version: 9.34.0
       '@nullvoxpopuli/ember-rolldown':
         specifier: ^2.7.0
-        version: 2.7.0(35190290210cd7126c88e642f3389863)
+        version: 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.7)
       '@rollup/plugin-babel':
         specifier: ^6.1.0
-        version: 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+        version: 6.1.0(@babel/core@7.29.7)
       '@types/debug':
         specifier: 4.1.13
         version: 4.1.13
@@ -2830,9 +2827,6 @@ importers:
       globals:
         specifier: ^16.5.0
         version: 16.5.0
-      rollup:
-        specifier: ^4.62.4
-        version: 4.62.4
       tsdown:
         specifier: ^0.22.14
         version: 0.22.14(typescript@5.9.3)
@@ -3479,13 +3473,6 @@ packages:
   '@ast-grep/napi@0.45.1':
     resolution: {integrity: sha512-4cmGQEHoP9GLHEhGvd1vgSzO3Y6KF7FczDk4+q/VfXV9/9sNxNVgNHC8t3BglhIADDcoHrCMc9aw4lHG+M240A==}
     engines: {node: '>= 10'}
-
-  '@babel/cli@7.29.7':
-    resolution: {integrity: sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==}
-    engines: {node: '>=6.9.0'}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -4884,9 +4871,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
-  '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
-    resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
 
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
@@ -6574,10 +6558,6 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
@@ -6748,10 +6728,6 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
-
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
 
   binary-search@1.3.6:
     resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
@@ -6981,10 +6957,6 @@ packages:
   charm@1.0.2:
     resolution: {integrity: sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==}
 
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
-
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -7097,10 +7069,6 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  commander@6.2.1:
-    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
-    engines: {node: '>= 6'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -8094,9 +8062,6 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
-  fs-readdir-recursive@1.1.0:
-    resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
-
   fs-tree-diff@0.5.9:
     resolution: {integrity: sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==}
 
@@ -8456,10 +8421,6 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
-
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -9658,10 +9619,6 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -10048,10 +10005,6 @@ packages:
   sirv@3.0.1:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
-
-  slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -11234,20 +11187,6 @@ snapshots:
       '@ast-grep/napi-win32-arm64-msvc': 0.45.1
       '@ast-grep/napi-win32-ia32-msvc': 0.45.1
       '@ast-grep/napi-win32-x64-msvc': 0.45.1
-
-  '@babel/cli@7.29.7(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jridgewell/trace-mapping': 0.3.31
-      commander: 6.2.1
-      convert-source-map: 2.0.0
-      fs-readdir-recursive: 1.1.0
-      glob: 7.2.3
-      make-dir: 2.1.0
-      slash: 2.0.0
-    optionalDependencies:
-      '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
-      chokidar: 3.6.0
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -13359,9 +13298,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
-    optional: true
-
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
@@ -13394,32 +13330,32 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
 
-  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(@types/babel__core@7.20.5)(rollup@4.62.4)':
+  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0':
     dependencies:
       '@babel/core': 7.29.7
       '@rolldown/pluginutils': 1.0.1
-      '@rollup/plugin-babel': 7.1.0(45a47724d0c3ddc593192c302cc4ddd7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@types/babel__core'
       - rollup
       - supports-color
 
-  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(rollup@4.62.4)':
+  '@nullvoxpopuli/ember-build-tooling-utils@1.1.0(@types/babel__core@7.20.5)':
     dependencies:
       '@babel/core': 7.29.7
       '@rolldown/pluginutils': 1.0.1
-      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 7.1.0(6ad958b0fac2ae7830d3cd04df3c1700)
     transitivePeerDependencies:
       - '@types/babel__core'
       - rollup
       - supports-color
 
-  '@nullvoxpopuli/ember-rolldown@2.7.0(2aacdd840e8bbec18962f7e662bce1d9)':
+  '@nullvoxpopuli/ember-rolldown@2.7.0(3e7c9105b70edf3164d5342b4ab4a992)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@embroider/core': 4.6.3
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0
       babel-plugin-ember-template-compilation: 4.0.0
       content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.7)
@@ -13435,12 +13371,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nullvoxpopuli/ember-rolldown@2.7.0(35190290210cd7126c88e642f3389863)':
+  '@nullvoxpopuli/ember-rolldown@2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@embroider/core': 4.6.3
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0
       babel-plugin-ember-template-compilation: 4.0.0
       content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.7)
@@ -13456,33 +13392,33 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nullvoxpopuli/ember-rolldown@2.7.0(c8f39f27e8182233f20a22a606bbb702)':
+  '@nullvoxpopuli/ember-rolldown@2.7.0(dd9c62c9359839bd21dda73cd20118ba)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@embroider/core': 4.6.3
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(@types/babel__core@7.20.5)
+      babel-plugin-ember-template-compilation: 4.0.0
+      content-tag: 4.2.0
+      decorator-transforms: 2.4.0(@babel/core@7.29.7)
+    optionalDependencies:
+      tsdown: 0.22.14(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@glint/template'
+      - '@types/babel__core'
+      - bufferutil
+      - canvas
+      - rollup
+      - supports-color
+      - utf-8-validate
+
+  '@nullvoxpopuli/ember-rolldown@2.7.0(f9f38012fdf74be2edbed7adde6b26e4)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@embroider/core': 4.6.3(@glint/template@1.8.0)
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(rollup@4.62.4)
-      babel-plugin-ember-template-compilation: 4.0.0
-      content-tag: 4.2.0
-      decorator-transforms: 2.4.0(@babel/core@7.29.7)
-    optionalDependencies:
-      tsdown: 0.22.14(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@glint/template'
-      - '@types/babel__core'
-      - bufferutil
-      - canvas
-      - rollup
-      - supports-color
-      - utf-8-validate
-
-  '@nullvoxpopuli/ember-rolldown@2.7.0(e3ca87308ef280fbc816621dc8bb1f89)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
-      '@embroider/core': 4.6.3
-      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0(@types/babel__core@7.20.5)(rollup@4.62.4)
+      '@nullvoxpopuli/ember-build-tooling-utils': 1.1.0
       babel-plugin-ember-template-compilation: 4.0.0
       content-tag: 4.2.0
       decorator-transforms: 2.4.0(@babel/core@7.29.7)
@@ -13917,14 +13853,21 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-babel@6.1.0(45a47724d0c3ddc593192c302cc4ddd7)':
+  '@rollup/plugin-babel@6.1.0(6ad958b0fac2ae7830d3cd04df3c1700)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
+      '@rollup/pluginutils': 5.1.4
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.62.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@rollup/pluginutils': 5.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13938,26 +13881,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@7.1.0(45a47724d0c3ddc593192c302cc4ddd7)':
+  '@rollup/plugin-babel@7.1.0(6ad958b0fac2ae7830d3cd04df3c1700)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
+      '@rollup/pluginutils': 5.1.4
       workerpool: 9.3.4
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.62.4
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)(rollup@4.62.4)':
+  '@rollup/plugin-babel@7.1.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4(rollup@4.62.4)
+      '@rollup/pluginutils': 5.1.4
       workerpool: 9.3.4
-    optionalDependencies:
-      rollup: 4.62.4
     transitivePeerDependencies:
       - supports-color
 
@@ -15034,13 +14974,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15055,7 +14994,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15078,6 +15016,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15088,13 +15027,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(2ace520979813bc28a1da2ed416b8a6f)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(c8f39f27e8182233f20a22a606bbb702)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(f9f38012fdf74be2edbed7adde6b26e4)
       '@rolldown/plugin-babel': 0.2.3(fd9871dab955e5f20c3ebce3bcb10969)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15109,7 +15047,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15132,6 +15069,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15142,13 +15080,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(7d28fa5cc489b7c9fe2c5ae481fc97f1)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(c8f39f27e8182233f20a22a606bbb702)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(f9f38012fdf74be2edbed7adde6b26e4)
       '@rolldown/plugin-babel': 0.2.3(334004921246d0ebcfcce2a809d85392)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15163,7 +15100,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15186,6 +15122,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15196,13 +15133,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(811209bf6762a9674e8f151cca7c5169)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel': 0.2.3(fd9871dab955e5f20c3ebce3bcb10969)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15217,7 +15153,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15240,6 +15175,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15250,13 +15186,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(81335d813583fd6ff6735a432deb9a38)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel': 0.2.3(8f8046503e306ae9fa9db9ca615f7a4a)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15271,7 +15206,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15294,6 +15228,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15304,13 +15239,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(@babel/runtime@7.29.7)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15325,7 +15259,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15348,6 +15281,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15358,13 +15292,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(@babel/runtime@7.29.7)(vite@8.2.1)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel': 0.2.3(fb5671dca28089711b004ff9d42e9161)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15379,7 +15312,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15402,6 +15334,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15412,13 +15345,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(@types/babel__core@7.20.5)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(e3ca87308ef280fbc816621dc8bb1f89)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(dd9c62c9359839bd21dda73cd20118ba)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
-      '@rollup/plugin-babel': 6.1.0(45a47724d0c3ddc593192c302cc4ddd7)
+      '@rollup/plugin-babel': 6.1.0(6ad958b0fac2ae7830d3cd04df3c1700)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15433,7 +15365,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15456,6 +15387,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15466,13 +15398,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(cb4314c638767b8f713f44d189f2fc92)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(2aacdd840e8bbec18962f7e662bce1d9)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(3e7c9105b70edf3164d5342b4ab4a992)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15487,7 +15418,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(5d0206a3438b9e0ec371eb579551ff9e)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15510,6 +15440,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15520,13 +15451,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(e21bb88fa88e86ab389341ee1b23f0ca)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(c8f39f27e8182233f20a22a606bbb702)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(f9f38012fdf74be2edbed7adde6b26e4)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15541,7 +15471,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15564,6 +15493,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15574,13 +15504,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(e8dce4ef0fa5851dc3a702940d6c0e66)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(2aacdd840e8bbec18962f7e662bce1d9)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(3e7c9105b70edf3164d5342b4ab4a992)
       '@rolldown/plugin-babel': 0.2.3(fb5671dca28089711b004ff9d42e9161)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15595,7 +15524,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(5d0206a3438b9e0ec371eb579551ff9e)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15618,6 +15546,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -15628,13 +15557,12 @@ snapshots:
 
   '@warp-drive/internal-config@file:tools/internal-config(vite@8.2.1)':
     dependencies:
-      '@babel/cli': 7.29.7(@babel/core@7.29.7)
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.29.7(@babel/core@7.29.7)(eslint@9.34.0)
       '@eslint/js': 9.34.0
-      '@nullvoxpopuli/ember-rolldown': 2.7.0(35190290210cd7126c88e642f3389863)
+      '@nullvoxpopuli/ember-rolldown': 2.7.0(afc1a33fa47dd3532ca1f8a889e766d9)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(vite@8.2.1)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)(rollup@4.62.4)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.41.0(ff068f05036278b96bb632ac0d7d2e3b)
       '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15649,7 +15577,6 @@ snapshots:
       eslint-plugin-qunit: 8.2.6(eslint@9.34.0)
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.34.0)
       globals: 16.5.0
-      rollup: 4.62.4
       tsdown: 0.22.14(typescript@5.9.3)
       typescript: 5.9.3
       typescript-eslint: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
@@ -15672,6 +15599,7 @@ snapshots:
       - oxc-resolver
       - publint
       - rolldown
+      - rollup
       - supports-color
       - tsx
       - unplugin-unused
@@ -16123,12 +16051,6 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-    optional: true
-
   archy@1.0.0: {}
 
   argparse@1.0.10:
@@ -16324,9 +16246,6 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
-
-  binary-extensions@2.3.0:
-    optional: true
 
   binary-search@1.3.6: {}
 
@@ -16673,19 +16592,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    optional: true
-
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -16784,8 +16690,6 @@ snapshots:
   commander@14.0.3: {}
 
   commander@2.20.3: {}
-
-  commander@6.2.1: {}
 
   commander@7.2.0: {}
 
@@ -17868,8 +17772,6 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
-  fs-readdir-recursive@1.1.0: {}
-
   fs-tree-diff@0.5.9:
     dependencies:
       heimdalljs-logger: 0.1.10
@@ -18269,11 +18171,6 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-    optional: true
 
   is-core-module@2.16.1:
     dependencies:
@@ -19498,11 +19395,6 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
-    optional: true
-
   readdirp@4.1.2: {}
 
   readdirp@5.1.1: {}
@@ -20019,8 +19911,6 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
-
-  slash@2.0.0: {}
 
   smart-buffer@4.2.0: {}
 

--- a/tools/internal-config/package.json
+++ b/tools/internal-config/package.json
@@ -4,7 +4,6 @@
   "version": "5.9.0-alpha.23",
   "type": "module",
   "dependencies": {
-    "@babel/cli": "^7.29.7",
     "@babel/core": "^7.29.7",
     "@babel/eslint-parser": "7.29.7",
     "@nullvoxpopuli/ember-rolldown": "^2.7.0",
@@ -26,7 +25,6 @@
     "eslint-plugin-n": "^17.21.3",
     "eslint-plugin-qunit": "^8.2.6",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "rollup": "^4.62.4",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"
   },


### PR DESCRIPTION
## Summary
- `@babel/cli` was declared in [tools/internal-config/package.json](tools/internal-config/package.json) but unused — no script anywhere in the monorepo invokes the `babel` CLI.
- `rollup` (the plain bundler package) was declared only to satisfy `@rollup/plugin-babel`'s `peerDependency`. That plugin's own shipped code never actually requires `rollup` at runtime — the only reference is a type-only `import type {...} from 'rollup'` in its `.d.ts`. `@rollup/plugin-babel` itself is **not** removed — it's real, load-bearing code: [tools/internal-config/vite/babel.js](tools/internal-config/vite/babel.js) wraps it as `maybeBabel()`, the actual babel-transform mechanism for all Vite 8/Rolldown apps, run through Rolldown's Rollup-compat plugin bridge (see the comment there for why plain `@rolldown/plugin-babel` isn't used instead).
- `rollup` itself stays installed regardless — `workbox-build` (pulled in by the docs site's PWA tooling) has its own real, independent need for it — so this doesn't shrink `node_modules` further on its own. It just stops `internal-config` from declaring a dependency it doesn't use.

## Test plan
- [x] `pnpm install` — lockfile updates cleanly (178 net lines removed), `@babel/cli` gone entirely, `rollup` remains only via `workbox-build`
- [x] `pnpm --filter main-test-app build:tests` (real `vite build`) — succeeds, confirming `@rollup/plugin-babel`'s babel transform still resolves and runs correctly without the explicit `rollup` declaration
- [x] `pnpm --filter main-test-app test` — full suite: 5349 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)