### PR TITLE
perf(ci): unserialize lts/releases from browser-tests, drop ember-beta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,7 @@ jobs:
           retention-days: 1
 
   lts:
-    needs: [browser-tests]
+    needs: [install]
     strategy:
       fail-fast: false
       matrix:
@@ -234,7 +234,7 @@ jobs:
 
   releases:
     timeout-minutes: 12
-    needs: [browser-tests]
+    needs: [install]
     if: |
       github.event_name == 'pull_request' && (
         github.base_ref == 'main' || github.base_ref == 'beta'
@@ -244,7 +244,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [ember-canary, ember-beta]
+        release: [ember-canary]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## Summary
- `lts` and `releases` now depend on `install` directly instead of `browser-tests`. Both jobs only need the shared caches `install` already warms (the turbo remote-cache proxy disk cache and the local turbo build cache, both keyed by commit sha) — they don't consume any artifact or output that `browser-tests` produces. Chaining them behind `browser-tests` needlessly serialized ~2.3-2.7min of `lts`/`releases` runtime behind ~2.9-3.3min of `browser-tests` runtime on the critical path; they can now start concurrently right after `install`.
- Dropped the `ember-beta` scenario from the `releases` matrix (`release: [ember-canary, ember-beta]` → `release: [ember-canary]`). Looking at CI history on `main`, all 8 real failures out of the last ~100 runs came from `releases (ember-canary)`/`releases (ember-beta)` breaking due to upstream Ember prerelease changes rather than our own test infra — `ember-beta` is lower signal than `ember-canary` for the same CI-minutes/noise cost.

## Verification
- Confirmed via `.github/actions/setup/action.yml` that neither `lts` nor `releases` consume any artifact/output specific to `browser-tests` — the only shared state is the turbo caches, which `install` already populates and which are restored by commit-sha-prefixed cache keys regardless of which job runs next.
- Checked branch protection's required status checks (`gh api repos/.../branches/main/protection`): only `lint`, `Test Chrome (development)`, and `Test Chrome (production)` are required. Neither `lts` nor `releases (ember-canary)`/`releases (ember-beta)` is a required check, so dropping the `ember-beta` matrix leg does not touch branch protection.
- The separate, manually-triggered `.github/workflows/deprecations-check.yml` (workflow_dispatch only) still references its own `ember-beta` scenario for an unrelated job (`test-all-deprecations-releases`) and is intentionally left untouched — it's out of scope for this change and doesn't affect `main`'s automatic CI gating.

## Test plan
- [ ] CI on this PR passes (`lint`, `Test Chrome (development)`, `Test Chrome (production)`, `lts`, `releases (ember-canary)`)
- [ ] Confirm via `gh run view <id> --json jobs` that `lts`/`releases` now start concurrently with `browser-tests` rather than after it