### PR TITLE
fix(ci): sync core's injected build-config copy before core's own build:pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",
     "sync:specs": "pnpm --filter './specs' run sync",
+    "sync:core": "pnpm --filter @warp-drive/core run sync",
     "preview": "cd docs-viewer && pnpm start",
     "lint:tests": "turbo --log-order=stream lint --filter=./tests/* --continue --concurrency=$(./bin/calculate-jobs)",
     "lint:pkg": "turbo --log-order=stream lint --filter=./packages/* --continue --concurrency=$(./bin/calculate-jobs)",

--- a/turbo.json
+++ b/turbo.json
@@ -52,6 +52,18 @@
       "dependsOn": ["@warp-drive/build-config#build:pkg", "@warp-drive/core#build:pkg"]
     },
 
+    // Mirrors //#sync above, but for the opposite direction: @warp-drive/core's
+    // own build:pkg needs build-config's *freshly built* output synced into
+    // core's injected copy before core's babel.config.mjs requires it -- //#sync
+    // can't cover this because it depends on core's build:pkg too (using it here
+    // would be a cycle), so it only runs after core has already (possibly
+    // wrongly) built. These are two separate sync points for two separate races;
+    // do not merge them or make either conditional/cached.
+    "//#sync:core": {
+      "cache": false,
+      "dependsOn": ["@warp-drive/build-config#build:pkg"]
+    },
+
     // run build in all library packages
     // these do not require any associated packages
     // to have been built to build other than
@@ -120,7 +132,7 @@
         "../../config/**"
       ],
       "outputs": ["addon-test-support/**", "dist/**", "cjs-dist/**", "tsconfig.tsbuildinfo"],
-      "dependsOn": ["@warp-drive/build-config#build:pkg"],
+      "dependsOn": ["@warp-drive/build-config#build:pkg", "//#sync:core"],
       "outputLogs": "new-only",
       "env": ["IS_UNPKG_BUILD"]
     },


### PR DESCRIPTION
## Summary
Fixes a pre-existing, non-deterministic CI flake surfaced on PR #10920's `install` job:
```
Error: You appear to be using a native ECMAScript module configuration file,
which is only supported when running Babel asynchronously or when using the
Node.js `--experimental-require-module` flag.
```

## Root cause
- `@warp-drive/core`'s `babel.config.mjs` is loaded synchronously at build time (via `@nullvoxpopuli/ember-rolldown`'s `detectConfigFile()` → Babel's `loadPartialConfigSync`) and requires `@warp-drive/build-config`'s built output.
- That resolves through core's own `node_modules/@warp-drive/build-config` — a pnpm "injected" (hardlinked) workspace copy (`inject-workspace-packages=true` in `.npmrc`).
- pnpm's `sync-injected-deps-after-scripts` hook refreshes these injected copies, but only when pnpm itself directly runs a package's script — never for a turbo-orchestrated task run (already documented in existing `turbo.json`/`.github/actions/setup/action.yml` comments).
- The existing `//#sync` task exists for exactly this class of problem, but it depends on **both** `@warp-drive/build-config#build:pkg` **and** `@warp-drive/core#build:pkg`, so it's scheduled to run *after* core's own build — too late to help core. It can't be added as a dependency of core's own `build:pkg` either, since that would be a cycle.
- So `@warp-drive/core#build:pkg` could run against a stale-or-missing injected `build-config` copy, and Babel's own error handling (`lib/config/files/module-types.js`) masks that `require()` failure as the generic, misleading "native ESM config file" message.
- This is a real, pre-existing race, not something caused by PR #10920's actual diff — any PR touching `warp-drive-packages/core/src/**` forces a genuine cache miss on `@warp-drive/core#build:pkg`, which is what exposes it. Confirmed via `git log`: this exact class of bug (injected-workspace-dep staleness under turbo orchestration) has a long history in this repo (a7b664e76, ad42fc7d2, 757723bb5/ce61b4dd5, f09b2558d, e488b1fd2, 92950cc06, a35c87328) — all of which fixed the *consumers-of-core* direction. This is the one remaining, unfixed direction: core's own build needing build-config synced into itself first.

## Fix
- New task `//#sync:core` (mirrors `//#sync`, but depends only on `@warp-drive/build-config#build:pkg` — no cycle).
- `@warp-drive/core#build:pkg`'s `dependsOn` now includes `//#sync:core`.
- New root script `sync:core` (`pnpm --filter @warp-drive/core run sync`), following the existing `sync:specs` naming convention. Deliberately no `--if-present`: this task exists specifically because core's `sync` stub must run, so it should fail loudly rather than silently no-op if that stub is ever removed.
- Both tasks/comments explicitly cross-reference each other and state they must not be merged or made conditional/cached — per this area's history, a well-intentioned "cleanup" that doesn't realize two separate races exist is exactly how this class of bug keeps getting reintroduced.

No changes needed to `.npmrc`, `.github/actions/setup/action.yml`, or the unpkg release path (`tools/release/core/publish/steps/amend-for-unpkg.ts`) — traced and confirmed the release script's `bumpAllPackages` runs a real `pnpm install` (hitting this fixed graph) before the unpkg step invokes `tsdown` directly, so core's injected copy is already correct by then.

## Test plan
- [x] `pnpm exec turbo run build:pkg --filter=@warp-drive/core --dry=json` confirms `//#sync:core` is now correctly pulled into the graph (previously `//#sync` wasn't reachable at all when scoped to core alone) with no dependency cycle: `build-config#build:pkg → //#sync:core → core#build:pkg`.
- [x] Full unfiltered `--dry=json` confirms the existing `//#sync` → downstream-consumer ordering is untouched.
- [ ] CI: since this is a race, a single green run doesn't prove it — watch for the "native ECMAScript module configuration file" error disappearing across reruns/future PRs.