### PR TITLE
fix(ci): declare real inputs/outputs for the sync-logos build:pkg task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -167,6 +167,15 @@
       "env": ["IS_UNPKG_BUILD"]
     },
     "@warp-drive/internal-tooling#build:pkg": {
+      // This task's real work (`sync-logos.ts`) reads the monorepo-root `logos/` directory and
+      // writes into every other package's own `logos/` dir plus the docs site's
+      // `public/logos` -- none of which live under this package, so without these, turbo's
+      // cache key is blind to logo changes and (worse) a cache hit restores nothing, silently
+      // skipping the copy. Per-package `logos/` copies are committed to git, so a skipped run
+      // leaves them correct regardless; `public/logos` is gitignored (see .gitignore) and is
+      // the one output that actually depends on this cache entry being accurate.
+      "inputs": ["src/**", "tsconfig.json", "package.json", "../../logos/**"],
+      "outputs": ["../../docs-viewer/docs.warp-drive.io/public/logos/**"],
       "dependsOn": [],
       "outputLogs": "new-only"
     },


### PR DESCRIPTION
## Summary
`canary.warp-drive.io` is currently missing all logo images. Root cause:

- The site's logos live at `docs-viewer/docs.warp-drive.io/public/logos/`, which is **gitignored**
  — it only exists because `@warp-drive/internal-tooling`'s `sync-logos.ts` copies the
  repo-root `logos/` directory into it, via the root `prepare` script (`turbo run build:pkg`).
- That task (`@warp-drive/internal-tooling#build:pkg`) declared **no `inputs`/`outputs`** in
  `turbo.json`. #10782 (merged 2026-08-25) removed this task's `"cache": false`, and also added
  a shared, commit-keyed local turbo cache restore step across CI jobs/workflows.
- With no declared inputs, the task's cache key is only sensitive to `tools/internal-tooling`'s
  own (rarely-changing) files — so once *any* job for a given commit runs it, every other job for
  that same commit (e.g. the docs deploy job) gets a cache **hit** and skips running it entirely.
  With no declared outputs, there's nothing for turbo to restore in its place, so a fresh
  checkout's `public/logos` is simply never created.

This has been true for every canary deploy since #10782 landed.

## Fix
Declare the task's real inputs (its own `src/**` plus the root `logos/**` it reads from) and its
one output that actually depends on being cached correctly (`public/logos/**` — the per-package
`logos/` copies this same script also writes are committed to git, so they stay correct even if
the task is skipped).

## Test plan
- [x] `rm -rf docs-viewer/docs.warp-drive.io/public/logos && turbo run build:pkg --filter=@warp-drive/internal-tooling` → cache miss, executes, produces 59 files
- [x] `rm -rf docs-viewer/docs.warp-drive.io/public/logos && turbo run build:pkg --filter=@warp-drive/internal-tooling` again → cache **hit**, restores all 59 files without re-running the script (this is the exact scenario a fresh CI checkout hits)
- [x] Confirmed via the same steps *without* this fix that a cache hit currently restores nothing, leaving `public/logos` empty