### PR TITLE
fix(eslint-plugin): guard null parent in no-create-record-rerender rule

### DIFF
--- a/packages/eslint-plugin-warp-drive/src/rules/no-create-record-rerender.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/no-create-record-rerender.js
@@ -151,7 +151,11 @@ function getParentFunction(/** @type {import('eslint').Rule.Node} */ node) {
  * @return {Boolean}
  */
 function parentFunctionIsConstructor(maybeParentFunction) {
-  return 'kind' in maybeParentFunction.parent && maybeParentFunction.parent.kind === 'constructor';
+  return (
+    maybeParentFunction.parent !== null &&
+    'kind' in maybeParentFunction.parent &&
+    maybeParentFunction.parent.kind === 'constructor'
+  );
 }
 
 /**
@@ -161,6 +165,7 @@ function parentFunctionIsConstructor(maybeParentFunction) {
  */
 function parentFunctionIsInit(maybeParentFunction) {
   return (
+    maybeParentFunction.parent !== null &&
     'key' in maybeParentFunction.parent &&
     maybeParentFunction.parent.key.type === 'Identifier' &&
     forbiddenParentMethodKeyNames.includes(maybeParentFunction.parent.key.name)


### PR DESCRIPTION
## Summary
- Docs compilation was failing on main ([run](https://github.com/warp-drive-data/warp-drive/actions/runs/33029596201/job/98378779600)) because TypeDoc's TS compilation of `no-create-record-rerender.js` hit `TS18047: 'maybeParentFunction.parent' is possibly 'null'` in two places, aborting the `Generate Artifact` step.
- Added explicit null checks before narrowing `maybeParentFunction.parent`.

## Test plan
- [x] `pnpm run build` in `docs-viewer` completes with "Found 0 errors and 231 warnings" (previously failed with the TS18047 errors above)