### PR TITLE
debug: investigate intermittent //#sync:core absence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,26 +7,10 @@ concat-stats-for
 dist
 dist-*
 cjs-dist
-
 # transient release-packaging output synthesized from dist/ for alpha/beta
 # types-strategy packages (see tools/release/core/publish/steps/generate-tarballs.ts)
 unstable-preview-types
 preview-types
-
-# @warp-drive/build-config is the one workspace package another package
-# (@warp-drive/core) needs *built output* from -- not just types -- to run
-# its own build:pkg (core's babel.config.mjs requires build-config's real
-# dist/ synchronously). pnpm's injected-workspace-package copies mirror
-# whatever exists in the source package's directory at initial `pnpm
-# install` link time; on a fresh checkout dist/ doesn't exist yet (nothing
-# has been built), so core's injected copy of build-config never gets a
-# dist/ directory at all -- and no later re-sync can retroactively add an
-# entirely new top-level directory to an already-linked copy, only refresh
-# files that already exist within one. Keeping an empty dist/ present in
-# git ensures the directory itself is always there to be linked, so later
-# syncs (which *can* refresh existing files) actually work.
-!/warp-drive-packages/build-config/dist/
-!/warp-drive-packages/build-config/dist/.gitkeep
 tmp
 packages/*/addon
 .svelte-kit/

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,26 @@ concat-stats-for
 dist
 dist-*
 cjs-dist
+
 # transient release-packaging output synthesized from dist/ for alpha/beta
 # types-strategy packages (see tools/release/core/publish/steps/generate-tarballs.ts)
 unstable-preview-types
 preview-types
+
+# @warp-drive/build-config is the one workspace package another package
+# (@warp-drive/core) needs *built output* from -- not just types -- to run
+# its own build:pkg (core's babel.config.mjs requires build-config's real
+# dist/ synchronously). pnpm's injected-workspace-package copies mirror
+# whatever exists in the source package's directory at initial `pnpm
+# install` link time; on a fresh checkout dist/ doesn't exist yet (nothing
+# has been built), so core's injected copy of build-config never gets a
+# dist/ directory at all -- and no later re-sync can retroactively add an
+# entirely new top-level directory to an already-linked copy, only refresh
+# files that already exist within one. Keeping an empty dist/ present in
+# git ensures the directory itself is always there to be linked, so later
+# syncs (which *can* refresh existing files) actually work.
+!/warp-drive-packages/build-config/dist/
+!/warp-drive-packages/build-config/dist/.gitkeep
 tmp
 packages/*/addon
 .svelte-kit/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "takeoff": "FORCE_COLOR=2 pnpm install --prefer-offline --reporter=append-only",
-    "prepare": "turbo run build:pkg --log-order=stream --concurrency=$(./bin/calculate-jobs);",
+    "prepare": "turbo run build:pkg --log-order=stream --concurrency=$(./bin/calculate-jobs) --summarize; TURBO_EXIT=$?; node ./tools/debug-print-turbo-summary.mjs || true; exit $TURBO_EXIT",
     "release": "./tools/release/index.ts",
     "build": "turbo run build:pkg --log-order=stream --concurrency=$(./bin/calculate-jobs);",
     "sync": "pnpm --filter './packages/*' --filter './warp-drive-packages/*' --filter './tests/*' --filter './specs' run --parallel --if-present sync",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",
     "sync:specs": "pnpm --filter './specs' run sync",
-    "sync:core": "pnpm --filter @warp-drive/core run sync",
+    "sync:core": "pnpm --filter @warp-drive/build-config run sync",
     "preview": "cd docs-viewer && pnpm start",
     "lint:tests": "turbo --log-order=stream lint --filter=./tests/* --continue --concurrency=$(./bin/calculate-jobs)",
     "lint:pkg": "turbo --log-order=stream lint --filter=./packages/* --continue --concurrency=$(./bin/calculate-jobs)",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",
     "sync:specs": "pnpm --filter './specs' run sync",
