### PR TITLE
docs: show @since as a badge instead of a body section

### DIFF
--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
@@ -18,7 +18,6 @@ defineProps<{
   font-weight: 600;
   line-height: 22px;
   padding: 0 10px;
-  vertical-align: middle;
   background: #ddd6fe;
   color: #5b21b6;
 }

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
@@ -18,7 +18,7 @@ defineProps<{
   font-weight: 600;
   line-height: 22px;
   padding: 0 10px;
-  transform: translateY(-2px);
+  vertical-align: middle;
   background: #ddd6fe;
   color: #5b21b6;
 }

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+defineProps<{
+  kind: string;
+}>();
+</script>
+
+<template>
+  <span class="kind-badge">{{ kind }}</span>
+</template>
+
+<style scoped>
+.kind-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 12px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 22px;
+  padding: 0 10px;
+  transform: translateY(-2px);
+  background: #ddd6fe;
+  color: #5b21b6;
+}
+
+.dark .kind-badge {
+  background: #5b21b6;
+  color: #ede9fe;
+}
+</style>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+defineProps<{
+  version: string;
+}>();
+</script>
+
+<template>
+  <span class="since-badge">
+    <span class="since-badge-label">since</span>
+    <span class="since-badge-version">v{{ version }}</span>
+  </span>
+</template>
+
+<style scoped>
+.since-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 22px;
+  border: 1px solid transparent;
+  transform: translateY(-2px);
+}
+
+/* light mode */
+.since-badge-label {
+  background: #fde68a;
+  color: #92400e;
+  padding: 0 8px;
+  font-weight: 600;
+}
+
+.since-badge-version {
+  background: #d3e1f5;
+  color: #374559;
+  padding: 0 10px;
+}
+
+/* dark mode */
+.dark .since-badge-label {
+  background: #92400e;
+  color: #fef3c7;
+}
+
+.dark .since-badge-version {
+  background: #334155;
+  color: #cbd5e1;
+}
+</style>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
@@ -22,7 +22,7 @@ defineProps<{
   font-weight: 500;
   line-height: 22px;
   border: 1px solid transparent;
-  transform: translateY(-2px);
+  vertical-align: middle;
 }
 
 /* light mode */

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
@@ -22,7 +22,6 @@ defineProps<{
   font-weight: 500;
   line-height: 22px;
   border: 1px solid transparent;
-  vertical-align: middle;
 }
 
 /* light mode */

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/custom.css
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/custom.css
@@ -35,3 +35,16 @@ body {
 .vp-doc p {
   line-height: 20px;
 }
+
+/*
+ * A heading's badges (<KindBadge>, <SinceBadge>) are much smaller than the heading text they sit
+ * inline with. `vertical-align: middle` on the badge itself centers against the surrounding
+ * text's x-height, which is fine for similarly-sized text but visibly rides high next to a large
+ * heading. Making the heading a flex row instead centers every child (badges and text) by actual
+ * box height, which holds regardless of the size mismatch.
+ */
+.vp-doc :where(h1, h2, h3, h4, h5, h6):has(.kind-badge, .since-badge) {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/index.js
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/index.js
@@ -3,11 +3,13 @@ import 'virtual:group-icons.css';
 import './custom.css';
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client';
 import ModuleBadge from './ModuleBadge.vue';
+import SinceBadge from './SinceBadge.vue';
 
 export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app);
     app.component('ModuleBadge', ModuleBadge);
+    app.component('SinceBadge', SinceBadge);
   },
 };

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/index.js
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/index.js
@@ -4,6 +4,7 @@ import './custom.css';
 import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client';
 import ModuleBadge from './ModuleBadge.vue';
 import SinceBadge from './SinceBadge.vue';
+import KindBadge from './KindBadge.vue';
 
 export default {
   extends: DefaultTheme,
@@ -11,5 +12,6 @@ export default {
     enhanceAppWithTabs(app);
     app.component('ModuleBadge', ModuleBadge);
     app.component('SinceBadge', SinceBadge);
+    app.component('KindBadge', KindBadge);
   },
 };

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -536,6 +536,99 @@ function fileToImportPath(file: string): string {
   return `${packageName}/${cleanSubPath.join('/')}`;
 }
 
