### PR TITLE
fix(build-config): stop trusting __dirname in features.ts's ESM/CJS dual-mode check

### DIFF
--- a/warp-drive-packages/build-config/src/-private/utils/features.ts
+++ b/warp-drive-packages/build-config/src/-private/utils/features.ts
@@ -5,7 +5,13 @@ import { fileURLToPath } from 'node:url';
 import * as CURRENT_FEATURES from '../../canary-features.ts';
 type FEATURE = keyof typeof CURRENT_FEATURES;
 
-const dirname = typeof __dirname !== 'undefined' ? __dirname : fileURLToPath(new URL('.', import.meta.url));
+// This package's "." export always resolves to this compiled ESM file (see
+// package.json's `exports` map) -- there is no separate CJS build where a real
+// `__dirname` would exist. Node's synchronous require-of-ESM interop (e.g. Babel's
+// `loadPartialConfigSync`, used by @nullvoxpopuli/ember-rolldown's `detectConfigFile`)
+// stubs in `__dirname = "."`, a truthy but wrong value, silently resolving
+// `../package.json` against `process.cwd()` instead of this file's real directory.
+const dirname = fileURLToPath(new URL('.', import.meta.url));
 const relativePkgPath = path.join(dirname, '../package.json');
 
 const version = JSON.parse(fs.readFileSync(relativePkgPath, 'utf-8')).version;


### PR DESCRIPTION
its not clear this is truly diagnosed correctly as the core issue, but seems like a good cleanup

Notes from Claude below, which I am skeptical of some of the claims of:
-------------------

## Summary
- `@warp-drive/build-config`'s `features.ts` used `typeof __dirname !== 'undefined' ? __dirname : ...import.meta.url fallback` to locate its own `package.json`, but this package's `exports` map always resolves to the compiled ESM `dist/index.js` — there's no CJS build where `__dirname` is ever a real path.
- Node's synchronous require-of-ESM interop (hit whenever something calls Babel's `loadPartialConfigSync` on an `.mjs` config that imports this package — e.g. `@nullvoxpopuli/ember-rolldown`'s `detectConfigFile`, used by `tsdown`) stubs in `__dirname = "."`, a truthy but wrong value. The old check picked the CJS branch anyway and resolved `../package.json` against `process.cwd()` instead of the file's real directory, throwing `ENOENT`.
- Babel's own config-loader swallows that `ENOENT` for any `.mjs` config file and reports a generic "you appear to be using a native ECMAScript module configuration file..." error instead — which is why this surfaced in CI as `@warp-drive/core#build:pkg` failing with a Babel ESM-support message on a cache miss, even though Node fully supports ESM config files. The fix is to just always resolve via `import.meta.url`, since this file is always run as ESM.

## Test plan
- [x] Reproduced directly: `node -e "require('warp-drive-packages/core/babel.config.mjs')"` threw `ENOENT: ... open '../package.json'` from build-config's `dist/index.js` before this change.
- [x] Confirmed the same `require()` call returns cleanly after the fix and rebuild.
- [x] Ran `turbo run build:pkg --filter=@warp-drive/core --force` end-to-end after the fix — succeeds (previously failed with the masked ESM error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)