### PR TITLE
docs(schema-dsl): group class decorators under an Entity Decorators category

### DIFF
--- a/warp-drive-packages/schema-dsl/src/entities/compose-trait.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/compose-trait.ts
@@ -41,6 +41,7 @@ import type { AnyConstructor } from '../-private/types.ts';
  * @since 5.9.0
  * @public
  * @classDecorator
+ * @category Entity Decorators
  */
 export function trait(..._traits: AnyConstructor[]): (target: AnyConstructor) => void {
   return function (_target: AnyConstructor): void {};

--- a/warp-drive-packages/schema-dsl/src/entities/object-schema.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/object-schema.ts
@@ -63,6 +63,7 @@ export interface ObjectSchemaOptions {
  * @since 5.9.0
  * @public
  * @classDecorator
+ * @category Entity Decorators
  */
 export function ObjectSchema(target: AnyConstructor): void;
 export function ObjectSchema(type: string, options?: ObjectSchemaOptions): (target: AnyConstructor) => void;

--- a/warp-drive-packages/schema-dsl/src/entities/resource.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/resource.ts
@@ -115,6 +115,7 @@ export interface ResourceOptions {
  * @since 5.9.0
  * @public
  * @classDecorator
+ * @category Entity Decorators
  */
 export function Resource(target: AnyConstructor): void;
 export function Resource(type: string, options?: ResourceOptions): (target: AnyConstructor) => void;

--- a/warp-drive-packages/schema-dsl/src/entities/trait.ts
+++ b/warp-drive-packages/schema-dsl/src/entities/trait.ts
@@ -66,6 +66,7 @@ export interface TraitOptions {
  * @since 5.9.0
  * @public
  * @classDecorator
+ * @category Entity Decorators
  */
 export function Trait(target: AnyConstructor): void;
 export function Trait(name: string, options?: TraitOptions): (target: AnyConstructor) => void;


### PR DESCRIPTION
## Summary
- Tags the four class-level decorators (`Resource`, `ObjectSchema`, `Trait`, `trait`) with `@category Entity Decorators`.
- These already render under the "Class Decorators" group (from the `@classDecorator`-driven grouping added in #10907); this adds a `@category` on top so they show as a labeled "Entity Decorators" sub-section within that group, using TypeDoc's built-in category mechanism.

## Test plan
- [ ] CI docs build