### PR TITLE
docs: add memory-alpha to the api docs Tooling section

### DIFF
--- a/docs-viewer/src/nav.json
+++ b/docs-viewer/src/nav.json
@@ -3,40 +3,105 @@
     {
       "text": "Universal",
       "packages": [
-        "@warp-drive/core",
-        "@warp-drive/json-api",
-        "@warp-drive/utilities",
-        "@warp-drive/legacy",
-        "@warp-drive/experiments"
+        { "name": "@warp-drive/core", "description": "Core package for WarpDrive | All the Universal Basics" },
+        { "name": "@warp-drive/json-api", "description": "A {json:api} Cache Implementation for WarpDrive" },
+        {
+          "name": "@warp-drive/utilities",
+          "description": "Utilities package for WarpDrive | Things your app might find useful"
+        },
+        {
+          "name": "@warp-drive/legacy",
+          "description": "Decommissioned Packages for WarpDrive | Things your app might still want to maintain use of for a little longer."
+        },
+        { "name": "@warp-drive/experiments", "description": "Experimental features for WarpDrive" }
       ]
     },
     {
       "text": "Frameworks",
-      "packages": ["@warp-drive/ember", "@warp-drive/react"]
+      "packages": [
+        {
+          "name": "@warp-drive/ember",
+          "description": "Data bindings and utilities for Ember applications using WarpDrive"
+        },
+        {
+          "name": "@warp-drive/react",
+          "description": "Data bindings and utilities for React applications using WarpDrive"
+        }
+      ]
     },
     {
       "text": "Tooling",
-      "packages": ["@warp-drive/holodeck", "@warp-drive/schema-dsl", "eslint-plugin-warp-drive"]
+      "packages": [
+        { "name": "@warp-drive/holodeck", "description": "⚡️ Simple, Fast HTTP Mocking for Tests" },
+        { "name": "@warp-drive/schema-dsl", "description": "TypeScript DSL for defining WarpDrive schemas" },
+        { "name": "eslint-plugin-warp-drive", "description": "ESLint rules for Applications using WarpDrive or EmberData" },
+        {
+          "name": "@warp-drive/memory-alpha",
+          "description": "WarpDrive knowledge packaged as plain markdown for AI coding agents (Claude Skills, MCP servers, Copilot/Cursor instruction files, etc.)"
+        }
+      ]
     },
     {
       "text": "Legacy Packages",
       "packages": [
-        "@ember-data/adapter",
-        "@ember-data/active-record",
-        "@ember-data/debug",
-        "@ember-data/legacy-compat",
-        "@ember-data/model",
-        "@ember-data/json-api",
-        "@ember-data/store",
-        "@ember-data/graph",
-        "@ember-data/request",
-        "@ember-data/request-utils",
-        "@ember-data/rest",
-        "@ember-data/serializer",
-        "@ember-data/tracking",
-        "@warp-drive/core-types",
-        "@warp-drive/build-config",
-        "@warp-drive/schema-record"
+        {
+          "name": "@ember-data/adapter",
+          "description": "(Legacy) JSON:API and REST Implementations of the Adapter Interface for use with @ember-data/store"
+        },
+        {
+          "name": "@ember-data/active-record",
+          "description": "(Legacy) ActiveRecord Format Support for EmberData"
+        },
+        {
+          "name": "@ember-data/debug",
+          "description": "Provides support for the ember-inspector for apps built with Ember and EmberData"
+        },
+        {
+          "name": "@ember-data/legacy-compat",
+          "description": "Compatibility Shims for Older (Legacy) EmberData"
+        },
+        {
+          "name": "@ember-data/model",
+          "description": "(Legacy) Ember implementation of a resource presentation layer for use with @ember-data/store"
+        },
+        {
+          "name": "@ember-data/json-api",
+          "description": "(Legacy) JSON:API document and resource cache implementation for EmberData"
+        },
+        {
+          "name": "@ember-data/store",
+          "description": "(Legacy) EmberData Store service which coordinates the cache with the network and presentation layers."
+        },
+        {
+          "name": "@ember-data/graph",
+          "description": "(Internal) Normalized graph for managing relationships between WarpDrive resources"
+        },
+        {
+          "name": "@ember-data/request",
+          "description": "(Legacy) A simple, small and fast framework-agnostic library to make `fetch` happen"
+        },
+        {
+          "name": "@ember-data/request-utils",
+          "description": "(Legacy) Request Building Utilities for use with EmberData"
+        },
+        { "name": "@ember-data/rest", "description": "(Legacy) REST Format Support for EmberData" },
+        {
+          "name": "@ember-data/serializer",
+          "description": "(Legacy) JSON, JSON:API and REST Implementations of the Serializer Interface for use with @ember-data/store"
+        },
+        { "name": "@ember-data/tracking", "description": "DEPRECATED - Use @warp-drive/ember" },
+        {
+          "name": "@warp-drive/core-types",
+          "description": "(Legacy) Core logic, utils and types for WarpDrive and EmberData"
+        },
+        {
+          "name": "@warp-drive/build-config",
+          "description": "(Legacy) Build Configuration for projects using WarpDrive"
+        },
+        {
+          "name": "@warp-drive/schema-record",
+          "description": "(Legacy) Schema Driven Resource Presentation for WarpDrive and EmberData"
+        }
       ]
     }
   ]

