### PR TITLE
docs+feat: glowing status badges for deprecated/discouraged/recommended, auto-badge @warp-drive/experiments

### DIFF
--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/KindBadge.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <span class="kind-badge">{{ kind }}</span>
+  <span class="kind-badge ignore-header">{{ kind }}</span>
 </template>
 
 <style scoped>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/ModuleBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/ModuleBadge.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <span class="module-badge">
+  <span class="module-badge ignore-header">
     <span class="module-badge-label">module</span>
     <span class="module-badge-path">{{ path }}</span>
   </span>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/SinceBadge.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <span class="since-badge">
+  <span class="since-badge ignore-header">
     <span class="since-badge-label">since</span>
     <span class="since-badge-version">v{{ version }}</span>
   </span>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/StatusBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/StatusBadge.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+type Variant = 'recommended' | 'discouraged' | 'deprecated';
+
+const props = defineProps<{
+  variant: Variant;
+  text?: string;
+}>();
+
+const defaultText: Record<Variant, string> = {
+  recommended: 'recommended',
+  discouraged: 'discouraged',
+  deprecated: 'deprecated',
+};
+</script>
+
+<template>
+  <span class="status-badge" :class="variant">{{ text ?? defaultText[props.variant] }}</span>
+</template>
+
+<style scoped>
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 12px;
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 22px;
+  padding: 0 10px;
+  animation: status-badge-glow 2.2s ease-in-out infinite;
+}
+
+/* light mode */
+.status-badge.recommended {
+  background: linear-gradient(135deg, #a7f3d0, #bae6fd);
+  color: #065f46;
+  --status-glow: rgba(45, 212, 191, 0.65);
+}
+
+.status-badge.discouraged {
+  background: #fed7aa;
+  color: #9a3412;
+  --status-glow: rgba(251, 146, 60, 0.65);
+}
+
+.status-badge.deprecated {
+  background: #fecaca;
+  color: #991b1b;
+  --status-glow: rgba(248, 113, 113, 0.7);
+}
+
+/* dark mode */
+.dark .status-badge.recommended {
+  background: linear-gradient(135deg, #065f46, #0369a1);
+  color: #d1fae5;
+  --status-glow: rgba(45, 212, 191, 0.55);
+}
+
+.dark .status-badge.discouraged {
+  background: #9a3412;
+  color: #fed7aa;
+  --status-glow: rgba(251, 146, 60, 0.55);
+}
+
+.dark .status-badge.deprecated {
+  background: #991b1b;
+  color: #fecaca;
+  --status-glow: rgba(248, 113, 113, 0.6);
+}
+
+@keyframes status-badge-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 3px 0 var(--status-glow);
+  }
+  50% {
+    box-shadow: 0 0 9px 2px var(--status-glow);
+  }
+}
+</style>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/StatusBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/StatusBadge.vue
@@ -14,7 +14,7 @@ const defaultText: Record<Variant, string> = {
 </script>
 
 <template>
-  <span class="status-badge" :class="variant">{{ text ?? defaultText[props.variant] }}</span>
+  <span class="status-badge ignore-header" :class="variant">{{ text ?? defaultText[props.variant] }}</span>
 </template>
 
 <style scoped>

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/StatusBadge.vue
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/StatusBadge.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-type Variant = 'recommended' | 'discouraged' | 'deprecated';
+type Variant = "recommended" | "discouraged" | "deprecated";
 
 const props = defineProps<{
   variant: Variant;
@@ -7,9 +7,9 @@ const props = defineProps<{
 }>();
 
 const defaultText: Record<Variant, string> = {
-  recommended: 'recommended',
-  discouraged: 'discouraged',
-  deprecated: 'deprecated',
+  recommended: "recommended",
+  discouraged: "discouraged",
+  deprecated: "deprecated",
 };
 </script>
 

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/custom.css
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/custom.css
@@ -43,7 +43,7 @@ body {
  * heading. Making the heading a flex row instead centers every child (badges and text) by actual
  * box height, which holds regardless of the size mismatch.
  */
-.vp-doc :where(h1, h2, h3, h4, h5, h6):has(.kind-badge, .since-badge) {
+.vp-doc :where(h1, h2, h3, h4, h5, h6):has(.kind-badge, .since-badge, .status-badge) {
   display: flex;
   align-items: center;
   flex-wrap: wrap;

--- a/docs-viewer/docs.warp-drive.io/.vitepress/theme/index.js
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/theme/index.js
@@ -5,6 +5,7 @@ import { enhanceAppWithTabs } from 'vitepress-plugin-tabs/client';
 import ModuleBadge from './ModuleBadge.vue';
 import SinceBadge from './SinceBadge.vue';
 import KindBadge from './KindBadge.vue';
+import StatusBadge from './StatusBadge.vue';
 
 export default {
   extends: DefaultTheme,
@@ -13,5 +14,6 @@ export default {
     app.component('ModuleBadge', ModuleBadge);
     app.component('SinceBadge', SinceBadge);
     app.component('KindBadge', KindBadge);
+    app.component('StatusBadge', StatusBadge);
   },
 };

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -582,8 +582,11 @@ function sinceBadgeMarkup(version: string): string {
  * TypeDoc renders each `@since` tag as its own `#### Since` section beneath the heading of the
  * thing it documents (the page's own H1, or a nested member heading for e.g. a class method).
  * This removes every such section from the body and turns its version into a `<SinceBadge>`
- * appended to the heading it described, so `@since` reads as a badge next to the name of the
- * documented thing rather than as a separate body section.
+ * attached to the heading it described, so `@since` reads as a badge next to the name of the
+ * documented thing rather than as a separate body section. The page's own H1 keeps its badge on
+ * the same line as its name; every other (nested member) heading gets it on its own line
+ * directly below instead — inline badges start crowding a smaller heading's name much sooner
+ * than they do the page's title.
  */
 function extractSinceBadges(content: string): { content: string; moduleSince: string | null } {
   const lines = content.split('\n');
@@ -594,7 +597,7 @@ function extractSinceBadges(content: string): { content: string; moduleSince: st
   }
 
   const linesToRemove = new Set<number>();
-  const badgesByHeadingLine = new Map<number, string[]>();
+  const badgesByHeadingLine = new Map<number, { level: number; badges: string[] }>();
   let moduleSince: string | null = null;
 
   for (let hi = 0; hi < headings.length; hi++) {
@@ -634,21 +637,32 @@ function extractSinceBadges(content: string): { content: string; moduleSince: st
       continue;
     }
 
-    const existing = badgesByHeadingLine.get(parent.index) ?? [];
-    existing.push(sinceBadgeMarkup(version));
+    const existing = badgesByHeadingLine.get(parent.index) ?? { level: parent.level, badges: [] };
+    existing.badges.push(sinceBadgeMarkup(version));
     badgesByHeadingLine.set(parent.index, existing);
   }
 
-  for (const [lineIndex, badges] of badgesByHeadingLine) {
-    lines[lineIndex] = `${lines[lineIndex]} ${badges.join(' ')}`;
+  const insertAfterByLine = new Map<number, string>();
+  for (const [lineIndex, { level, badges }] of badgesByHeadingLine) {
+    const markup = badges.join(' ');
+    if (level === 1) {
+      lines[lineIndex] = `${lines[lineIndex]} ${markup}`;
+    } else {
+      insertAfterByLine.set(lineIndex, markup);
+    }
   }
 
-  const kept = lines
-    .filter((_, i) => !linesToRemove.has(i))
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n');
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (linesToRemove.has(i)) continue;
+    kept.push(lines[i]);
+    const insertion = insertAfterByLine.get(i);
+    if (insertion !== undefined) kept.push(insertion);
+  }
 
-  return { content: kept, moduleSince };
+  const result = kept.join('\n').replace(/\n{3,}/g, '\n\n');
+
+  return { content: result, moduleSince };
 }
 
 // Structural groupings typedoc-plugin-markdown inserts between an overloaded function/method's

--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -728,17 +728,110 @@ function escapeHeadingText(text: string): string {
 }
 
 /**
- * Removes the page's first H1 (and the blank line before it), returning any `<SinceBadge>`
- * that had been attached to it so the caller can relocate it (module pages show that badge next
- * to `<ModuleBadge>` instead of a redundant title).
+ * Removes the page's first H1 (and the blank line before it), returning any `<SinceBadge>`/
+ * `<StatusBadge>` that had been attached to it so the caller can relocate it (module pages show
+ * those badges next to `<ModuleBadge>` instead of a redundant title).
  */
 function stripH1(content: string): { content: string; badges: string } {
   let badges = '';
-  const next = content.replace(/\n\n# [^\n]*?((?:\s*<SinceBadge[^\n]*\/>)*)\n\n?/, (_match, b: string) => {
-    badges = b.trim();
-    return '\n\n';
-  });
+  const next = content.replace(
+    /\n\n# [^\n]*?((?:\s*<(?:SinceBadge|StatusBadge)[^\n]*\/>)*)\n\n?/,
+    (_match, b: string) => {
+      badges = b.trim();
+      return '\n\n';
+    }
+  );
   return { content: next, badges };
+}
+
+function statusBadgeMarkup(variant: 'recommended' | 'discouraged' | 'deprecated'): string {
+  return `<StatusBadge variant="${variant}" />`;
+}
+
+/**
+ * TypeDoc renders every `@deprecated` tag as its own `#### Deprecated` section beneath the
+ * heading of the thing it documents, same shape as `@since`. Unlike `@since`, the deprecation
+ * message is worth keeping visible in the body, so this only appends a `<StatusBadge>` to the
+ * heading it describes rather than removing the section.
+ */
+function extractDeprecatedBadges(content: string): string {
+  const lines = content.split('\n');
+  const headings: { index: number; level: number; text: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = HEADING_RE.exec(lines[i]);
+    if (m) headings.push({ index: i, level: m[1].length, text: m[2].trim() });
+  }
+
+  for (let hi = 0; hi < headings.length; hi++) {
+    const heading = headings[hi];
+    if (heading.text !== 'Deprecated') continue;
+
+    let parent: (typeof headings)[number] | null = null;
+    for (let pi = hi - 1; pi >= 0; pi--) {
+      if (headings[pi].level < heading.level) {
+        parent = headings[pi];
+        break;
+      }
+    }
+    // A bare `@deprecated` with no enclosing heading would only happen via the same
+    // packages-mode readme workaround `typedoc-since-plugin.mjs` needs for `@since` — nothing
+    // injects `@deprecated` that way today, so there's no heading to attach a badge to.
+    if (!parent) continue;
+
+    lines[parent.index] = `${lines[parent.index]} ${statusBadgeMarkup('deprecated')}`;
+  }
+
+  return lines.join('\n');
+}
+
+const FLAG_TOKEN_RE = /\*\*`([A-Za-z]+)`\*\*/g;
+const FLAGS_LINE_RE = /^(?:\*\*`[A-Za-z]+`\*\*)(?: \*\*`[A-Za-z]+`\*\*)*$/;
+const STATUS_FLAG_VARIANTS: Record<string, 'recommended' | 'discouraged'> = {
+  Recommended: 'recommended',
+  Discouraged: 'discouraged',
+};
+
+/**
+ * TypeDoc renders `@recommended`/`@discouraged` (registered as modifier tags, not block tags)
+ * as a bold, backticked flag (e.g. `` **`Recommended`** ``) on its own line right after the
+ * heading of the thing they describe, possibly alongside other flags like `` **`Legacy`** ``.
+ * This turns just the recommended/discouraged token into a `<StatusBadge>` appended to that
+ * heading, leaving any other flag on the same line untouched.
+ */
+function extractStatusFlagBadges(content: string): string {
+  const lines = content.split('\n');
+  const headingLineIndexes: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (HEADING_RE.test(lines[i])) headingLineIndexes.push(i);
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!FLAGS_LINE_RE.test(line)) continue;
+
+    const tokens = [...line.matchAll(FLAG_TOKEN_RE)].map((m) => m[1]);
+    const statusTokens = tokens.filter((t) => t in STATUS_FLAG_VARIANTS);
+    if (statusTokens.length === 0) continue;
+
+    let headingLineIndex = -1;
+    for (let hi = headingLineIndexes.length - 1; hi >= 0; hi--) {
+      if (headingLineIndexes[hi] < i) {
+        headingLineIndex = headingLineIndexes[hi];
+        break;
+      }
+    }
+    // A flags line always sits directly under the heading of the symbol it flags; if somehow
+    // there isn't one above it, leave the line as TypeDoc rendered it.
+    if (headingLineIndex === -1) continue;
+
+    const badges = statusTokens.map((t) => statusBadgeMarkup(STATUS_FLAG_VARIANTS[t]));
+    lines[headingLineIndex] = `${lines[headingLineIndex]} ${badges.join(' ')}`;
+
+    const remainingTokens = tokens.filter((t) => !(t in STATUS_FLAG_VARIANTS));
+    lines[i] = remainingTokens.map((t) => `**\`${t}\`**`).join(' ');
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n');
 }
 
 export async function postProcessApiDocs() {
@@ -816,6 +909,12 @@ export async function postProcessApiDocs() {
     const sinceResult = extractSinceBadges(newContent);
     newContent = sinceResult.content;
 
+    // Turn every `#### Deprecated` section into a `<StatusBadge>` next to the heading it
+    // describes, and turn the `@recommended`/`@discouraged` flags TypeDoc renders for those
+    // modifier tags into matching `<StatusBadge>`s.
+    newContent = extractDeprecatedBadges(newContent);
+    newContent = extractStatusFlagBadges(newContent);
+
     if (path.basename(file) === 'index.md') {
       // Module page: the module name is already shown via <ModuleBadge>, so drop the redundant
       // H1 title, relocating any `@since` badge it carried onto the <ModuleBadge> line.
@@ -832,6 +931,11 @@ export async function postProcessApiDocs() {
     // if the file is in @warp-drive/legacy add the legacy badge
     if (file.includes('@warp-drive/legacy')) {
       newContent = newContent.replace(/^(<ModuleBadge [^\n]+\/>)/, `$1 <Badge type="danger" text="@legacy" />`);
+    }
+
+    // if the file is in @warp-drive/experiments add the experimental badge
+    if (file.includes('@warp-drive/experiments')) {
+      newContent = newContent.replace(/^(<ModuleBadge [^\n]+\/>)/, `$1 <Badge type="warning" text="@experimental" />`);
     }
 
     // insert frontmatter

--- a/guides/contributing/writing-documentation/writing-api-docs.md
+++ b/guides/contributing/writing-documentation/writing-api-docs.md
@@ -298,6 +298,11 @@ package's `<ModuleBadge>` on the module's index page instead:
 > `core-types/src/cache.ts`). Put `@since` on a subpackage's exported
 > members instead until this is extended.
 
+On a class's own member (a method, property, etc.), `@since` shows up
+on its own line directly below the member's heading instead of next
+to it — a nested heading is much narrower than a page's own title, so
+crowding it with an inline badge reads worse much sooner.
+
 ### Overriding the displayed kind and name with `@badge` and `@title`
 
 Every function, class, interface, variable, type alias, and enumeration

--- a/guides/contributing/writing-documentation/writing-api-docs.md
+++ b/guides/contributing/writing-documentation/writing-api-docs.md
@@ -759,6 +759,11 @@ object because it is actively being removed.
 export type StableRecordIdentifier<T extends string = string> = ResourceKey<T>;
 ```
 
+A glowing red badge is automatically added next to the heading of
+whatever the tag describes; the deprecation message itself stays in
+the page body as its own `#### Deprecated` section rather than being
+absorbed into the badge, since it's usually worth reading in full.
+
 ### The `@discouraged` Tag
 
 `@discouraged` signals that a function, object, or class is an older,
@@ -768,6 +773,9 @@ optional to describe those cases in the tag.
 
 If a `@recommended` alternative exists, cross-link to it.
 
+A glowing orange badge is automatically added next to the heading of
+whatever the tag describes.
+
 ### The `@recommended` Tag
 
 `@recommended` is a companion tag to `@deprecated` and `@discouraged`.
@@ -776,6 +784,35 @@ something. It's not mandatory to link back to the `@discouraged` or
 `@deprecated` alternative(s), but doing so is encouraged. Since
 `@recommended` implies the existence of a `@discouraged` and/or
 `@deprecated` counterpart, it shouldn't be used on its own.
+
+A glowing blue/green badge is automatically added next to the heading
+of whatever the tag describes.
+
+### The `@legacy` Tag, and the `@warp-drive/legacy` and `@warp-drive/experiments` Badges
+
+`@legacy` is a repo-specific modifier tag for symbols that predate the
+current architecture but aren't (yet) `@deprecated` — it renders as a
+plain, unstyled `` **`Legacy`** `` flag before the summary, the same
+way any other modifier tag without special handling does (see
+`@discouraged`/`@recommended` above for tags that *do* get special
+handling).
+
+Separate from that tag, every page under the `@warp-drive/legacy`
+package automatically gets a red "@legacy" badge next to its
+`<ModuleBadge>`, and every page under `@warp-drive/experiments`
+automatically gets an orange "@experimental" badge the same way.
+Both are applied purely by which package a file lives in — via
+`docs-viewer/src/site-utils.ts` checking the generated file's path —
+not by any doc comment tag, so nothing needs to be written in source
+to get them; anything moved into (or out of) either package picks up
+(or loses) its badge automatically.
+
+Note that TypeDoc's own standard `@experimental` modifier tag (along
+with `@alpha`/`@beta`/`@internal`/`@public`) is unrelated to the
+`@warp-drive/experiments` badge above — tagging a symbol
+`@experimental` elsewhere in the codebase does not add that badge, and
+currently renders as nothing more than an unstyled
+`` **`Experimental`** `` flag, same as `@legacy` above.
 
 <br>
 


### PR DESCRIPTION
## Summary
- Adds a new `<StatusBadge>` component (glowing red/orange/blue-green) rendered next to a
  symbol's heading for `@deprecated`/`@discouraged`/`@recommended` respectively:
  - `@deprecated` keeps its existing `#### Deprecated` message section in the body — only a
    badge is added, nothing is removed.
  - `@recommended`/`@discouraged` are modifier tags TypeDoc renders as an inline bold/backticked
    flag (`` **`Recommended`** ``) with no heading of their own; `site-utils.ts` converts just
    that token into a badge, leaving any other flag on the same line (e.g. `@legacy`) untouched.
- Every page under `@warp-drive/experiments` now automatically gets an `@experimental` badge
  next to its `<ModuleBadge>`, using the same file-path-based mechanism `@warp-drive/legacy`'s
  `@legacy` badge already uses — nothing needs to be written in source for it.
- Updates `guides/contributing/writing-documentation/writing-api-docs.md` to document all of the
  above, plus clarify how `@legacy` (a real, unstyled modifier tag) relates to the
  `@warp-drive/legacy` badge (a file-path check, independent of any tag) — and the same
  distinction for TypeDoc's standard `@experimental` tag vs. the new `@warp-drive/experiments`
  badge.

## Test plan
- [x] Ran a local `typedoc` + `postProcessApiDocs` build and confirmed:
  - real `@deprecated` symbols (e.g. `CacheCapabilitiesManager.getSchemaDefinitionService`) get
    the badge next to their heading with the `#### Deprecated` message still in the body
  - the one real `@recommended` usage in the codebase renders as a badge with no leftover
    `` **`Recommended`** `` flag text
  - `@warp-drive/experiments` pages get the new `@experimental` badge; `@warp-drive/legacy`
    pages are unaffected and still get their existing `@legacy` badge
  - a symbol with both `@since` and `@deprecated` renders both badges together correctly