### PR TITLE
fix(build): force injected-workspace-dep sync into the build:pkg task graph

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -30,6 +30,28 @@
     /////////////////////////////////////////////////
     /////////////////////////////////////////////////
 
+    // pnpm's sync-injected-deps-after-scripts hook (see .npmrc) only fires
+    // when pnpm itself runs a package's script -- it never fires for a
+    // turbo-orchestrated run, whether turbo actually executes the underlying
+    // command or restores it from cache. That's fine when every build:pkg in
+    // the run is a cache miss (each one still goes through a real pnpm script
+    // invocation as turbo executes it) or when every one is a cache hit (the
+    // last real run already synced everything correctly). It breaks when the
+    // run is a *mix*: if @warp-drive/core#build:pkg is a cache hit (skipped
+    // entirely, no script execution, no hook) while a consumer like
+    // @warp-drive/diagnostic is a cache miss (forced to actually build), the
+    // consumer's injected copy of @warp-drive/core's dist/ was never
+    // refreshed, and its build:pkg -- which imports real runtime code from it
+    // via babel.config.mjs, not just types -- fails with a missing-module
+    // error. `cache: false` forces this task to always execute regardless of
+    // upstream cache state, which closes that gap; it does not force
+    // downstream build:pkg tasks to also miss cache, since turbo hashes a
+    // dependency task by its declared inputs, not by whether it actually ran.
+    "//#sync": {
+      "cache": false,
+      "dependsOn": ["@warp-drive/build-config#build:pkg", "@warp-drive/core#build:pkg"]
+    },
+
     // run build in all library packages
     // these do not require any associated packages
     // to have been built to build other than
@@ -63,7 +85,7 @@
         "cjs-dist/**",
         "tsconfig.tsbuildinfo"
       ],
-      "dependsOn": ["@warp-drive/core#build:pkg"],
+      "dependsOn": ["@warp-drive/core#build:pkg", "//#sync"],
       // https://turbo.build/repo/docs/reference/configuration#outputLogs
       "outputLogs": "new-only",
       // NODE_ENV, EMBER_DATA_FULL_COMPAT, and BABEL_DISABLE_CACHE are only read by


### PR DESCRIPTION
## Summary

Fixes the root cause behind PR #10877's `install` failure (`Cannot find module '.../packages/diagnostic/node_modules/@warp-drive/core/dist/build-config/babel-macros.js'`).

`@warp-drive/core` is an "injected" (physically copied, not symlinked) workspace dependency, per `.npmrc`'s `inject-workspace-packages=true`. Those injected copies only get refreshed by pnpm's `sync-injected-deps-after-scripts` hook, which fires when **pnpm itself** runs a package's script — it never fires for a turbo-orchestrated run, regardless of whether turbo executes the underlying command for real or restores it from cache.

That's invisible in two common cases:
- **All cache misses**: every `build:pkg` still goes through a real pnpm script invocation as turbo executes it, so the hook fires along the way and everything stays in sync.
- **All cache hits**: nothing executes, but the *last* real run already synced everything correctly, so stale state never surfaces.

It breaks on a **mixed** run: if `@warp-drive/core#build:pkg` is a cache hit (skipped entirely, no script execution, no hook) while a consumer like `@warp-drive/diagnostic` is a cache miss (forced to actually build, because *its own* `package.json` changed), diagnostic's injected copy of core's `dist/` is never refreshed. Diagnostic's build imports real runtime code from it via `babel.config.mjs` (not just types), so it fails outright.

## Fix

Add a `cache: false` task that always executes regardless of upstream cache state, depending on the two packages whose build output other packages actually import at build time (per the existing comment in `turbo.json`: `@warp-drive/build-config` and `@warp-drive/core` are the only non-leaf build-time sources):

```jsonc
"//#sync": {
  "cache": false,
  "dependsOn": ["@warp-drive/build-config#build:pkg", "@warp-drive/core#build:pkg"]
},
"build:pkg": {
  ...
  "dependsOn": ["@warp-drive/core#build:pkg", "//#sync"]
}
```

`//#sync` runs the existing root `sync` script (`pnpm --filter ... run --parallel --if-present sync`), which fans out to each package's own no-op `sync` script — that's what triggers pnpm's hook. No new script needed.

**Does this reintroduce full rebuilds every run?** No — verified locally with a scratch `cache: false` task before writing this fix: an upstream `cache: false` task re-executing does not force a downstream task to miss cache, because turbo hashes a dependency task by its declared inputs, not by whether it actually ran. Ran the same task twice with zero file changes; the uncacheable upstream re-executed both times, and the downstream task was still a clean cache hit both times.

## Test plan
- [x] `turbo run build:pkg --filter=@warp-drive/diagnostic --dry=json` — task graph resolves with no cycles, `//#sync` correctly inserted as a dependency
- [x] Local scratch experiment confirming `cache: false` upstream tasks don't poison downstream caching (see above)
- [ ] CI (this is the real test: watching for a green `install` job under normal mixed cache conditions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)