### PR TITLE
fix(docs): match @warp-drive/ember's API docs sidebar to other packages

### DIFF
--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -477,6 +477,16 @@ function cleanSidebarItems(items: SidebarItem[], isPrimitive = false): SidebarIt
       continue;
     }
 
+    if (item.text === 'index') {
+      // Packages whose primary entry point has to be pre-compiled (e.g. @warp-drive/ember,
+      // whose .gts sources typedoc can't parse directly) point typedoc at the compiled
+      // index.d.ts instead of a raw .ts file, and typedoc keeps that as its own "index"
+      // module rather than merging it into the package root the way a raw .ts entry point
+      // is. Merge it by hand so the sidebar shape matches packages that don't need this.
+      hoisted.items!.push(...cleanSidebarItems(item.items || []));
+      continue;
+    }
+
     if (item.text === 'Modules') {
       // hoist modules up
       submodules = cleanSidebarItems(item.items || []);
@@ -494,13 +504,13 @@ function cleanSidebarItems(items: SidebarItem[], isPrimitive = false): SidebarIt
     continue;
   }
 
-  if (submodules.length === 0) {
-    return newItems;
-  }
-
   if (hoisted.items!.length > 0) {
     // if we have hoisted items, we add them to the new items
     newItems.unshift(hoisted);
+  }
+
+  if (submodules.length === 0) {
+    return newItems;
   }
 
   return newItems.concat(submodules);

--- a/warp-drive-packages/ember/typedoc.config.mjs
+++ b/warp-drive-packages/ember/typedoc.config.mjs
@@ -3,6 +3,7 @@ import { entryPoints } from './tsdown.config.mjs';
 /** @type {Partial<import("typedoc").TypeDocOptions>} */
 const config = {
   $schema: 'https://typedoc.org/schema.json',
+  entryFileName: 'index',
   entryPoints: entryPoints
     .map((v) => v.replace('./src', './dist').replace('.ts', '.d.ts'))
     .filter((entry) => !entry.includes('-private')),


### PR DESCRIPTION
## Summary
`@warp-drive/ember` has to point typedoc at its compiled `dist/index.d.ts` instead of
`src/index.ts` (typedoc can't parse `.gts` sources directly). That difference causes typedoc
to keep the primary entry point as its own "index" module instead of merging it into the
package root the way it does for every other package's raw `.ts` entry point — so ember's API
docs sidebar showed a redundant top-level "index" entry (with the actual `<Await />`/`<Request />`/
`<Throw />` component pages nested under it) alongside its overview/readme page, instead of the
`exports` bucket every other package gets.
- `docs-viewer/src/site-utils.ts`: `cleanSidebarItems` now merges a top-level "index" module into
  the same `exports` bucket used for `Classes`/`Variables`/`Functions`, and unshifts that bucket
  onto the sidebar regardless of whether the package also has real "Modules" submodules (needed
  because ember has no "Modules" wrapper, only its hoisted `exports` and a plain `install`
  submodule — the old early-return would have dropped the hoisted content).
- `warp-drive-packages/ember/typedoc.config.mjs`: adds `entryFileName: 'index'`, matching the
  convention already used by ~18 other packages (harmless on its own, but confirmed via a local
  typedoc build not to be what actually caused the nesting).

## Test plan
- [x] Ran a local `typedoc` + `postProcessApiDocs` build and confirmed `@warp-drive/ember`'s
  sidebar entry now matches `@warp-drive/react`'s shape (`exports` bucket + `install` submodule,
  no separate `index` entry)
- [x] Confirmed other packages' sidebar shapes (holodeck, react, schema-dsl) are unchanged