### PR TITLE
perf(ci): audit CI caches, remove dead Broccoli cache restoration

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,15 +16,6 @@ inputs:
     description: Whether to restore lint caches
     required: false
     default: false
-  ## Speeds Up Build of bigger apps by enabling reuse
-  restore-broccoli-cache:
-    description: Whether to restore broccoli
-    required: false
-    default: false
-  use-production-caches:
-    description: Whether to restore from production caches
-    required: false
-    default: false
   install:
     description: Whether to install dependencies
     required: false
@@ -86,7 +77,6 @@ runs:
         echo "DISABLE_TURBO_CACHE = ${{ inputs.DISABLE_TURBO_CACHE }}"
         echo "ACTIONS_RUNNER_DEBUG = ${{ inputs.ACTIONS_RUNNER_DEBUG }}"
         echo "restore-lint-caches = ${{ inputs.restore-lint-caches }}"
-        echo "restore-broccoli-cache = ${{ inputs.restore-broccoli-cache }}"
 
     # felixmosh/turborepo-gh-artifacts' local proxy server (below) serves a
     # GET for artifact <id> straight from ${RUNNER_TEMP}/turbo-cache/<id>.gz
@@ -220,27 +210,6 @@ runs:
       # Generates the cert if needed, using our local copy of @warp-drive/holodeck
       run: |
         node ./packages/holodeck/server/ensure-cert.js
