### PR TITLE
fix(ci): point sync:core at build-config's own sync script, not core's

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "turbo run start --filter=./packages/* --concurrency=23",
     "start:specs": "turbo run start --filter=./specs",
     "sync:specs": "pnpm --filter './specs' run sync",
-    "sync:core": "pnpm --filter @warp-drive/core run sync",
+    "sync:core": "pnpm --filter @warp-drive/build-config run sync",
     "preview": "cd docs-viewer && pnpm start",
     "lint:tests": "turbo --log-order=stream lint --filter=./tests/* --continue --concurrency=$(./bin/calculate-jobs)",
     "lint:pkg": "turbo --log-order=stream lint --filter=./packages/* --continue --concurrency=$(./bin/calculate-jobs)",

--- a/turbo.json
+++ b/turbo.json
@@ -59,6 +59,14 @@
     // would be a cycle), so it only runs after core has already (possibly
     // wrongly) built. These are two separate sync points for two separate races;
     // do not merge them or make either conditional/cached.
+    //
+    // Named for *who* needs the sync (core), but its underlying script
+    // (sync:core, see root package.json) runs @warp-drive/build-config's own
+    // "sync" script, not core's. sync-injected-deps-after-scripts pushes a
+    // package's freshly-built output out to consumers when *that package's
+    // own* script runs -- running core's own sync script (core is the
+    // consumer here) does not pull build-config's output in, no matter how
+    // or when it's invoked; confirmed directly against a live repro.
     "//#sync:core": {
       "cache": false,
       "dependsOn": ["@warp-drive/build-config#build:pkg"]


### PR DESCRIPTION
## Summary
Root-causes and fixes the intermittent CI flake first surfaced on PR #10920's `install` job (masked as a generic, misleading "native ECMAScript module configuration file" error from Babel loading `@warp-drive/core`'s `babel.config.mjs`).

## Investigation
Done via a throwaway debug branch/PR (#10924, closed without merging) that added `turbo run --summarize` output and direct on-disk file-state checks (mtime/size/sha1) to CI, then reverted once root-caused. Confirmed:

1. The real, otherwise Babel-swallowed error is:
   ```
   Error [ERR_MODULE_NOT_FOUND]: Cannot find module
   '.../warp-drive-packages/core/node_modules/@warp-drive/build-config/dist/babel-macros.js'
   ```
2. `//#sync:core` (added in #10922 to refresh core's injected copy of `@warp-drive/build-config` before core's own `build:pkg` runs) reliably runs, in the right order, every time — confirmed via `--summarize`. Turbo's task graph and scheduling are not at fault.
3. The actual mistake was which package's own sync script it ran. pnpm's `sync-injected-deps-after-scripts` hook pushes a package's freshly-built output out to consumers when *that package's own* script runs — it does not pull a dependency's output in when a *consumer*'s script runs, no matter how or when that's invoked. Confirmed directly: even a fully isolated, manual `pnpm --filter @warp-drive/core run sync` (core being the consumer), independent of turbo entirely, could not populate a missing injected copy. Running `pnpm --filter @warp-drive/build-config run sync` (build-config being the source) instead fixed it immediately.
4. Across every CI run observed, **100% of failures** had `@warp-drive/build-config#build:pkg` served as a cache **hit** (bypassing pnpm's script runner); **0%** of cache-miss/real-execution runs failed — consistent with the corrected mechanism.

## Fix
One line: `sync:core` now runs `pnpm --filter @warp-drive/build-config run sync` instead of `pnpm --filter @warp-drive/core run sync`. This is the same mechanism `//#sync` itself already relies on (its broad fan-out includes every source package's own sync script) — just applied specifically and reliably for this one dependency edge. No filesystem bypass, no placeholder files needed.

## Test plan
- [x] Reproduced the exact failure-prone condition (`build-config#build:pkg` served as a cache hit) against this fix in CI multiple times on the debug branch — all passed, with the injected copy's content confirmed matching build-config's real output (mtime/size/sha1), even starting from a genuinely dist-less state.
- [x] Re-verified after main's pnpm 10 → 11 upgrade (#10925) landed — still passes.
- [ ] Watch this PR's own CI, including a rerun or two given the original bug's intermittent nature.