### PR TITLE
fix(renovate): cap branchConcurrentLimit to reduce OOM/timeout risk

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,6 +53,7 @@
   },
   "rangeStrategy": "bump",
   "prHourlyLimit": 10,
+  "branchConcurrentLimit": 3,
   "vulnerabilityAlerts": {
     "labels": [":label: security"],
     "automerge": false,


### PR DESCRIPTION
## Summary
- Renovate scans on Mend's hosted free tier are hitting `kernel-out-of-memory` and timing out.
- Log evidence shows each branch that needs an artifact update spawns a full-workspace `pnpm install --lockfile-only --recursive` across all 63 packages (~1650 resolved deps), and several of these ran back-to-back in a single scan.
- `branchConcurrentLimit` was unset (unlimited), so a run could attempt as many of these as passed Renovate's other gates (7-day `minimumReleaseAge`, hourly limits, etc.) all at once.
- Capping it to 3 bounds how many full-workspace lockfile regenerations happen per scan, trading a slower backlog clear-rate for staying under the memory ceiling.

## Test plan
- [ ] Confirm the next scheduled Renovate scan completes without `kernel-out-of-memory` / timeout
- [ ] Confirm branches/PRs still get created and updated over subsequent scans (just fewer per run)