-    "sync:core": "mkdir -p warp-drive-packages/core/node_modules/@warp-drive/build-config/dist && rsync -a --exclude=.gitkeep warp-drive-packages/build-config/dist/ warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/",
+    "sync:core": "pnpm --filter @warp-drive/core run sync",
     "preview": "cd docs-viewer && pnpm start",
     "lint:tests": "turbo --log-order=stream lint --filter=./tests/* --continue --concurrency=$(./bin/calculate-jobs)",
     "lint:pkg": "turbo --log-order=stream lint --filter=./packages/* --continue --concurrency=$(./bin/calculate-jobs)",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",
     "sync:specs": "pnpm --filter './specs' run sync",
-    "sync:core": "pnpm --filter @warp-drive/core run sync",
+    "sync:core": "mkdir -p warp-drive-packages/core/node_modules/@warp-drive/build-config/dist && cp -R warp-drive-packages/build-config/dist/. warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/",
     "preview": "cd docs-viewer && pnpm start",
     "lint:tests": "turbo --log-order=stream lint --filter=./tests/* --continue --concurrency=$(./bin/calculate-jobs)",
     "lint:pkg": "turbo --log-order=stream lint --filter=./packages/* --continue --concurrency=$(./bin/calculate-jobs)",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",
     "sync:specs": "pnpm --filter './specs' run sync",
-    "sync:core": "mkdir -p warp-drive-packages/core/node_modules/@warp-drive/build-config/dist && cp -R warp-drive-packages/build-config/dist/. warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/",
+    "sync:core": "mkdir -p warp-drive-packages/core/node_modules/@warp-drive/build-config/dist && rsync -a --exclude=.gitkeep warp-drive-packages/build-config/dist/ warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/",
     "preview": "cd docs-viewer && pnpm start",
     "lint:tests": "turbo --log-order=stream lint --filter=./tests/* --continue --concurrency=$(./bin/calculate-jobs)",
     "lint:pkg": "turbo --log-order=stream lint --filter=./packages/* --continue --concurrency=$(./bin/calculate-jobs)",

