### PR TITLE
fix: crash in ManyArrayManager#_syncArray on links-only hasMany re-sync

### DIFF
--- a/tests/core/tests/polaris-mode/has-many-field-read-test.ts
+++ b/tests/core/tests/polaris-mode/has-many-field-read-test.ts
@@ -1013,6 +1013,70 @@ module('Reads | hasMany in linksMode', function (hooks) {
     assert.equal(record.name, 'Leo', 'name is accessible');
   });
 
+  test('(sync) we do not error when a save response updates the link on an already-materialized links-only relationship', function (assert) {
+    const store = new Store();
+    const { schema } = store;
+
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          {
+            name: 'name',
+            kind: 'field',
+          },
+          {
+            name: 'friends',
+            type: 'user',
+            kind: 'hasMany',
+            options: { inverse: 'friends', async: false, linksMode: true },
+          },
+        ],
+      })
+    );
+
+    // simulates an initial response whose relationship only ever includes a link, never `data`
+    const record = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Leo',
+        },
+        relationships: {
+          friends: {
+            links: { related: '/user/1/friends' },
+          },
+        },
+      },
+    });
+
+    // materializes the ManyArray for the first time; `data` is missing so this
+    // takes the "known-to-be-empty" fallback path in `getHasManyField`
+    assert.equal(record.friends?.length, 0, 'friends is treated as known-to-be-empty');
+
+    // simulates a save response (e.g. createRecord/updateRecord) whose relationship
+    // again only includes a link (still no `data`), but with a different href than
+    // before. This marks the relationship stale and forces `ManyArrayManager#_syncArray`
+    // to re-run against the already-materialized ManyArray.
+    store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Leo',
+        },
+        relationships: {
+          friends: {
+            links: { related: '/user/1/friends?page=2' },
+          },
+        },
+      },
+    });
+
+    assert.equal(record.friends?.length, 0, 'friends is still treated as known-to-be-empty after re-sync');
+  });
+
   test('(sync) we error in linksMode if the related resources are not included (no link)', async function (assert) {
     const store = new Store();
     const { schema } = store;

--- a/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts
+++ b/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts
@@ -46,10 +46,13 @@ export class ManyArrayManager {
 
     const currentState = array[Context].source;
 
-    // unlike in the normal RecordArray case, we don't need to divorce the reference
-    // because we don't need to worry about associate/disassociate since the graph
-    // takes care of that for us
-    if (currentState !== rawValue.data) {
+    // rawValue.data is undefined when the relationship has never received membership
+    // data (e.g. a links-only payload) - there is nothing to sync in that case, and the
+    // array must already be empty since it could only ever have been populated from data
+    if (rawValue.data !== undefined && currentState !== rawValue.data) {
+      // unlike in the normal RecordArray case, we don't need to divorce the reference
+      // because we don't need to worry about associate/disassociate since the graph
+      // takes care of that for us
       currentState.length = 0;
       fastPush(currentState, rawValue.data as ResourceKey[]);
     }

--- a/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts
+++ b/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts
@@ -54,7 +54,7 @@ export class ManyArrayManager {
       // because we don't need to worry about associate/disassociate since the graph
       // takes care of that for us
       currentState.length = 0;
-      fastPush(currentState, rawValue.data as ResourceKey[]);
+      fastPush(currentState, rawValue.data);
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes a bug reported in Discord: saving a record whose hasMany relationship response contains only `links` (no `data`) could later throw inside `ManyArrayManager#_syncArray`'s call to `fastPush`, because `rawValue.data` was `undefined`.

## Root cause
- [`updateRelationshipOperation`](https://github.com/warp-drive-data/warp-drive/blob/main/warp-drive-packages/core/src/graph/-private/operations/update-relationship.ts) used to default a sync hasMany relationship's `data` to `[]` when a payload contained only `links`. That fallback was removed in #10524.
- Without it, `relationship.state.hasReceivedData` stays `false` forever for such a relationship, so [`legacyGetCollectionRelationshipData`](https://github.com/warp-drive-data/warp-drive/blob/main/warp-drive-packages/core/src/graph/-private/edges/collection.ts) omits the `data` key entirely from the payload it returns (`{ links }`, no `data`).
- This doesn't crash on **first** read: [`getHasManyField`](https://github.com/warp-drive-data/warp-drive/blob/main/warp-drive-packages/core/src/reactive/-private/kind/has-many-field.ts#L41) has a defensive `rawValue.data?.slice() ?? []` when first materializing the `ManyArray`.
- But [`ManyArrayManager#_syncArray`](https://github.com/warp-drive-data/warp-drive/blob/main/warp-drive-packages/core/src/reactive/-private/fields/many-array-manager.ts#L54) had **no such guard**. Once the relationship is marked stale again (e.g. a second push/save response whose links-only payload has a *different* `links.related` href, which flips `relationship.state.isStale` via the `hasUpdatedLink` branch) and the already-materialized `ManyArray` is read again, `_syncArray` called `fastPush(currentState, rawValue.data)` with `rawValue.data` `undefined`, throwing:
  ```
  TypeError: Cannot read properties of undefined (reading 'length')
      at fastPush
      at ManyArrayManager._syncArray
  ```

## Fix
Added a single `rawValue.data !== undefined` guard in `_syncArray`, directly in front of the clear-and-refill it protects — not a `?? []` fallback (which would silently empty an already-populated array on an unrelated links-only change) and not a fix upstream in the graph layer (which would touch every consumer of relationship state to fix a bug specific to this one array-sync path). If the relationship has never received membership data, there's nothing to sync: the array could only ever have been populated from real data in the first place.

## Test plan
- [x] The regression test added in the first commit (`(sync) we do not error when a save response updates the link on an already-materialized links-only relationship`) now passes locally (rebuilt `@warp-drive/core` + `tests/core`, ran via `bun ./diagnostic.js`: 204 total, 202 pass, 2 skip, 0 fail).
- [ ] CI to confirm across the full matrix.