+const HEADING_RE = /^(#{1,6}) (.*)$/;
+
+function sinceBadgeMarkup(version: string): string {
+  return `<SinceBadge version="${version.replace(/"/g, '&quot;')}" />`;
+}
+
+/**
+ * TypeDoc renders each `@since` tag as its own `#### Since` section beneath the heading of the
+ * thing it documents (the page's own H1, or a nested member heading for e.g. a class method).
+ * This removes every such section from the body and turns its version into a `<SinceBadge>`
+ * appended to the heading it described, so `@since` reads as a badge next to the name of the
+ * documented thing rather than as a separate body section.
+ */
+function extractSinceBadges(content: string): { content: string; moduleSince: string | null } {
+  const lines = content.split('\n');
+  const headings: { index: number; level: number; text: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEADING_RE.exec(lines[i]);
+    if (m) headings.push({ index: i, level: m[1].length, text: m[2].trim() });
+  }
+
+  const linesToRemove = new Set<number>();
+  const badgesByHeadingLine = new Map<number, string[]>();
+  let moduleSince: string | null = null;
+
+  for (let hi = 0; hi < headings.length; hi++) {
+    const heading = headings[hi];
+    if (heading.text !== 'Since') continue;
+
+    const blockEnd = hi + 1 < headings.length ? headings[hi + 1].index : lines.length;
+    // The tag's own content is just its first paragraph — stop at the first blank line rather
+    // than the next heading, so a trailing `***` member separator (or a following tag section
+    // like `#### Deprecated`) isn't swallowed into the version string.
+    let versionStart = heading.index + 1;
+    while (versionStart < blockEnd && lines[versionStart].trim() === '') versionStart++;
+    let versionEnd = versionStart;
+    while (versionEnd < blockEnd && lines[versionEnd].trim() !== '') versionEnd++;
+    // A version is always a single token (e.g. `5.9.0`); a handful of source comments have a
+    // stray unrecognized tag (e.g. a leftover `@class Foo`) immediately after `@since` with no
+    // blank line between them, which TypeDoc folds into the same tag content as a second line —
+    // only the first line is ever the actual version.
+    const version = (lines[versionStart] ?? '').trim();
+
+    let removalEnd = versionEnd;
+    if (removalEnd < blockEnd && lines[removalEnd].trim() === '') removalEnd++;
+    for (let li = heading.index; li < removalEnd; li++) linesToRemove.add(li);
+
+    let parent: (typeof headings)[number] | null = null;
+    for (let pi = hi - 1; pi >= 0; pi--) {
+      if (headings[pi].level < heading.level) {
+        parent = headings[pi];
+        break;
+      }
+    }
+
+    if (!parent) {
+      // No enclosing heading (e.g. a module's own `@since`, rendered before any heading) —
+      // let the caller attach this to the module badge instead.
+      moduleSince = version;
+      continue;
+    }
+
+    const existing = badgesByHeadingLine.get(parent.index) ?? [];
+    existing.push(sinceBadgeMarkup(version));
+    badgesByHeadingLine.set(parent.index, existing);
+  }
+
+  for (const [lineIndex, badges] of badgesByHeadingLine) {
+    lines[lineIndex] = `${lines[lineIndex]} ${badges.join(' ')}`;
+  }
+
+  const kept = lines
+    .filter((_, i) => !linesToRemove.has(i))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n');
+
+  return { content: kept, moduleSince };
+}
+
+/**
+ * Removes the page's first H1 (and the blank line before it), returning any `<SinceBadge>`
+ * that had been attached to it so the caller can relocate it (module pages show that badge next
+ * to `<ModuleBadge>` instead of a redundant title).
+ */
+function stripH1(content: string): { content: string; badges: string } {
+  let badges = '';
+  const next = content.replace(/\n\n# [^\n]*?((?:\s*<SinceBadge[^\n]*\/>)*)\n\n?/, (_match, b: string) => {
+    badges = b.trim();
+    return '\n\n';
+  });
+  return { content: next, badges };
+}
+
 export async function postProcessApiDocs() {
   const dir = path.join(__dirname, '../tmp/api');
   const outDir = path.join(__dirname, '../docs.warp-drive.io/api');
@@ -589,8 +682,22 @@ export async function postProcessApiDocs() {
     const importPath = fileToImportPath(file);
     newContent = newContent.replace(/^[^\n]+\n\n/, `<ModuleBadge path="${importPath}" />\n\n`);
 
-    // Remove the first H1 heading and the blank line before it
-    newContent = newContent.replace(/\n\n# [^\n]+\n\n?/, '\n\n');
+    // Turn every `#### Since` section into a `<SinceBadge>` next to the heading it describes
+    const sinceResult = extractSinceBadges(newContent);
+    newContent = sinceResult.content;
+
+    if (path.basename(file) === 'index.md') {
+      // Module page: the module name is already shown via <ModuleBadge>, so drop the redundant
+      // H1 title, relocating any `@since` badge it carried onto the <ModuleBadge> line.
+      const { content: withoutH1, badges } = stripH1(newContent);
+      newContent = withoutH1;
+      const since = badges || (sinceResult.moduleSince ? sinceBadgeMarkup(sinceResult.moduleSince) : '');
+      if (since) {
+        newContent = newContent.replace(/^(<ModuleBadge [^\n]+\/>)/, `$1 ${since}`);
+      }
+    }
+    // Non-module pages keep their H1 so the page shows the name of the thing being documented,
+    // with any `<SinceBadge>` appended right next to it.
 
     // if the file is in @warp-drive/legacy add the legacy badge
     if (file.includes('@warp-drive/legacy')) {

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -637,12 +637,7 @@ function extractSinceBadges(content: string): { content: string; moduleSince: st
 // Structural groupings typedoc-plugin-markdown inserts between an overloaded function/method's
 // H1 and its per-overload content — not real nested members, so a `@badge` tag under one of
 // these (once per overload) still counts as belonging to the page's own top-level symbol.
-const PASSTHROUGH_HEADINGS = new Set([
-  'Call Signature',
-  'Constructor Signature',
-  'Get Signature',
-  'Set Signature',
-]);
+const PASSTHROUGH_HEADINGS = new Set(['Call Signature', 'Constructor Signature', 'Get Signature', 'Set Signature']);
 
 /**
  * Reads an optional single-line tag (rendered as e.g. `## Badge` / `## Title`) on the page's own

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -777,7 +777,7 @@ export async function postProcessApiDocs() {
     const importPath = fileToImportPath(file);
     newContent = newContent.replace(/^[^\n]+\n\n/, `<ModuleBadge path="${importPath}" />\n\n`);
 
-    // On a member's own page, show its kind (Function, Class, ...) as a <KindBadge> next to its
+    // On a member's own page, show its kind (Function, Class, ...) as a <KindBadge> before its
     // name instead of TypeDoc's "{Kind}: " title prefix (dropped via pageTitleTemplates in
     // typedoc.config.mjs). A `@badge <Label>` tag on that symbol overrides the label shown (e.g.
     // a class that's conceptually a "Component", a variable that's a "Handler").
@@ -786,7 +786,7 @@ export async function postProcessApiDocs() {
       const kindOverride = extractKindOverride(newContent);
       newContent = kindOverride.content;
       const kind = kindOverride.kind ?? defaultKind;
-      newContent = newContent.replace(/^# ([^\n]+)$/m, (heading) => `${heading} ${kindBadgeMarkup(kind)}`);
+      newContent = newContent.replace(/^# ([^\n]+)$/m, (_match, title: string) => `# ${kindBadgeMarkup(kind)} ${title}`);
     }
 
     // Turn every `#### Since` section into a `<SinceBadge>` next to the heading it describes

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -634,6 +634,82 @@ function extractSinceBadges(content: string): { content: string; moduleSince: st
   return { content: kept, moduleSince };
 }
 
+// Structural groupings typedoc-plugin-markdown inserts between an overloaded function/method's
+// H1 and its per-overload content — not real nested members, so a `@badge` tag under one of
+// these (once per overload) still counts as belonging to the page's own top-level symbol.
+const PASSTHROUGH_HEADINGS = new Set([
+  'Call Signature',
+  'Constructor Signature',
+  'Get Signature',
+  'Set Signature',
+]);
+
+/**
+ * Reads an optional `@badge <Label>` tag on the page's own top-level symbol, letting a doc
+ * author override the `<KindBadge>` label — e.g. a class that's conceptually a "Component", a
+ * variable that's really a "Handler", a function that's a query "Builder" — and strips that tag's
+ * section(s) from the body. Only a `@badge` that belongs to the page's own symbol counts: walking
+ * up from it must reach the H1 without passing through anything other than the structural
+ * signature groupings above — a real nested member (e.g. a class's own method) blocks it, since
+ * `<KindBadge>` only ever appears once, next to the page's own H1.
+ */
+function extractKindOverride(content: string): { content: string; kind: string | null } {
+  const lines = content.split('\n');
+  const headings: { index: number; level: number; text: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEADING_RE.exec(lines[i]);
+    if (m) headings.push({ index: i, level: m[1].length, text: m[2].trim() });
+  }
+
+  const linesToRemove = new Set<number>();
+  let kind: string | null = null;
+
+  for (let hi = 0; hi < headings.length; hi++) {
+    const heading = headings[hi];
+    if (heading.text !== 'Badge') continue;
+
+    let reachedH1 = false;
+    let idx = hi;
+    while (true) {
+      let parentIdx = -1;
+      for (let pi = idx - 1; pi >= 0; pi--) {
+        if (headings[pi].level < headings[idx].level) {
+          parentIdx = pi;
+          break;
+        }
+      }
+      if (parentIdx === -1) break;
+      if (headings[parentIdx].level === 1) {
+        reachedH1 = true;
+        break;
+      }
+      if (!PASSTHROUGH_HEADINGS.has(headings[parentIdx].text)) break;
+      idx = parentIdx;
+    }
+    if (!reachedH1) continue;
+
+    const blockEnd = hi + 1 < headings.length ? headings[hi + 1].index : lines.length;
+    let versionStart = heading.index + 1;
+    while (versionStart < blockEnd && lines[versionStart].trim() === '') versionStart++;
+    const value = (lines[versionStart] ?? '').trim();
+    if (!value) continue;
+
+    let removalEnd = versionStart + 1;
+    while (removalEnd < blockEnd && lines[removalEnd].trim() !== '') removalEnd++;
+    if (removalEnd < blockEnd && lines[removalEnd].trim() === '') removalEnd++;
+    for (let li = heading.index; li < removalEnd; li++) linesToRemove.add(li);
+
+    kind ??= value;
+  }
+
+  const kept = lines
+    .filter((_, i) => !linesToRemove.has(i))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n');
+
+  return { content: kept, kind };
+}
+
 /**
  * Removes the page's first H1 (and the blank line before it), returning any `<SinceBadge>`
  * that had been attached to it so the caller can relocate it (module pages show that badge next
@@ -703,9 +779,13 @@ export async function postProcessApiDocs() {
 
     // On a member's own page, show its kind (Function, Class, ...) as a <KindBadge> next to its
     // name instead of TypeDoc's "{Kind}: " title prefix (dropped via pageTitleTemplates in
-    // typedoc.config.mjs)
-    const kind = fileKindLabel(file);
-    if (kind) {
+    // typedoc.config.mjs). A `@badge <Label>` tag on that symbol overrides the label shown (e.g.
+    // a class that's conceptually a "Component", a variable that's a "Handler").
+    const defaultKind = fileKindLabel(file);
+    if (defaultKind) {
+      const kindOverride = extractKindOverride(newContent);
+      newContent = kindOverride.content;
+      const kind = kindOverride.kind ?? defaultKind;
       newContent = newContent.replace(/^# ([^\n]+)$/m, (heading) => `${heading} ${kindBadgeMarkup(kind)}`);
     }
 

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -645,15 +645,13 @@ const PASSTHROUGH_HEADINGS = new Set([
 ]);
 
 /**
- * Reads an optional `@badge <Label>` tag on the page's own top-level symbol, letting a doc
- * author override the `<KindBadge>` label — e.g. a class that's conceptually a "Component", a
- * variable that's really a "Handler", a function that's a query "Builder" — and strips that tag's
- * section(s) from the body. Only a `@badge` that belongs to the page's own symbol counts: walking
- * up from it must reach the H1 without passing through anything other than the structural
- * signature groupings above — a real nested member (e.g. a class's own method) blocks it, since
- * `<KindBadge>` only ever appears once, next to the page's own H1.
+ * Reads an optional single-line tag (rendered as e.g. `## Badge` / `## Title`) on the page's own
+ * top-level symbol, and strips its section(s) from the body. Only a tag that belongs to the
+ * page's own symbol counts: walking up from it must reach the H1 without passing through
+ * anything other than the structural signature groupings above — a real nested member (e.g. a
+ * class's own method) blocks it, since these tags only ever affect the page's own H1.
  */
-function extractKindOverride(content: string): { content: string; kind: string | null } {
+function extractTopLevelTagValue(content: string, tagText: string): { content: string; value: string | null } {
   const lines = content.split('\n');
   const headings: { index: number; level: number; text: string }[] = [];
   for (let i = 0; i < lines.length; i++) {
@@ -662,11 +660,11 @@ function extractKindOverride(content: string): { content: string; kind: string |
   }
 
   const linesToRemove = new Set<number>();
-  let kind: string | null = null;
+  let value: string | null = null;
 
   for (let hi = 0; hi < headings.length; hi++) {
     const heading = headings[hi];
-    if (heading.text !== 'Badge') continue;
+    if (heading.text !== tagText) continue;
 
     let reachedH1 = false;
     let idx = hi;
@@ -689,17 +687,17 @@ function extractKindOverride(content: string): { content: string; kind: string |
     if (!reachedH1) continue;
 
     const blockEnd = hi + 1 < headings.length ? headings[hi + 1].index : lines.length;
-    let versionStart = heading.index + 1;
-    while (versionStart < blockEnd && lines[versionStart].trim() === '') versionStart++;
-    const value = (lines[versionStart] ?? '').trim();
-    if (!value) continue;
+    let contentStart = heading.index + 1;
+    while (contentStart < blockEnd && lines[contentStart].trim() === '') contentStart++;
+    const foundValue = (lines[contentStart] ?? '').trim();
+    if (!foundValue) continue;
 
-    let removalEnd = versionStart + 1;
+    let removalEnd = contentStart + 1;
     while (removalEnd < blockEnd && lines[removalEnd].trim() !== '') removalEnd++;
     if (removalEnd < blockEnd && lines[removalEnd].trim() === '') removalEnd++;
     for (let li = heading.index; li < removalEnd; li++) linesToRemove.add(li);
 
-    kind ??= value;
+    value ??= foundValue;
   }
 
   const kept = lines
@@ -707,7 +705,14 @@ function extractKindOverride(content: string): { content: string; kind: string |
     .join('\n')
     .replace(/\n{3,}/g, '\n\n');
 
-  return { content: kept, kind };
+  return { content: kept, value };
+}
+
+/** Escapes `<`/`>` so literal component-like syntax (e.g. `<Await />`) renders as text rather
+ * than being parsed as an HTML/Vue tag — matches how TypeDoc itself escapes generics in headings
+ * (e.g. `Await\<T, E\>`). */
+function escapeHeadingText(text: string): string {
+  return text.replace(/</g, '\\<').replace(/>/g, '\\>');
 }
 
 /**
@@ -779,14 +784,20 @@ export async function postProcessApiDocs() {
 
     // On a member's own page, show its kind (Function, Class, ...) as a <KindBadge> before its
     // name instead of TypeDoc's "{Kind}: " title prefix (dropped via pageTitleTemplates in
-    // typedoc.config.mjs). A `@badge <Label>` tag on that symbol overrides the label shown (e.g.
-    // a class that's conceptually a "Component", a variable that's a "Handler").
+    // typedoc.config.mjs). A `@badge <Label>` tag overrides the label shown (e.g. a class that's
+    // conceptually a "Component", a variable that's a "Handler"). A `@title <Text>` tag overrides
+    // the name itself (e.g. showing a component's name as `<Await />`).
     const defaultKind = fileKindLabel(file);
     if (defaultKind) {
-      const kindOverride = extractKindOverride(newContent);
+      const kindOverride = extractTopLevelTagValue(newContent, 'Badge');
       newContent = kindOverride.content;
-      const kind = kindOverride.kind ?? defaultKind;
-      newContent = newContent.replace(/^# ([^\n]+)$/m, (_match, title: string) => `# ${kindBadgeMarkup(kind)} ${title}`);
+      const titleOverride = extractTopLevelTagValue(newContent, 'Title');
+      newContent = titleOverride.content;
+      const kind = kindOverride.value ?? defaultKind;
+      newContent = newContent.replace(/^# ([^\n]+)$/m, (_match, title: string) => {
+        const displayTitle = titleOverride.value ? escapeHeadingText(titleOverride.value) : title;
+        return `# ${kindBadgeMarkup(kind)} ${displayTitle}`;
+      });
     }
 
     // Turn every `#### Since` section into a `<SinceBadge>` next to the heading it describes

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -517,6 +517,25 @@ const ApiDocumentation = `# API Docs\n\n`;
 
 const TYPE_DIRS = new Set(['classes', 'functions', 'interfaces', 'type-aliases', 'variables', 'enumerations']);
 
+const KIND_LABELS: Record<string, string> = {
+  classes: 'Class',
+  functions: 'Function',
+  interfaces: 'Interface',
+  'type-aliases': 'Type Alias',
+  variables: 'Variable',
+  enumerations: 'Enumeration',
+};
+
+/** The reflection kind (Function, Class, ...) for a member's own page, derived from its output directory. */
+function fileKindLabel(file: string): string | null {
+  const dir = file.split('/').find((segment) => segment in KIND_LABELS);
+  return dir ? KIND_LABELS[dir] : null;
+}
+
+function kindBadgeMarkup(kind: string): string {
+  return `<KindBadge kind="${kind}" />`;
+}
+
 function fileToImportPath(file: string): string {
   // e.g. "@warp-drive/core/build-config/debugging.md" → "@warp-drive/core/build-config/debugging"
   // e.g. "@warp-drive/core/classes/ConfiguredStore.md" → "@warp-drive/core"
@@ -681,6 +700,14 @@ export async function postProcessApiDocs() {
     // Replace the entire breadcrumb line with the badge (no subpath links)
     const importPath = fileToImportPath(file);
     newContent = newContent.replace(/^[^\n]+\n\n/, `<ModuleBadge path="${importPath}" />\n\n`);
+
+    // On a member's own page, show its kind (Function, Class, ...) as a <KindBadge> next to its
+    // name instead of TypeDoc's "{Kind}: " title prefix (dropped via pageTitleTemplates in
+    // typedoc.config.mjs)
+    const kind = fileKindLabel(file);
+    if (kind) {
+      newContent = newContent.replace(/^# ([^\n]+)$/m, (heading) => `${heading} ${kindBadgeMarkup(kind)}`);
+    }
 
     // Turn every `#### Since` section into a `<SinceBadge>` next to the heading it describes
     const sinceResult = extractSinceBadges(newContent);

--- a/docs-viewer/src/typedoc-since-plugin.mjs
+++ b/docs-viewer/src/typedoc-since-plugin.mjs
@@ -1,0 +1,58 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { Converter, Renderer, ReflectionKind } from 'typedoc';
+
+/**
+ * TypeDoc's `packages` entry point strategy fully converts each package in isolation, then
+ * serializes that project to plain JSON and rebuilds fresh reflection objects from it to merge
+ * all packages together (see `_convertPackages` -> `projectToObject` / `reviveProjects` in
+ * typedoc's dist). That round-trip drops the package's own `@module` doc comment down to a
+ * plain-text `readme` blob, discarding every block tag (`@since` included) along the way — there
+ * is no structured place left for `@since` to land by the time rendering happens.
+ *
+ * This plugin sidesteps that entirely: it reads each package's own `@since` straight out of its
+ * entry file's `@module` comment (a couple of regexes, not TypeDoc's comment parser) while that
+ * package is being converted, keeps it in memory here, and reattaches it as a synthetic `## Since`
+ * section on the package's readme right before rendering — where our post-processing in
+ * site-utils.ts already knows how to turn a `## Since` section into a `<SinceBadge>`.
+ */
+
+const sinceByPackageName = new Map();
+
+// Only the package's own root entry file (`<package>/src/index.ts`) maps cleanly to a single
+// top-level Module reflection named after the npm package; other entry files become submodules
+// whose final reflection name doesn't follow a fixed convention, so they're left for later.
+function readModuleSince(entryFile) {
+  if (basename(entryFile) !== 'index.ts') return;
+
+  const packageDir = dirname(dirname(entryFile));
+  const packageJsonPath = join(packageDir, 'package.json');
+  if (!existsSync(packageJsonPath)) return;
+
+  const source = readFileSync(entryFile, 'utf-8');
+  const leadingComment = /^\/\*\*([\s\S]*?)\*\//.exec(source);
+  if (!leadingComment || !/@module\b/.test(leadingComment[1])) return;
+
+  const sinceMatch = /@since\s+(\S+)/.exec(leadingComment[1]);
+  if (!sinceMatch) return;
+
+  const { name } = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  sinceByPackageName.set(name, sinceMatch[1]);
+}
+
+export function load(app) {
+  app.converter.on(Converter.EVENT_BEGIN, () => {
+    for (const entryPoint of app.options.getValue('entryPoints')) {
+      readModuleSince(entryPoint);
+    }
+  });
+
+  app.renderer.on(Renderer.EVENT_BEGIN, (event) => {
+    for (const reflection of event.project.getReflectionsByKind(ReflectionKind.Module)) {
+      const since = sinceByPackageName.get(reflection.name);
+      if (since && Array.isArray(reflection.readme)) {
+        reflection.readme.push({ kind: 'text', text: `\n\n## Since\n\n${since}\n` });
+      }
+    }
+  });
+}

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -45,6 +45,9 @@ const config = {
     // inheritNone: true,
     useCodeBlocks: true,
     hidePageTitle: false,
+    // Drop the "{kind}: " prefix (e.g. "Function: ") from member page H1s — the kind is shown
+    // as a <KindBadge> next to the name instead (see postProcessApiDocs in site-utils.ts).
+    pageTitleTemplates: { member: '{keyword} {name}' },
     groupReferencesByType: true,
     alwaysCreateEntryPointModule: true,
     groupOrder: [
@@ -98,6 +101,7 @@ const config = {
   excludeExternals: true,
   useCodeBlocks: true,
   hidePageTitle: false,
+  pageTitleTemplates: { member: '{keyword} {name}' },
   // typeAliasPropertiesFormat: 'htmlTable',
   // inheritNone: true,
 };

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -64,7 +64,7 @@ const config = {
       'Type Aliases',
       'Modules',
     ],
-    blockTags: [...OptionDefaults.blockTags, '@deprecated', '@until', '@since', '@id', '@badge'],
+    blockTags: [...OptionDefaults.blockTags, '@deprecated', '@until', '@since', '@id', '@badge', '@title'],
     modifierTags: [
       ...OptionDefaults.modifierTags,
       '@noInheritDoc',

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -76,6 +76,7 @@ const config = {
     ],
   },
   plugin: [
+    import.meta.resolve('./src/typedoc-since-plugin.mjs').slice(7),
     import.meta.resolve('typedoc-plugin-no-inherit').slice(7),
     import.meta.resolve('typedoc-plugin-markdown').slice(7),
     import.meta.resolve('typedoc-vitepress-theme').slice(7),

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -64,7 +64,7 @@ const config = {
       'Type Aliases',
       'Modules',
     ],
-    blockTags: [...OptionDefaults.blockTags, '@deprecated', '@until', '@since', '@id'],
+    blockTags: [...OptionDefaults.blockTags, '@deprecated', '@until', '@since', '@id', '@badge'],
     modifierTags: [
       ...OptionDefaults.modifierTags,
       '@noInheritDoc',

--- a/guides/contributing/writing-documentation/writing-api-docs.md
+++ b/guides/contributing/writing-documentation/writing-api-docs.md
@@ -264,6 +264,12 @@ we would do the following in `packages/core-types/src/index.ts`
 
 ### Always specify `@since` on non-type public APIs
 
+`@since` renders as a small badge rather than a body section, so it's
+always visible next to the name of the thing it describes without
+taking up page space.
+
+On a function, class, interface, variable, or type alias, it shows up
+right next to that page's own name:
 
 ```ts
 /**
@@ -271,6 +277,121 @@ we would do the following in `packages/core-types/src/index.ts`
  * @public
 */
 ```
+
+On a package's `@module` doc comment, it shows up next to that
+package's `<ModuleBadge>` on the module's index page instead:
+
+```ts
+/**
+ * This package provides essential types and symbols used
+ * by all the other WarpDrive packages.
+ *
+ * @module
+ * @since 5.9.0
+ */
+```
+
+> [!NOTE]
+> Module-level `@since` is currently only picked up from a package's
+> own root entry file (e.g. `packages/core-types/src/index.ts`), not
+> from a subpackage's own `@module` comment (e.g.
+> `core-types/src/cache.ts`). Put `@since` on a subpackage's exported
+> members instead until this is extended.
+
+### Overriding the displayed kind and name with `@badge` and `@title`
+
+Every function, class, interface, variable, type alias, and enumeration
+gets its own page whose heading shows its TypeScript kind (`Function`,
+`Class`, `Interface`, `Variable`, `Type Alias`, `Enumeration`) as a
+badge next to its name. That default is accurate but not always the
+most useful label for a reader — a class can be a component, a plain
+object can be a request handler, a function can be a request builder.
+
+Use `@badge <Label>` to override the kind badge with a more meaningful
+conceptual label:
+
+```ts
+/**
+ * The `<Await />` component allow you to utilize reactive control flow
+ * for asynchronous states in your application.
+ *
+ * @badge Component
+ */
+export class Await<T, E> extends Component<AwaitSignature<T, E>> {}
+```
+
+```ts
+/**
+ * A basic Fetch Handler which converts a request into a
+ * `fetch` call presuming the response to be `json`.
+ *
+ * @badge Handler
+ */
+const Fetch = { ... };
+```
+
+Use `@title <Text>` to override the name shown in the page heading
+itself, when the raw name (or its generic signature) isn't the most
+legible way to present it — for instance showing a component by its
+usage syntax instead of its class signature:
+
+```ts
+/**
+ * @badge Component
+ * @title <Await />
+ */
+export class Await<T, E> extends Component<AwaitSignature<T, E>> {}
+```
+
+renders as **`<Await />`** instead of **`Await<T, E>`**. Write the
+title exactly as it should be read — no escaping needed, even for
+angle brackets.
+
+Both tags only affect the page's own top-level symbol; they have no
+effect when used on a nested class member, since only the page's own
+heading shows these badges.
+
+### Grouping related members with `@category`
+
+`@category` is a standard TypeDoc tag (not specific to this repo) that
+groups related children — a class's methods/properties, or a module's
+top-level exports — into named sections instead of TypeDoc's default
+kind-based grouping (all methods together, then all properties, etc.).
+
+Tag each member with the category it belongs to:
+
+```ts
+class JSONAPICache {
+  /**
+   * @category Cache Management
+   */
+  mutate(mutation: Mutation): void {}
+
+  /**
+   * @category Cache Forking
+   */
+  fork(): Promise<JSONAPICache> {}
+}
+```
+
+which renders as `## Cache Management` and `## Cache Forking` sections
+on `JSONAPICache`'s page, each listing the members tagged into it.
+Optionally add `@categoryDescription <Name>` to the containing class,
+interface, or module's own doc comment to show a short blurb under
+that section's heading:
+
+```ts
+/**
+ * @categoryDescription Cache Management
+ * APIs for primary cache management functionality
+ */
+class JSONAPICache {}
+```
+
+Keep category names short, human-scannable topic phrases consistent
+with existing ones in the same package (e.g. `Resource Data`,
+`Resource Lifecycle`, `Cache Management`) rather than inventing a new
+one-off name per symbol.
 
 ### Use `@hideconstructor` for classes that aren't directly instantiated by users
 

--- a/warp-drive-packages/core/src/request/-private/fetch.ts
+++ b/warp-drive-packages/core/src/request/-private/fetch.ts
@@ -129,6 +129,7 @@ const ERROR_STATUS_CODE_FOR = new Map([
  * ```
  *
  * @public
+ * @badge Handler
  */
 const Fetch = {
   /**

--- a/warp-drive-packages/ember/src/-private/await.gts
+++ b/warp-drive-packages/ember/src/-private/await.gts
@@ -87,6 +87,7 @@ interface AwaitSignature<T, E = Error | string | object> {
  *
  * @category Components
  * @public
+ * @badge Component
  */
 export class Await<T, E> extends Component<AwaitSignature<T, E>> {
   /**

--- a/warp-drive-packages/ember/src/-private/await.gts
+++ b/warp-drive-packages/ember/src/-private/await.gts
@@ -88,6 +88,7 @@ interface AwaitSignature<T, E = Error | string | object> {
  * @category Components
  * @public
  * @badge Component
+ * @title <Await />
  */
 export class Await<T, E> extends Component<AwaitSignature<T, E>> {
   /**

--- a/warp-drive-packages/schema-dsl/src/index.ts
+++ b/warp-drive-packages/schema-dsl/src/index.ts
@@ -1,6 +1,7 @@
 /**
  * @module
  * @mergeModuleWith <project>
+ * @since 5.9.0
  */
 
 export { ObjectSchema, type ObjectSchemaOptions } from './entities/object-schema.ts';

--- a/warp-drive-packages/utilities/src/-private/json-api/query.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/query.ts
@@ -59,6 +59,7 @@ import { ACCEPT_HEADER_VALUE } from './-utils.ts';
  * ```
  *
  * @public
+ * @badge Builder
  */
 export function query<T extends TypedRecordInstance>(
   type: TypeFromInstance<T>,


### PR DESCRIPTION
## Summary
- `@since` no longer renders as a dedicated `## Since` body section on API doc pages. Instead, it's shown as a `<SinceBadge>` right next to the heading of the thing it describes — the page's H1 for a top-level symbol, or a member's own heading for e.g. a class method.
- Restores the H1 on symbol pages (it was previously stripped entirely by post-processing), so there's a name for the badge to sit next to. Module index pages still drop the H1 (redundant with `<ModuleBadge>`) but move any module-level `@since` badge onto the `<ModuleBadge>` line instead.
- Adds `@since` support for module-level (`@module`) doc comments. This required a small custom TypeDoc plugin (`docs-viewer/src/typedoc-since-plugin.mjs`): TypeDoc's `packages` entry point strategy fully converts each package, then serializes it to plain JSON and rebuilds fresh reflection objects to merge all packages together — that round-trip drops every block tag (not just `@since`) from module-level comments, keeping only the plain-text summary. The plugin reads `@since` directly from each package's entry file instead, and reattaches it before rendering.
- Adds `@since 5.9.0` to schema-dsl's module doc comment as the first real usage of module-level `@since`.

## Test plan
- [x] Ran a full `typedoc` + `postProcessApiDocs()` build across the whole monorepo and spot-checked output: function pages (`schema-dsl/functions/belongsTo.md`), a module index page with its own `@since` (`schema-dsl/index.md`), and a class with many nested per-method `@since` tags (`core/classes/Store.md`).
- [x] Verified no malformed `<SinceBadge>` tags anywhere in the generated output (caught and fixed two edge cases: a version's content accidentally swallowing a trailing `***` member separator, and a pre-existing malformed source comment with an unrecognized `@class` tag folded into `@since`'s content).
- [x] Confirmed `## Since` sections are fully removed and `Deprecated`/`Until` sections and `***` separators are left untouched.
- [ ] Visual check in the browser (`pnpm build` / `pnpm preview` in `docs-viewer`) — worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)