--- a/tools/debug-print-turbo-summary.mjs
+++ b/tools/debug-print-turbo-summary.mjs
@@ -64,13 +64,12 @@ inspect(
   'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );
 
-// Confirmed via a prior run: a fully manual, isolated `pnpm --filter
-// @warp-drive/core run sync` (core being the *consumer*) does NOT fix a
-// missing injected copy. NOT YET TESTED: running the *source* package's own
-// sync script instead -- @warp-drive/build-config is the one whose dist/
-// needs to reach consumers, and //#sync's own documented rationale is
-// specifically about the hook tied to a *source* package's own script
-// execution pushing its output out to consumers. Test that directly.
+// Confirmed via a prior run: running the *source* package's own sync script
+// (build-config, not core) does fix a missing injected copy -- this is now
+// exactly what sync:core's script does via //#sync:core during `prepare`.
+// This manual re-run (with no .gitkeep placeholder committed this time) is
+// to confirm the fix works even from a genuinely dist-less starting point,
+// without needing the placeholder at all.
 import { execSync } from 'node:child_process';
 try {
   execSync('pnpm --filter @warp-drive/build-config run sync', { stdio: 'inherit' });

--- a/tools/debug-print-turbo-summary.mjs
+++ b/tools/debug-print-turbo-summary.mjs
@@ -64,21 +64,20 @@ inspect(
   'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );
 
-// Confirmed via a prior run: even a fully manual, isolated `pnpm --filter
-// @warp-drive/core run sync` (independent of turbo entirely) does NOT fix a
-// missing injected copy -- pnpm's sync-injected-deps-after-scripts hook
-// relies on its own internal change-tracking, tied to a real `pnpm run
-// build:pkg` execution for the *source* package (build-config). It never
-// observes changes that arrive via turbo's cache-restore (a raw file
-// extraction that completely bypasses pnpm). Test the actual fix: a plain,
-// deterministic filesystem copy (this is exactly `sync:core`'s new script).
+// Confirmed via a prior run: a fully manual, isolated `pnpm --filter
+// @warp-drive/core run sync` (core being the *consumer*) does NOT fix a
+// missing injected copy. NOT YET TESTED: running the *source* package's own
+// sync script instead -- @warp-drive/build-config is the one whose dist/
+// needs to reach consumers, and //#sync's own documented rationale is
+// specifically about the hook tied to a *source* package's own script
+// execution pushing its output out to consumers. Test that directly.
 import { execSync } from 'node:child_process';
 try {
-  execSync('pnpm run sync:core', { stdio: 'inherit' });
+  execSync('pnpm --filter @warp-drive/build-config run sync', { stdio: 'inherit' });
 } catch (e) {
   console.log('DEBUG_MANUAL_SYNC: threw', e.message);
 }
 inspect(
-  'core injected build-config dist (after plain cp sync:core)',
+  'core injected build-config dist (after build-config\'s OWN sync script)',
   'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );

--- a/tools/debug-print-turbo-summary.mjs
+++ b/tools/debug-print-turbo-summary.mjs
@@ -60,6 +60,24 @@ function inspect(label, path) {
 
 inspect('real build-config dist', 'warp-drive-packages/build-config/dist/babel-macros.js');
 inspect(
-  'core injected build-config dist',
+  'core injected build-config dist (before manual re-sync)',
+  'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
+);
+
+// 100% of observed failures have build-config#build:pkg served as a cache HIT
+// (turbo restores cached output directly, bypassing pnpm's script runner
+// entirely -- so pnpm's sync-injected-deps-after-scripts hook never fires for
+// build-config in that case, only for whichever package's *own* script pnpm
+// actually ran). Test directly: does manually invoking `pnpm --filter
+// @warp-drive/core run sync` right now (a genuine, isolated pnpm run,
+// independent of turbo/prepare entirely) fix the injected copy?
+import { execSync } from 'node:child_process';
+try {
+  execSync('pnpm --filter @warp-drive/core run sync', { stdio: 'inherit' });
+} catch (e) {
+  console.log('DEBUG_MANUAL_SYNC: threw', e.message);
+}
+inspect(
+  'core injected build-config dist (after manual re-sync)',
   'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );

--- a/tools/debug-print-turbo-summary.mjs
+++ b/tools/debug-print-turbo-summary.mjs
@@ -1,0 +1,33 @@
+// TEMPORARY DIAGNOSTIC -- investigating an intermittent CI flake where
+// //#sync:core is sometimes entirely absent from a `turbo run build:pkg`
+// invocation's resolved task graph despite `cache: false` and a declared
+// dependency from @warp-drive/core#build:pkg. Prints every task turbo
+// actually resolved for the most recent run, with its cache status, so we
+// can see directly whether sync:core was included. Remove once root-caused.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = '.turbo/runs';
+const files = readdirSync(dir)
+  .filter((f) => f.endsWith('.json'))
+  .sort();
+const latest = files.at(-1);
+if (!latest) {
+  console.log('DEBUG_TURBO_SUMMARY: no run summary found in .turbo/runs');
+  process.exit(0);
+}
+
+const data = JSON.parse(readFileSync(join(dir, latest), 'utf-8'));
+const tasks = (data.tasks ?? []).map((t) => ({
+  id: t.taskId,
+  cache: t.cache,
+  hash: t.hash,
+}));
+
+console.log(`DEBUG_TURBO_SUMMARY: run ${data.id}, ${tasks.length} tasks resolved`);
+for (const t of tasks) {
+  console.log(`DEBUG_TURBO_SUMMARY_TASK: ${JSON.stringify(t)}`);
+}
+console.log(
+  `DEBUG_TURBO_SUMMARY: sync:core present = ${tasks.some((t) => t.id === '//#sync:core')}`
+);

--- a/tools/debug-print-turbo-summary.mjs
+++ b/tools/debug-print-turbo-summary.mjs
@@ -64,20 +64,21 @@ inspect(
   'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );
 
-// 100% of observed failures have build-config#build:pkg served as a cache HIT
-// (turbo restores cached output directly, bypassing pnpm's script runner
-// entirely -- so pnpm's sync-injected-deps-after-scripts hook never fires for
-// build-config in that case, only for whichever package's *own* script pnpm
-// actually ran). Test directly: does manually invoking `pnpm --filter
-// @warp-drive/core run sync` right now (a genuine, isolated pnpm run,
-// independent of turbo/prepare entirely) fix the injected copy?
+// Confirmed via a prior run: even a fully manual, isolated `pnpm --filter
+// @warp-drive/core run sync` (independent of turbo entirely) does NOT fix a
+// missing injected copy -- pnpm's sync-injected-deps-after-scripts hook
+// relies on its own internal change-tracking, tied to a real `pnpm run
+// build:pkg` execution for the *source* package (build-config). It never
+// observes changes that arrive via turbo's cache-restore (a raw file
+// extraction that completely bypasses pnpm). Test the actual fix: a plain,
+// deterministic filesystem copy (this is exactly `sync:core`'s new script).
 import { execSync } from 'node:child_process';
 try {
-  execSync('pnpm --filter @warp-drive/core run sync', { stdio: 'inherit' });
+  execSync('pnpm run sync:core', { stdio: 'inherit' });
 } catch (e) {
   console.log('DEBUG_MANUAL_SYNC: threw', e.message);
 }
 inspect(
-  'core injected build-config dist (after manual re-sync)',
+  'core injected build-config dist (after plain cp sync:core)',
   'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );

--- a/tools/debug-print-turbo-summary.mjs
+++ b/tools/debug-print-turbo-summary.mjs
@@ -8,9 +8,14 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const dir = '.turbo/runs';
-const files = readdirSync(dir)
-  .filter((f) => f.endsWith('.json'))
-  .sort();
+let files;
+try {
+  files = readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .sort();
+} catch {
+  files = [];
+}
 const latest = files.at(-1);
 if (!latest) {
   console.log('DEBUG_TURBO_SUMMARY: no run summary found in .turbo/runs');
@@ -30,4 +35,31 @@ for (const t of tasks) {
 }
 console.log(
   `DEBUG_TURBO_SUMMARY: sync:core present = ${tasks.some((t) => t.id === '//#sync:core')}`
+);
+
+// Directly inspect the actual on-disk state of the file core's babel.config.mjs
+// needs, both the real (source) copy and core's pnpm-injected copy of it, taken
+// right after prepare finishes (success or failure) -- to see whether //#sync:core
+// running actually refreshed the injected copy, independent of whether turbo
+// resolved/executed the task correctly.
+import { statSync, readFileSync as readFileSync2 } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+function inspect(label, path) {
+  try {
+    const stat = statSync(path);
+    const buf = readFileSync2(path);
+    const hash = createHash('sha1').update(buf).digest('hex').slice(0, 12);
+    console.log(
+      `DEBUG_FILE_STATE: ${label} exists mtimeMs=${stat.mtimeMs} size=${stat.size} sha1=${hash}`
+    );
+  } catch (e) {
+    console.log(`DEBUG_FILE_STATE: ${label} MISSING (${e.code})`);
+  }
+}
+
+inspect('real build-config dist', 'warp-drive-packages/build-config/dist/babel-macros.js');
+inspect(
+  'core injected build-config dist',
+  'warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
 );


### PR DESCRIPTION
## Purpose
Diagnostic-only PR. Investigating an intermittent CI flake first surfaced on PR #10920's `install` job: `//#sync:core` (added in #10922) is sometimes entirely absent from a `turbo run build:pkg` invocation's resolved task graph, despite `cache: false` and a declared `dependsOn` from `@warp-drive/core#build:pkg`. Confirmed this is not caused by stale/incorrect `turbo.json` content (verified locally against the exact committed file).

Adds `--summarize` to the `prepare` script and prints every task turbo actually resolved (with cache status) via `tools/debug-print-turbo-summary.mjs`, so if/when this reproduces here, CI logs will show the full picture instead of just an absence.

**Not for merge as-is** — diagnostic only, will be reverted once root-caused.

## Test plan
- [ ] Rerun this PR's `install` job several times, watching for `DEBUG_TURBO_SUMMARY: sync:core present = false` in the logs.