-
-    - name: Setup Broccoli Caching
-      if: ${{ inputs.restore-broccoli-cache == 'true' }}
-      shell: bash
-      run: |
-        echo "FORCE_PERSISTENCE_IN_CI=true" >> $GITHUB_ENV
-        echo "BROCCOLI_PERSISTENT_FILTER_CACHE_ROOT=${{ github.workspace }}/.broccoli-cache" >> $GITHUB_ENV
-
-    - name: Restore Broccoli Cache
-      if: ${{ inputs.restore-broccoli-cache == 'true' }}
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: |
-          ${{ github.workspace }}/.broccoli-cache
-          node_modules/.cache
-          tests/dont-write-new-tests-here/node_modules/.cache
-        key: broccoli${{inputs.use-production-caches == 'true' && '-production-' || '-'}}${{ github.head_ref }}-${{inputs.ref }}
-        restore-keys: |
-          broccoli${{inputs.use-production-caches == 'true' && '-production-' || '-'}}${{ github.head_ref }}
-          broccoli${{inputs.use-production-caches == 'true' && '-production-' || '-'}}${{ github.base_ref }}
-          broccoli${{inputs.use-production-caches == 'true' && '-production-' || '-'}}main
 
     - name: Restore Lint Caches
       if: ${{ inputs.restore-lint-caches == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/setup
         with:
-          restore-broccoli-cache: true
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           with-cert: true
@@ -149,7 +148,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/setup
         with:
-          restore-broccoli-cache: true
           jobs: 4
           parallel-build: true
           with-cert: true
@@ -209,7 +207,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/setup
         with:
-          restore-broccoli-cache: true
           with-cert: true
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -250,7 +247,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: ./.github/actions/setup
         with:
-          restore-broccoli-cache: true
           with-cert: true
           install: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Audit of every caching layer in `.github/actions/setup/action.yml` / `.github/workflows/main.yml` (pnpm store, turbo local + remote-proxy, eslint/prettier/tsc, Broccoli persistent-filter). One concrete fix included; the rest is a report for a human to weigh in on (no changes made where I couldn't concretely confirm dead code).

## What changed

Removed the Broccoli persistent-filter cache restoration (`restore-broccoli-cache` input + its two steps in `action.yml`, and the 4 `restore-broccoli-cache: true` usages in `main.yml` for `special-build-tests`, `browser-tests`, `lts`, `releases`), plus the now-orphaned `use-production-caches` input that only fed the Broccoli cache key.

**Why it's confirmed dead, not just suspected:** `tests/dont-write-new-tests-here` (main-test-app, the only app any of these 4 jobs build) migrated from Broccoli/ember-cli to `@embroider/vite` in #10697. There is no `ember-cli-build.js` left anywhere in the repo. I pulled real CI logs (`gh api .../actions/jobs/<id>/logs`) for browser-tests (both dev+prod legs), lts, releases(canary), and special-build-tests across several recent runs on main and open PRs:
- Every restore attempt: `Cache not found for input keys: broccoli-...` (all restore-key fallbacks miss too — this cache has never had a successful save since the migration).
- Every save attempt: `Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.` — `.broccoli-cache` is simply never created by the vite build.

So this was pure restore+save round-trip overhead on every one of those jobs with zero payoff.

**What I deliberately left alone:** `@embroider/core` (which backs `@embroider/vite`'s `ember()`/`hbs()` plugins) still lists `broccoli-persistent-filter` as a direct dependency in `pnpm-lock.yaml`. That's why I didn't assume this was dead from static analysis alone — I only removed it after confirming empirically (via the CI logs above) that the cache directory is never actually populated in practice, i.e. that dependency path isn't exercised at runtime for this build. I left the `.broccoli-cache/*` eslint-ignore entry in `tools/internal-config/eslint/ignore.js` alone since it's a no-op if the directory doesn't exist and isn't part of the CI cache machinery.

## Full cache audit (no code changes except the above)

| Cache | Health | Notes |
|---|---|---|
| pnpm store (`actions/setup-node`'s built-in `cache: pnpm`) | Healthy | Consistent `Cache hit for: node-cache-Linux-x64-pnpm-<lockfile-hash>` across sampled runs; correctly keyed off the lockfile. |
| Turbo remote-cache proxy disk cache (`turbo-remote-cache-${{ github.run_id }}`) | Healthy | Restores 40-50MB+ per job; key is unique per run by design (actions/cache keys are immutable) with a `turbo-remote-cache-` prefix restore-key, so every job after `install` in the same run gets an exact hit off `install`'s save. Matches the extensive existing comment in `action.yml`. |
| Turbo local build cache (`.turbo/cache`, `turbo-local-cache-<sha>-<suffix>`) | Healthy | 200MB+ restored per job via the `turbo-local-cache-<sha>-` restore-key fallback (usually hitting `install`'s save under the same commit). Working as documented. |
| `.eslintcache` / `tsconfig.tsbuildinfo` / `.prettier-cache` (`lint-<head_ref>-<ref>`) | Hitting, but has a real blind spot | See below. |
| Broccoli persistent-filter cache | **Dead — removed** | See above. |
| `failed-test-log_<sha>_<stage>` (browser-tests retry log) | Fine | Tiny artifact, correctly scoped per commit+stage, not really a perf-relevant cache. |

### Eslintcache: is it hitting?

Yes. `pnpm lint` (`turbo lint --continue`) runs `eslint . --quiet --cache --cache-strategy=content` per package with no explicit `--cache-location`, so it defaults to `<package>/.eslintcache`, matching the `**/.eslintcache` glob `action.yml` restores/saves. Confirmed via CI logs:
- `Cache hit for restore-key: lint--<prev-sha>` (push-to-main events: `head_ref` is empty, so the key degenerates to a `lint-` prefix that matches any prior main-branch save — this is intentional/working, not a bug).
- Prettier + Lint + typecheck steps consistently run ~50s-1min combined in sampled recent runs, not the ~1m50s-alone figure quoted in the task — timings clearly vary by what changed.

**Real gap found:** the plugin `eslint-plugin-warp-drive` (consumed only by `tests/core` and `tests/legacy`) has no `build:pkg` script, so it never participates in the `^build:pkg`/`build:pkg` `dependsOn` edges that `turbo.json`'s `lint` task relies on to invalidate downstream packages when an upstream workspace dependency changes. Its `package.json` version also doesn't get bumped for internal rule-logic fixes (confirmed via a real recent commit, `3f0900ada`, "guard null parent in no-create-record-rerender rule" — touches only the rule's `.js` file, no version bump). ESLint's own `--cache` invalidation is based on the resolved config object (rule names/options, parser, eslint version) and file content, not on hashing a plugin's rule implementation — so neither layer is guaranteed to invalidate a consumer's cached "clean" result after a plugin-only rule-behavior change if the affected file's own content didn't change. In the one real instance I could check, turbo actually did show a cache miss for both consumers in that run, but a large fraction of unrelated packages also missed that same run (plausibly due to `tsconfig.tsbuildinfo` volatility, itself a declared turbo input), so I can't confidently attribute that miss to correct dependency-aware invalidation vs. incidental noise. I'm flagging this rather than guessing at a fix — options worth a human decision: give `eslint-plugin-warp-drive` a trivial `build:pkg` script so it joins the `^build:pkg` dependency edge, or adopt a policy of bumping its version on rule-behavior changes.

The GH Actions-level cache key itself (`lint-<head_ref>-<ref>`, `ref` defaulting to `github.sha`) is fine — it's unique per commit per branch, so staleness isn't introduced at that layer; any risk is inside ESLint's/turbo's own per-file/per-task invalidation as described above.

### Other observations
- No redundant caching found: the turbo local-cache and remote-cache-proxy layers look like duplication at first glance but are two different tiers (local disk vs. HTTP-backed remote fallback) as already explained in the code's own comments, not overlapping waste.
- Broccoli aside, I didn't find any other cache that's clearly never hitting.

## Test plan
- [x] YAML validity checked locally (`yaml.safe_load` on both files)
- [x] Opened this PR so CI runs `special-build-tests`, `browser-tests`, `lts`, and `releases` (the 4 jobs whose `restore-broccoli-cache` input was removed) end-to-end without it
- [ ] Confirm CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)