### PR TITLE
docs(memory-alpha): trek explainer on overview + dedicated API docs page

### DIFF
--- a/warp-drive-packages/memory-alpha/api-docs.md
+++ b/warp-drive-packages/memory-alpha/api-docs.md
@@ -1,0 +1,7 @@
+# @warp-drive/memory-alpha
+
+WarpDrive knowledge packaged as plain markdown for AI coding agents — no exports, no code,
+just a directory of skill files meant to be read directly or adapted into tool-specific formats
+(Claude Skills, MCP servers, Cursor rules, Copilot instructions, etc.).
+
+See [the manual](/skills/index.md) for the full set of skills.

--- a/warp-drive-packages/memory-alpha/skills/overview.md
+++ b/warp-drive-packages/memory-alpha/skills/overview.md
@@ -7,8 +7,10 @@ Each skill is a single markdown file describing one thing to accomplish with War
 a schema, making a request, handling a mutation, and so on. Skills are grouped into directories
 by topic, the same way the [Guides](/guides/index.md) are, and published as the
 [`@warp-drive/memory-alpha`](https://www.npmjs.com/package/@warp-drive/memory-alpha) npm
-package so they can be installed into any project and consumed by an MCP server, a Claude Code
-skill, or adapted into tool-specific instruction files (Cursor rules, Copilot instructions, etc.).
+package — named after the Federation's central archive of all recorded knowledge, minus the
+away-team incident that torched the original — so it can be installed into any project and
+consumed by an MCP server, a Claude Code skill, or adapted into tool-specific instruction files
+(Cursor rules, Copilot instructions, etc.).
 
 Browse the categories in the sidebar to get started. If you're an AI agent rather than a human
 reader, don't start here — read the package's `skills/index.md` (or its

--- a/warp-drive-packages/memory-alpha/typedoc.config.mjs
+++ b/warp-drive-packages/memory-alpha/typedoc.config.mjs
@@ -2,10 +2,10 @@
 const config = {
   $schema: 'https://typedoc.org/schema.json',
   // this package has no source code, only markdown skills, so its docs
-  // page is just the overview readme with no exported members
+  // page is just a brief intro with no exported members
   entryPoints: [],
   out: 'doc',
-  readme: 'skills/overview.md',
+  readme: 'api-docs.md',
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- Adds the Star Trek "Memory Alpha" explainer (the Federation's central knowledge archive, minus the away-team incident) to the human-facing `/skills` overview page.
- Gives the typedoc-generated API docs page (`/api/@warp-drive/memory-alpha`) its own short intro that links out to the skills manual, instead of reusing/duplicating the full overview content.

## Test plan
- [x] Ran a local `typedoc` build and confirmed `/api/@warp-drive/memory-alpha` renders the new brief intro with a working link to `/skills/index.md`
- [x] Confirmed `overview.md` (published at `/skills`) still reads correctly with the added explainer sentence