### PR TITLE
docs(memory-alpha): wire agent entrypoints for Claude, Codex/Grok, Copilot, Cursor, Gemini

### DIFF
--- a/.cursor/rules/memory-alpha.mdc
+++ b/.cursor/rules/memory-alpha.mdc
@@ -1,0 +1,17 @@
+---
+description: Route to WarpDrive's memory-alpha skill index before starting any task
+alwaysApply: true
+---
+
+This repo's knowledge base for AI coding agents is `@warp-drive/memory-alpha`, shipped as plain
+markdown at `warp-drive-packages/memory-alpha/skills/`.
+
+Before starting any task in this repo:
+
+1. Read `warp-drive-packages/memory-alpha/skills/index.md`.
+2. Find the single row that matches your task and read **only** that file.
+3. If nothing matches, the skill doesn't exist yet — proceed using your own judgment and the
+   surrounding code/docs as usual.
+
+Do not browse the rest of `skills/` or read whole directories beyond what the index tells you to
+load — the index is enough to route you.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,14 @@
+# GitHub Copilot Instructions
+
+This repo's knowledge base for AI coding agents is `@warp-drive/memory-alpha`, shipped as plain
+markdown at `warp-drive-packages/memory-alpha/skills/`.
+
+Before starting any task in this repo:
+
+1. Read `warp-drive-packages/memory-alpha/skills/index.md`.
+2. Find the single row that matches your task and read **only** that file.
+3. If nothing matches, the skill doesn't exist yet — proceed using your own judgment and the
+   surrounding code/docs as usual.
+
+Do not browse the rest of `skills/` or read whole directories beyond what the index tells you to
+load — the index is enough to route you.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions
+
+This repo's knowledge base for AI coding agents is [`@warp-drive/memory-alpha`](./warp-drive-packages/memory-alpha),
+shipped as plain markdown at `warp-drive-packages/memory-alpha/skills/`.
+
+Before starting any task in this repo:
+
+1. Read [`warp-drive-packages/memory-alpha/skills/index.md`](./warp-drive-packages/memory-alpha/skills/index.md).
+2. Find the single row that matches your task and read **only** that file.
+3. If nothing matches, the skill doesn't exist yet — proceed using your own judgment and the
+   surrounding code/docs as usual.
+
+Do not browse the rest of `skills/` or read whole directories beyond what the index tells you to
+load — the index is enough to route you.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Gemini CLI Instructions
+
+@AGENTS.md

--- a/warp-drive-packages/memory-alpha/README.md
+++ b/warp-drive-packages/memory-alpha/README.md
@@ -36,6 +36,24 @@ This table is kept in sync with [`skills/index.md`](./skills/index.md), which is
 routing table published inside the package itself for tooling that lands directly in `skills/`
 without reading this README first.
 
+## Editor & Agent Setup
+
+This repo wires the routing table above into every agent surface it develops against, and each
+one just points back to [`skills/index.md`](./skills/index.md) so there's a single place to
+update:
+
+| Agent | File |
+| --- | --- |
+| Claude Code | [`/CLAUDE.md`](../../CLAUDE.md) |
+| Codex, Grok, Cursor, and other tools following the open [AGENTS.md](https://agents.md) convention | [`/AGENTS.md`](../../AGENTS.md) |
+| Gemini CLI | [`/GEMINI.md`](../../GEMINI.md) |
+| GitHub Copilot | [`/.github/copilot-instructions.md`](../../.github/copilot-instructions.md) |
+| Cursor (project rule, in addition to its AGENTS.md support) | [`/.cursor/rules/memory-alpha.mdc`](../../.cursor/rules/memory-alpha.mdc) |
+
+Consuming this package from an app instead of contributing to WarpDrive itself? Copy whichever
+of those files matches your agent into your own repo and swap the path for
+`node_modules/@warp-drive/memory-alpha/skills/index.md`.
+
 ## Structure
 
 This package has no code and no dependencies — it is a directory of markdown files, organized


### PR DESCRIPTION
## Summary
- Adds root-level `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`, and `.cursor/rules/memory-alpha.mdc`, each just pointing agents at `warp-drive-packages/memory-alpha/skills/index.md` (no duplicated routing content).
- Codex and Grok already read `AGENTS.md` natively, so no separate file was needed for them; Gemini CLI needed its own `GEMINI.md`, which reuses the same `@AGENTS.md` import syntax as `CLAUDE.md`.
- Documents the convention in `warp-drive-packages/memory-alpha/README.md` with a table mapping agent → file, and a note that downstream consumers can copy the pattern into their own apps.

## Test plan
- [x] Confirmed `*.md` is prettier-ignored, so no formatting conflicts
- [x] Manually reviewed each entrypoint file's content and paths
- [ ] Open in Claude Code / Cursor / Copilot to confirm each surface picks up its file as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)