--- a/docs-viewer/src/nav.json
+++ b/docs-viewer/src/nav.json
@@ -34,7 +34,10 @@
       "packages": [
         { "name": "@warp-drive/holodeck", "description": "⚡️ Simple, Fast HTTP Mocking for Tests" },
         { "name": "@warp-drive/schema-dsl", "description": "TypeScript DSL for defining WarpDrive schemas" },
-        { "name": "eslint-plugin-warp-drive", "description": "ESLint rules for Applications using WarpDrive or EmberData" },
+        {
+          "name": "eslint-plugin-warp-drive",
+          "description": "ESLint rules for Applications using WarpDrive or EmberData"
+        },
         {
           "name": "@warp-drive/memory-alpha",
           "description": "WarpDrive knowledge packaged as plain markdown for AI coding agents (Claude Skills, MCP servers, Copilot/Cursor instruction files, etc.)"

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -380,15 +380,22 @@ function deepConvert(obj: Record<string, any>, orderedItems?: string[]) {
 
 type SidebarItem = { text: string; items?: SidebarItem[]; link?: string; collapsed?: boolean };
 
+interface ApiNavGroupPackage {
+  /** The package name, matching its `package.json` `name` field. */
+  name: string;
+  /** A short description of the package, shown alongside its nav entry. */
+  description: string;
+}
+
 interface ApiNavGroup {
   /** The section heading shown in the sidebar. */
   text: string;
   /**
-   * Package names belonging to this section, in display order. Packages not
+   * Packages belonging to this section, in display order. Packages not
    * listed in any group fall back to the "Frameworks" group, sorted
    * alphabetically after this group's explicitly ordered packages.
    */
-  packages: string[];
+  packages: ApiNavGroupPackage[];
 }
 
 const API_NAV_GROUPS = (
@@ -414,10 +421,10 @@ function sortByPackageOrder(items: SidebarItem[], order: string[]): SidebarItem[
 }
 
 export function splitApiDocsSidebar(sidebar: SidebarItem[]) {
-  const universalOrder = findApiNavGroup('Universal').packages;
-  const frameworksOrder = findApiNavGroup('Frameworks').packages;
-  const toolingOrder = findApiNavGroup('Tooling').packages;
-  const legacyOrder = findApiNavGroup('Legacy Packages').packages;
+  const universalOrder = findApiNavGroup('Universal').packages.map((p) => p.name);
+  const frameworksOrder = findApiNavGroup('Frameworks').packages.map((p) => p.name);
+  const toolingOrder = findApiNavGroup('Tooling').packages.map((p) => p.name);
+  const legacyOrder = findApiNavGroup('Legacy Packages').packages.map((p) => p.name);
 
   const oldPackages: SidebarItem[] = [];
   const corePackages = { text: 'Universal', items: [] as SidebarItem[] } satisfies SidebarItem;

--- a/docs-viewer/src/sync-guides.ts
+++ b/docs-viewer/src/sync-guides.ts
@@ -31,8 +31,10 @@ for (const packagePath of readdirSync(oldPackages)) {
   }
 }
 for (const packagePath of readdirSync(newPackages)) {
-  if (existsSync(join(newPackages, packagePath, 'typedoc.config.mjs'))) {
-    Packages.push(join(newPackages, packagePath, 'src'));
+  const srcPath = join(newPackages, packagePath, 'src');
+  // packages with no source (e.g. memory-alpha, which is markdown-only) have nothing to watch here
+  if (existsSync(join(newPackages, packagePath, 'typedoc.config.mjs')) && existsSync(srcPath)) {
+    Packages.push(srcPath);
   }
 }
 

--- a/docs-viewer/typedoc.config.mjs
+++ b/docs-viewer/typedoc.config.mjs
@@ -32,6 +32,7 @@ const config = {
     '../warp-drive-packages/json-api',
     '../warp-drive-packages/experiments',
     '../warp-drive-packages/schema-dsl',
+    '../warp-drive-packages/memory-alpha',
   ],
   entryFileName: 'index',
   packageOptions: {

--- a/warp-drive-packages/memory-alpha/typedoc.config.mjs
+++ b/warp-drive-packages/memory-alpha/typedoc.config.mjs
@@ -1,0 +1,11 @@
+/** @type {Partial<import("typedoc").TypeDocOptions>} */
+const config = {
+  $schema: 'https://typedoc.org/schema.json',
+  // this package has no source code, only markdown skills, so its docs
+  // page is just the overview readme with no exported members
+  entryPoints: [],
+  out: 'doc',
+  readme: 'skills/overview.md',
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- Adds a `typedoc.config.mjs` for `@warp-drive/memory-alpha` that uses `skills/overview.md` as its documentation entrypoint (the package has no source code, only markdown skills)
- Registers the package in `docs-viewer/typedoc.config.mjs`'s entry points and lists it last in the "Tooling" section of the generated API docs, alongside holodeck, schema-dsl, and eslint-plugin-warp-drive
- Reshapes `nav.json`'s per-group `packages` arrays from plain name strings to `{ name, description }` objects (prep work for showing descriptions on nav items, pending vitepress support), updating `site-utils.ts`'s consumers accordingly
- Guards `sync-guides.ts`'s dev-mode file watcher against packages with a `typedoc.config.mjs` but no `src/` directory (memory-alpha is markdown-only), avoiding a crash on `bun run start`

## Test plan
- [x] `pnpm exec typedoc` builds successfully and generates `tmp/api/@warp-drive/memory-alpha/index.md` from `skills/overview.md`
- [x] `postProcessApiDocs()` output places `@warp-drive/memory-alpha` last under "## Tooling Packages" in the generated `index.md`
- [x] `tsc --noEmit` in `docs-viewer` shows no new errors versus the pre-change baseline
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)