### PR TITLE
docs(schema-dsl): group decorators by kind via new @decorator/@classDecorator tags

### DIFF
--- a/docs-viewer/typedoc-plugins/decorator-groups.mjs
+++ b/docs-viewer/typedoc-plugins/decorator-groups.mjs
@@ -1,0 +1,31 @@
+import { Converter, CommentTag } from 'typedoc';
+
+/**
+ * `@decorator` and `@classDecorator` mark a function as a field-level or
+ * class-level decorator respectively. This maps that modifier tag onto a
+ * synthesized `@group` tag so decorators render under a "Field Decorators" /
+ * "Class Decorators" heading instead of a flat "Functions" list, with any
+ * `@category` tag still sub-dividing within that group as usual.
+ */
+const GROUP_BY_MODIFIER_TAG = {
+  '@classDecorator': 'Class Decorators',
+  '@decorator': 'Field Decorators',
+};
+
+function assignGroupFromModifierTag(_context, reflection) {
+  const comment = reflection.comment;
+  if (!comment) return;
+
+  for (const [modifierTag, groupName] of Object.entries(GROUP_BY_MODIFIER_TAG)) {
+    if (!comment.modifierTags.has(modifierTag)) continue;
+    if (comment.blockTags.some((tag) => tag.tag === '@group')) return;
+    comment.blockTags.push(new CommentTag('@group', [{ kind: 'text', text: groupName }]));
+    return;
+  }
+}
+
+/** @param {import('typedoc').Application} app */
+export function load(app) {
+  app.converter.on(Converter.EVENT_CREATE_DECLARATION, assignGroupFromModifierTag);
+  app.converter.on(Converter.EVENT_CREATE_SIGNATURE, assignGroupFromModifierTag);
+}

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -71,6 +71,8 @@ const config = {
       '@discouraged',
       '@legacy',
       '@polaris',
+      '@decorator',
+      '@classDecorator',
     ],
   },
   plugin: [
@@ -78,6 +80,7 @@ const config = {
     import.meta.resolve('typedoc-plugin-markdown').slice(7),
     import.meta.resolve('typedoc-vitepress-theme').slice(7),
     import.meta.resolve('typedoc-plugin-mdn-links').slice(7),
+    new URL('./typedoc-plugins/decorator-groups.mjs', import.meta.url).pathname,
   ],
   out: './tmp/api',
   sidebar: {

--- a/warp-drive-packages/schema-dsl/src/entities/compose-trait.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/compose-trait.ts
@@ -40,6 +40,7 @@ import type { AnyConstructor } from '../-private/types.ts';
  * @param traits - the {@link Trait}-decorated classes to compose
  * @since 5.9.0
  * @public
+ * @classDecorator
  */
 export function trait(..._traits: AnyConstructor[]): (target: AnyConstructor) => void {
   return function (_target: AnyConstructor): void {};

--- a/warp-drive-packages/schema-dsl/src/entities/object-schema.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/object-schema.ts
@@ -62,6 +62,7 @@ export interface ObjectSchemaOptions {
  *
  * @since 5.9.0
  * @public
+ * @classDecorator
  */
 export function ObjectSchema(target: AnyConstructor): void;
 export function ObjectSchema(type: string, options?: ObjectSchemaOptions): (target: AnyConstructor) => void;

--- a/warp-drive-packages/schema-dsl/src/entities/resource.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/resource.ts
@@ -114,6 +114,7 @@ export interface ResourceOptions {
  *
  * @since 5.9.0
  * @public
+ * @classDecorator
  */
 export function Resource(target: AnyConstructor): void;
 export function Resource(type: string, options?: ResourceOptions): (target: AnyConstructor) => void;

--- a/warp-drive-packages/schema-dsl/src/entities/trait.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/trait.ts
@@ -65,6 +65,7 @@ export interface TraitOptions {
  *
  * @since 5.9.0
  * @public
+ * @classDecorator
  */
 export function Trait(target: AnyConstructor): void;
 export function Trait(name: string, options?: TraitOptions): (target: AnyConstructor) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/alias.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/alias.ts
@@ -73,6 +73,7 @@ export interface AliasOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function alias(options: AliasOptions): (target: object, key: string) => void;
 export function alias(

--- a/warp-drive-packages/schema-dsl/src/fields/array.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/array.ts
@@ -55,6 +55,7 @@ export interface ArrayFieldOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function array(target: object, key: string): void;
 export function array(options: ArrayFieldOptions): (target: object, key: string) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/attribute.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/attribute.ts
@@ -55,6 +55,7 @@ export interface AttributeOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function attribute(target: object, key: string): void;
 export function attribute(options: AttributeOptions): (target: object, key: string) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/belongs-to.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/belongs-to.ts
@@ -93,6 +93,7 @@ export interface BelongsToOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function belongsTo(options: BelongsToOptions): (target: object, key: string) => void;
 export function belongsTo(

--- a/warp-drive-packages/schema-dsl/src/fields/createonly.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/createonly.ts
@@ -7,6 +7,7 @@
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function createonly(target: object, key: string): void;
 export function createonly(

--- a/warp-drive-packages/schema-dsl/src/fields/derived.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/derived.ts
@@ -56,6 +56,7 @@ export interface DerivedOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function derived(options: DerivedOptions): (target: object, key: string) => void;
 export function derived(

--- a/warp-drive-packages/schema-dsl/src/fields/editonly.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/editonly.ts
@@ -7,6 +7,7 @@
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function editonly(target: object, key: string): void;
 export function editonly(

--- a/warp-drive-packages/schema-dsl/src/fields/field.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/field.ts
@@ -54,6 +54,7 @@ export interface FieldOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function field(target: object, key: string): void;
 export function field(options: FieldOptions): (target: object, key: string) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/has-many.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/has-many.ts
@@ -93,6 +93,7 @@ export interface HasManyOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function hasMany(options: HasManyOptions): (target: object, key: string) => void;
 export function hasMany(

--- a/warp-drive-packages/schema-dsl/src/fields/hash.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/hash.ts
@@ -47,6 +47,7 @@ export interface HashOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function hash(options: HashOptions): (target: object, key: string) => void;
 export function hash(

--- a/warp-drive-packages/schema-dsl/src/fields/id.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/id.ts
@@ -50,6 +50,7 @@ export interface IdOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function id(target: object, key: string): void;
 export function id(options: IdOptions): (target: object, key: string) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/local.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/local.ts
@@ -49,6 +49,7 @@ export interface LocalOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function local(target: object, key: string): void;
 export function local(options: LocalOptions): (target: object, key: string) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/object.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/object.ts
@@ -56,6 +56,7 @@ export interface ObjectFieldOptions {
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function object(target: object, key: string): void;
 export function object(options: ObjectFieldOptions): (target: object, key: string) => void;

--- a/warp-drive-packages/schema-dsl/src/fields/optional.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/optional.ts
@@ -7,6 +7,7 @@
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function optional(target: object, key: string): void;
 export function optional(

--- a/warp-drive-packages/schema-dsl/src/fields/readonly.ts
+++ b/warp-drive-packages/schema-dsl/src/fields/readonly.ts
@@ -7,6 +7,7 @@
  *
  * @since 5.9.0
  * @public
+ * @decorator
  */
 export function readonly(target: object, key: string): void;
 export function readonly(


### PR DESCRIPTION
## Summary
- Add `@decorator` and `@classDecorator` as recognized TSDoc modifier tags, marking a schema-dsl export as a field-level vs. class-level decorator.
- Add a small TypeDoc plugin (`docs-viewer/typedoc-plugins/decorator-groups.mjs`) that maps those tags onto a synthesized `@group` tag, so generated docs split schema-dsl's flat `Functions` list into "Field Decorators" and "Class Decorators" sections. `@category` still sub-divides within each group when present, via TypeDoc's existing behavior — no changes needed there.
- Tag all 19 exported schema-dsl decorators accordingly (4 class decorators: `Resource`, `ObjectSchema`, `Trait`, `trait`; 15 field decorators: `field`, `id`, `local`, `hash`, `object`, `array`, `derived`, `alias`, `attribute`, `belongsTo`, `hasMany`, `readonly`, `optional`, `createonly`, `editonly`).

## Test plan
- [x] Ran `typedoc` directly against `warp-drive-packages/schema-dsl` with the updated config/plugin and confirmed the generated markdown renders `## Class Decorators` and `## Field Decorators` headings instead of a single `## Functions` list.
- [ ] CI docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)