### PR TITLE
perf(eslint): experiment - switch to typescript-eslint projectService

### DIFF
--- a/tools/internal-config/eslint/browser.js
+++ b/tools/internal-config/eslint/browser.js
@@ -46,7 +46,7 @@ export function browser(config = {}) {
   config.files = Array.isArray(config.files) ? config.files : ['**/*.{js,gjs}'];
   const base = ts.browser(config);
   // @ts-expect-error
-  base.languageOptions.parserOptions.project = null;
+  base.languageOptions.parserOptions.projectService = false;
   base.rules = rules(config);
   base.plugins = imports.plugins();
 

--- a/tools/internal-config/eslint/typescript.js
+++ b/tools/internal-config/eslint/typescript.js
@@ -141,8 +141,7 @@ export function browser(config) {
     languageOptions: {
       parser: parser(config.enableGlint),
       parserOptions: {
-        project: './tsconfig.json',
-        projectService: false,
+        projectService: true,
         tsconfigRootDir: config.dirname,
         extraFileExtensions: ['.gts', '.gjs'],
       },
@@ -189,7 +188,7 @@ export function node(config) {
     languageOptions: {
       parser: parser(),
       parserOptions: {
-        project: './tsconfig.json',
+        projectService: true,
         extraFileExtensions: ['.gts', '.gjs'],
       },
       /** @type {2022} */


### PR DESCRIPTION
## Summary

Experiment: switch the shared typed-lint config (`tools/internal-config/eslint/typescript.js`) from classic `parserOptions.project: './tsconfig.json'` to `parserOptions.projectService: true`, consumed by all ~49 package `eslint.config.mjs` files.

- `typescript.js`'s `browser()` and `node()` builders now set `projectService: true` instead of `project: './tsconfig.json'` (+ `projectService: false`).
- `browser.js`'s plain-JS/`.gjs` override (which previously nulled `parserOptions.project` to disable type-aware linting for those files) now sets `parserOptions.projectService = false` instead, to preserve identical non-type-checked behavior for those files.

A prior investigation benchmarked `project` vs `projectService` locally on a single package (`warp-drive-packages/core`) and found no measurable difference (~3.32s both ways) — but that was a narrow, single-package, single-process comparison that doesn't necessarily reflect real CI runner behavior across the full ~49-package lint fan-out. This PR exists to get **real CI numbers** for the whole-repo `lint` job, not just the earlier local microbenchmark.

This is a draft **experiment** — it is not intended to be merged based on this PR alone. It will be reviewed based on the actual CI timing it produces, and on correctness validation (comparing lint findings between the old and new parser modes across a representative sample of packages) tracked in review discussion.

## Test plan
- [x] `pnpm install` + `eslint .` runs clean (exit 0) under the new config on a representative sample (`warp-drive-packages/core`, `tests/core`, `tests/utilities`, `packages/codemods`)
- [ ] Diff old-vs-new config lint findings across the same sample to confirm no silently-dropped type-aware findings and no crashes
- [ ] Compare this PR's real CI `lint` job / `Lint` step duration against a recent `main` baseline