### PR TITLE
fix(docs-viewer): repair api doc source links and edit-this-page links

### DIFF
--- a/docs-viewer/docs.warp-drive.io/.vitepress/config.mts
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/config.mts
@@ -215,7 +215,11 @@ export default withPwa(
       ],
 
       editLink: {
-        pattern: 'https://github.com/warp-drive-data/warp-drive/edit/main/:path',
+        // API doc pages are generated from TS source elsewhere in the repo, so their
+        // "edit" target should be the original source file, not the generated markdown
+        // in api/. postProcessApiDocs() stamps that path into frontmatter as `editSource`.
+        pattern: (page) =>
+          `https://github.com/warp-drive-data/warp-drive/edit/main/${page.frontmatter.editSource ?? page.filePath}`,
       },
 
       search: {

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -499,11 +499,20 @@ function cleanSidebarItems(items: SidebarItem[], isPrimitive = false): SidebarIt
   return newItems.concat(submodules);
 }
 
-const DOC_FRONTMATTER = `---
+// Matches the first "Defined in: <path>:<line>" typedoc emits for a page (either a plain
+// path, or a markdown link `[path:line](url)` when a source link could be resolved), so we
+// can point the "Edit this page" link at the original source instead of the generated .md.
+const DEFINED_IN_PATTERN = /^Defined in: (?:\[([^:\]]+):\d+\]|([^:\n]+):\d+)/m;
+
+function buildFrontmatter(content: string): string {
+  const match = DEFINED_IN_PATTERN.exec(content);
+  const editSource = match?.[1] ?? match?.[2];
+  return `---
 outline:
-  level: [2, 3]
+  level: [2, 3]${editSource ? `\neditSource: ${editSource}` : ''}
 ---
 `;
+}
 const ApiDocumentation = `# API Docs\n\n`;
 
 const TYPE_DIRS = new Set(['classes', 'functions', 'interfaces', 'type-aliases', 'variables', 'enumerations']);
@@ -589,7 +598,7 @@ export async function postProcessApiDocs() {
     }
 
     // insert frontmatter
-    newContent = DOC_FRONTMATTER + newContent;
+    newContent = buildFrontmatter(newContent) + newContent;
 
     // if the content has a modules list, we remove it
     if (newContent.includes('## Modules')) {

--- a/docs-viewer/typedoc-plugins/source-links.mjs
+++ b/docs-viewer/typedoc-plugins/source-links.mjs
@@ -1,0 +1,32 @@
+import { execFileSync } from 'node:child_process';
+import { relative } from 'node:path';
+import { Converter } from 'typedoc';
+
+const gitRevision = execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' }).trim();
+const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf-8' }).trim();
+
+function toSourceUrl(fullFileName, line) {
+  const relPath = relative(repoRoot, fullFileName).split('\\').join('/');
+  return `https://github.com/warp-drive-data/warp-drive/blob/${gitRevision}/${relPath}#L${line}`;
+}
+
+/**
+ * typedoc's built-in git detection considers a repository valid only when `.git` is a
+ * directory (via `fs.stat(...).isDirectory()`), so it silently produces no `source.url`
+ * (no error, just a plain-text "Defined in" with no link) when docs are generated from a
+ * git worktree, where `.git` is a file pointing at the real gitdir elsewhere. We can't fix
+ * that detection from a plugin, so instead we fill in any `source.url` it left unset,
+ * computing the same GitHub blob link ourselves via the `git` CLI, which resolves
+ * worktrees fine. This runs after typedoc's own resolve step so it only backfills gaps
+ * rather than fighting the normal (non-worktree) path.
+ */
+export function load(app) {
+  app.converter.on(Converter.EVENT_RESOLVE_END, (context) => {
+    for (const id in context.project.reflections) {
+      const refl = context.project.reflections[id];
+      for (const source of refl.sources ?? []) {
+        source.url ??= toSourceUrl(source.fullFileName, source.line);
+      }
+    }
+  });
+}

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -78,6 +78,7 @@ const config = {
     import.meta.resolve('typedoc-plugin-markdown').slice(7),
     import.meta.resolve('typedoc-vitepress-theme').slice(7),
     import.meta.resolve('typedoc-plugin-mdn-links').slice(7),
+    new URL('./typedoc-plugins/source-links.mjs', import.meta.url).pathname,
   ],
   out: './tmp/api',
   sidebar: {


### PR DESCRIPTION
## Summary
- "Defined in" links on generated API doc pages (e.g. `/api/@warp-drive/core/variables/Fetch`) rendered as plain text instead of clickable GitHub links whenever docs were generated from a git worktree. typedoc's built-in git detection checks `fs.stat('.git').isDirectory()`, which is false for a worktree (where `.git` is a file pointing at the real gitdir), so it silently produced no `source.url` for every reflection. Added `docs-viewer/typedoc-plugins/source-links.mjs`, a small typedoc plugin that backfills any missing `source.url` after typedoc's own resolve step, computing the GitHub blob link via the `git` CLI directly (which resolves worktrees fine) instead of typedoc's fragile directory sniffing.
- "Edit this page" on API doc pages pointed at the generated markdown file under `api/` (e.g. `.../edit/main/api/@warp-drive/core/variables/Fetch.md`) instead of the TS source it was generated from. `postProcessApiDocs()` now extracts the source path from the page's own "Defined in" line and stamps it into frontmatter as `editSource`; the vitepress `editLink.pattern` is now a function that uses it when present, falling back to the page's own path otherwise (unchanged behavior for guides/non-API pages).

## Test plan
- [x] Regenerated typedoc output (`./node_modules/.bin/typedoc`) and confirmed all 2275 "Defined in" occurrences across the generated docs are now markdown links (previously 0 were), with correct repo-relative paths and no change to module/page naming (verified via before/after diff of generated file paths, e.g. `active-record` module path unchanged).
- [x] Ran `postProcessApiDocs()` and confirmed every page with a "Defined in" line gets a matching `editSource` frontmatter field (750 pages checked, none missing).
- [x] Ran a full `vitepress build` and inspected the built HTML for `/api/@warp-drive/core/variables/Fetch`:
  - `Defined in` → `https://github.com/warp-drive-data/warp-drive/blob/<sha>/warp-drive-packages/core/src/request/-private/fetch.ts#L133`
  - `Edit this page` → `https://github.com/warp-drive-data/warp-drive/edit/main/warp-drive-packages/core/src/request/-private/fetch.ts`
- [x] Confirmed a regular guide page (`guides/contributing/become-a-contributor`) still gets its normal edit link, unaffected by the change.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)