### PR TITLE
chore(deps): drop broccoli-funnel via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,9 @@
     "overrides": {
       "@embroider/macros": "^1.20.6",
       "ember-auto-import": "^2.13.1",
-      "broccoli-funnel": "^3.0.8",
+      "@embroider/addon-shim>broccoli-funnel": "-",
+      "ember-cli-babel>broccoli-funnel": "-",
+      "qunit-console-grouper>broccoli-funnel": "-",
       "broccoli-merge-trees": "^4.2.0",
       "@glimmer/validator": "^0.95.0",
       "@glint/ember-tsc": "1.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,9 @@ catalogs:
 overrides:
   '@embroider/macros': ^1.20.6
   ember-auto-import: ^2.13.1
-  broccoli-funnel: ^3.0.8
+  '@embroider/addon-shim>broccoli-funnel': '-'
+  ember-cli-babel>broccoli-funnel: '-'
+  qunit-console-grouper>broccoli-funnel: '-'
   broccoli-merge-trees: ^4.2.0
   '@glimmer/validator': ^0.95.0
   '@glint/ember-tsc': 1.10.0
@@ -6571,9 +6573,6 @@ packages:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
 
-  array-equal@1.0.2:
-    resolution: {integrity: sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==}
-
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
@@ -6775,10 +6774,6 @@ packages:
 
   broccoli-debug@0.6.5:
     resolution: {integrity: sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==}
-
-  broccoli-funnel@3.0.8:
-    resolution: {integrity: sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==}
-    engines: {node: 10.* || >= 12.*}
 
   broccoli-kitchen-sink-helpers@0.3.1:
     resolution: {integrity: sha512-gqYnKSJxBSjj/uJqeuRAzYVbmjWhG0mOZ8jrp6+fnUIOgLN6MvI7XxBECDHkYMIFPJ8Smf4xaI066Q2FqQDnXg==}
@@ -12436,7 +12431,6 @@ snapshots:
   '@embroider/addon-shim@1.10.0':
     dependencies:
       '@embroider/shared-internals': 3.1.1
-      broccoli-funnel: 3.0.8
       common-ancestor-path: 1.0.1
       semver: 7.8.5
     transitivePeerDependencies:
@@ -12445,7 +12439,6 @@ snapshots:
   '@embroider/addon-shim@1.10.2':
     dependencies:
       '@embroider/shared-internals': 3.1.1
-      broccoli-funnel: 3.0.8
       common-ancestor-path: 1.0.1
       semver: 7.8.5
     transitivePeerDependencies:
@@ -12454,7 +12447,6 @@ snapshots:
   '@embroider/addon-shim@1.10.3':
     dependencies:
       '@embroider/shared-internals': 3.1.1
-      broccoli-funnel: 3.0.8
       common-ancestor-path: 1.0.1
       semver: 7.8.5
     transitivePeerDependencies:
@@ -15984,8 +15976,6 @@ snapshots:
 
   aria-query@5.3.1: {}
 
-  array-equal@1.0.2: {}
-
   array-timsort@1.0.3: {}
 
   as-table@1.0.55:
@@ -16240,18 +16230,6 @@ snapshots:
       heimdalljs-logger: 0.1.10
       symlink-or-copy: 1.3.1
       tree-sync: 1.4.0
-    transitivePeerDependencies:
-      - supports-color
-
-  broccoli-funnel@3.0.8:
-    dependencies:
-      array-equal: 1.0.2
-      broccoli-plugin: 4.0.7
-      debug: 4.4.3
-      fs-tree-diff: 2.0.1
-      heimdalljs: 0.2.6
-      minimatch: 3.1.5
-      walk-sync: 2.2.0
     transitivePeerDependencies:
       - supports-color
 
@@ -16811,7 +16789,6 @@ snapshots:
       babel-plugin-module-resolver: 5.0.2
       broccoli-babel-transpiler: 8.0.2(@babel/core@7.29.7)
       broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
       broccoli-source: 3.0.1
       calculate-cache-key-for-tree: 2.0.0
       clone: 2.1.2
@@ -19116,11 +19093,7 @@ snapshots:
       rimraf: 5.0.10
       underscore.string: 3.3.6
 
-  qunit-console-grouper@0.3.0:
-    dependencies:
-      broccoli-funnel: 3.0.8
-    transitivePeerDependencies:
-      - supports-color
+  qunit-console-grouper@0.3.0: {}
 
   qunit-dom@3.6.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Removes `broccoli-funnel` from the resolved dependency tree via pnpm's edge-deletion override syntax (`"parent>child": "-"`), the same approach used in #10875 for `ember-cli-babel`.
- Three real dependents had it: `@embroider/addon-shim` (×3 version variants), `ember-cli-babel`, and `qunit-console-grouper`. All three edges are overridden away.
- Note: `@embroider/addon-shim`'s `dist/index.js` does `require("broccoli-funnel")` at the top level unconditionally, so this relies on that require path never actually executing under our build — confirmed out of band rather than via a local build in this PR.

## Test plan
- [x] `pnpm install` — lockfile only drops `broccoli-funnel` and its own now-unreferenced sub-deps (35 lines removed)
- [ ] CI — no local build/test run in this PR; relying on CI to confirm nothing breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)