### PR TITLE
perf(eslint): dedicated lint-only tsconfig per package

### DIFF
--- a/packages/-ember-data/tsconfig.eslint.json
+++ b/packages/-ember-data/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/-warp-drive/tsconfig.eslint.json
+++ b/packages/-warp-drive/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/active-record/tsconfig.eslint.json
+++ b/packages/active-record/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/adapter/tsconfig.eslint.json
+++ b/packages/adapter/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/codemods/tsconfig.eslint.json
+++ b/packages/codemods/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/core-types/tsconfig.eslint.json
+++ b/packages/core-types/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/debug/tsconfig.eslint.json
+++ b/packages/debug/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/diagnostic/tsconfig.eslint.json
+++ b/packages/diagnostic/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/eslint-plugin-warp-drive/tsconfig.eslint.json
+++ b/packages/eslint-plugin-warp-drive/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/graph/tsconfig.eslint.json
+++ b/packages/graph/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/holodeck/tsconfig.eslint.json
+++ b/packages/holodeck/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/json-api/tsconfig.eslint.json
+++ b/packages/json-api/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/legacy-compat/tsconfig.eslint.json
+++ b/packages/legacy-compat/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/model/tsconfig.eslint.json
+++ b/packages/model/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/request-utils/tsconfig.eslint.json
+++ b/packages/request-utils/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/request/tsconfig.eslint.json
+++ b/packages/request/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/rest/tsconfig.eslint.json
+++ b/packages/rest/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/schema-record/tsconfig.eslint.json
+++ b/packages/schema-record/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/serializer/tsconfig.eslint.json
+++ b/packages/serializer/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/store/tsconfig.eslint.json
+++ b/packages/store/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/packages/tracking/tsconfig.eslint.json
+++ b/packages/tracking/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/specs/tsconfig.eslint.json
+++ b/specs/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/codemods/tsconfig.eslint.json
+++ b/tests/codemods/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/core/tsconfig.eslint.json
+++ b/tests/core/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/dont-write-new-tests-here/tsconfig.eslint.json
+++ b/tests/dont-write-new-tests-here/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/ember-data__adapter/tsconfig.eslint.json
+++ b/tests/ember-data__adapter/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/ember-data__graph/tsconfig.eslint.json
+++ b/tests/ember-data__graph/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/ember-data__model/tsconfig.eslint.json
+++ b/tests/ember-data__model/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/ember-data__request/tsconfig.eslint.json
+++ b/tests/ember-data__request/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/example-app-ember/tsconfig.eslint.json
+++ b/tests/example-app-ember/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/experiments/tsconfig.eslint.json
+++ b/tests/experiments/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/framework-ember/tsconfig.eslint.json
+++ b/tests/framework-ember/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/framework-react/tsconfig.eslint.json
+++ b/tests/framework-react/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/framework-svelte/tsconfig.eslint.json
+++ b/tests/framework-svelte/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/framework-vue/tsconfig.eslint.json
+++ b/tests/framework-vue/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/json-api/tsconfig.eslint.json
+++ b/tests/json-api/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/legacy/tsconfig.eslint.json
+++ b/tests/legacy/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/performance/tsconfig.eslint.json
+++ b/tests/performance/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tests/utilities/tsconfig.eslint.json
+++ b/tests/utilities/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/tools/internal-config/eslint/typescript.js
+++ b/tools/internal-config/eslint/typescript.js
@@ -141,7 +141,12 @@ export function browser(config) {
     languageOptions: {
       parser: parser(config.enableGlint),
       parserOptions: {
-        project: './tsconfig.json',
+        // A dedicated, lint-only tsconfig (rather than the package's real
+        // build tsconfig) so `composite`/`references` — which exist for the
+        // build/editor and are otherwise inert for lint — can't accidentally
+        // start mattering here, and so `disableSourceOfProjectReferenceRedirect`
+        // is pinned regardless of what the build tsconfig does.
+        project: './tsconfig.eslint.json',
         projectService: false,
         tsconfigRootDir: config.dirname,
         extraFileExtensions: ['.gts', '.gjs'],
@@ -189,7 +194,7 @@ export function node(config) {
     languageOptions: {
       parser: parser(),
       parserOptions: {
-        project: './tsconfig.json',
+        project: './tsconfig.eslint.json',
         extraFileExtensions: ['.gts', '.gjs'],
       },
       /** @type {2022} */

--- a/warp-drive-packages/core/tsconfig.eslint.json
+++ b/warp-drive-packages/core/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/ember/tsconfig.eslint.json
+++ b/warp-drive-packages/ember/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/experiments/tsconfig.eslint.json
+++ b/warp-drive-packages/experiments/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/json-api/tsconfig.eslint.json
+++ b/warp-drive-packages/json-api/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/legacy/tsconfig.eslint.json
+++ b/warp-drive-packages/legacy/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/react/tsconfig.eslint.json
+++ b/warp-drive-packages/react/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/schema-dsl/tsconfig.eslint.json
+++ b/warp-drive-packages/schema-dsl/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/svelte/tsconfig.eslint.json
+++ b/warp-drive-packages/svelte/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/tc39-proposal-signals/tsconfig.eslint.json
+++ b/warp-drive-packages/tc39-proposal-signals/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/utilities/tsconfig.eslint.json
+++ b/warp-drive-packages/utilities/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}

--- a/warp-drive-packages/vue/tsconfig.eslint.json
+++ b/warp-drive-packages/vue/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "disableSourceOfProjectReferenceRedirect": true
+  }
+}


### PR DESCRIPTION
## Summary
- Points `parserOptions.project` at a new `tsconfig.eslint.json` per package (extends the real tsconfig, `composite: false`, `disableSourceOfProjectReferenceRedirect: true`, no `references`) instead of the real build tsconfig. Hardening only: `references`/`composite` were already confirmed inert for classic project-mode lint (only `dist/*.d.ts` enters the program, never a dependency's `src`), so this guards against that changing later (e.g. overlapping `include` globs, or a future move to `projectService`) rather than fixing a live bug.
- Verified byte-identical `eslint --format=json` output before/after on `packages/store`, `warp-drive-packages/ember`, and `tests/{core,framework-ember}` (the latter two include `.gts` files), plus a full `pnpm run lint` (85/85 tasks green).
- Root-caused the separate, already-measured `projectService` regression (see draft `perf/eslint-project-service`, not touched by this PR): `eslint --debug` shows the project service eagerly loading and file-watching *every* referenced composite project's tsconfig up front (visible as one `Config: .../tsconfig.json :` tsserver line per reference), even though none of that referenced source ever enters the lint program. Classic `project` mode never does this. Ruled out the two other candidate causes from the upstream typescript-eslint#9571 thread: `ember-eslint-parser` does pass a fresh `extraFileExtensions` array on every `.gts`/`.gjs` parse, but typescript-eslint compares it with `isDeepStrictEqual`, so no reload is triggered; and per-package lint runs never see cross-package tsconfig `include` overlaps, since each package lints with its own isolated `tsconfigRootDir`.
- Confirmed (and did **not** ship) that this same dedicated-tsconfig trick cannot recover `projectService` perf: TypeScript's project service discovers a file's project by walking up directories for a file literally named `tsconfig.json`, not via the parser's `defaultProject` option (that's only a fallback for files no project claims), so a same-directory `tsconfig.eslint.json` is never actually used for files the real `tsconfig.json` already covers. Recovering `projectService` perf would require stripping `composite`/`references` from the *real* tsconfig (impacts the actual build/editor wiring) or an unsupported host-level hack — recommend dropping that line of investigation.

## Test plan
- [x] `eslint --format=json` diffed before/after on `packages/store`, `warp-drive-packages/ember`, `tests/core`, `tests/framework-ember` — identical
- [x] `pnpm run lint` — 85/85 tasks pass
- [ ] Confirm real CI `Lint` step / `lint` job timings are a wash vs the classic-project-mode baseline (26-56s step / 2m9s-3m21s job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)