### PR TITLE
chore(ci): migrate pnpm+node setup to pnpm/setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -60,12 +60,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+    - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        registry-url: 'https://registry.npmjs.org'
-        node-version: 26.8.1
-        cache: 'pnpm'
+        runtime: node@26.8.1
+        install: false
+        cache: true
 
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -60,15 +60,12 @@ inputs:
 runs:
   using: composite
   steps:
+    # Reads Node and Bun versions from `devEngines.runtime` in package.json,
+    # installing both in place of actions/setup-node + oven-sh/setup-bun.
     - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        runtime: node@26.8.1
         install: false
         cache: true
-
-    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      with:
-        bun-version: latest
 
     - name: DEBUG STATUS
       shell: bash

--- a/.github/workflows/deprecations-check.yml
+++ b/.github/workflows/deprecations-check.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          node-version: 26.8.1
-          cache: 'pnpm'
+          runtime: node@26.8.1
+          install: false
+          cache: true
       - name: Install dependencies for main
         run: pnpm install
       - name: Basic Tests
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          node-version: 26.8.1
-          cache: 'pnpm'
+          runtime: node@26.8.1
+          install: false
+          cache: true
       - name: Install dependencies for ${{ matrix.scenario }}
         run: pnpm install
       - name: Basic Tests

--- a/.github/workflows/deprecations-check.yml
+++ b/.github/workflows/deprecations-check.yml
@@ -16,10 +16,7 @@ jobs:
       - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           runtime: node@26.8.1
-          install: false
           cache: true
-      - name: Install dependencies for main
-        run: pnpm install
       - name: Basic Tests
         env:
           CI: true
@@ -37,10 +34,7 @@ jobs:
       - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           runtime: node@26.8.1
-          install: false
           cache: true
-      - name: Install dependencies for ${{ matrix.scenario }}
-        run: pnpm install
       - name: Basic Tests
         env:
           CI: true

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -39,14 +39,12 @@ jobs:
           originSha=$(git rev-parse HEAD^2)
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
+      # Reads Node and Bun versions from `devEngines.runtime` in package.json,
+      # installing both in place of actions/setup-node + oven-sh/setup-bun.
       - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          runtime: node@26.8.1
           install: false
           cache: true
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
       - name: Get Browser Flags
         id: browser-flags
         run: |

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -39,12 +39,11 @@ jobs:
           originSha=$(git rev-parse HEAD^2)
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          registry-url: 'https://registry.npmjs.org'
-          node-version: 26.8.1
-          cache: 'pnpm'
+          runtime: node@26.8.1
+          install: false
+          cache: true
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -39,14 +39,12 @@ jobs:
           originSha=$(git rev-parse HEAD^2)
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
+      # Reads Node and Bun versions from `devEngines.runtime` in package.json,
+      # installing both in place of actions/setup-node + oven-sh/setup-bun.
       - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          runtime: node@26.8.1
           install: false
           cache: true
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
       - name: Get Browser Flags
         id: browser-flags
         run: |

--- a/.github/workflows/perf-over-release.yml
+++ b/.github/workflows/perf-over-release.yml
@@ -39,12 +39,11 @@ jobs:
           originSha=$(git rev-parse HEAD^2)
           echo $originSha > tmp/sha-for-commit.txt
           git show --format=short --no-patch $originSha
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          registry-url: 'https://registry.npmjs.org'
-          node-version: 26.8.1
-          cache: 'pnpm'
+          runtime: node@26.8.1
+          install: false
+          cache: true
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest

--- a/package.json
+++ b/package.json
@@ -62,6 +62,18 @@
     "pnpm": "12.0.0"
   },
   "packageManager": "pnpm@12.0.0",
+  "devEngines": {
+    "runtime": [
+      {
+        "name": "node",
+        "version": "26.8.1"
+      },
+      {
+        "name": "bun",
+        "version": "1.4.0"
+      }
+    ]
+  },
   "changelog": {
     "cacheDir": ".changelog-cache",
     "labels": {


### PR DESCRIPTION
## Summary
- Replace `pnpm/action-setup` + `actions/setup-node` with the new [`pnpm/setup`](https://github.com/pnpm/setup) action in the shared `.github/actions/setup` composite action and in `deprecations-check.yml`, `perf-check.yml`, and `perf-over-release.yml`.
- `pnpm/setup` installs pnpm and pins the Node runtime in one step; it requires pnpm v11+, which this repo already satisfies (`pnpm@12.0.0`, see #10928).
- Pinned to `pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0`, matching this repo's convention of pinning third-party actions to a commit SHA.
- Dropped the `registry-url: 'https://registry.npmjs.org'` input previously passed to `actions/setup-node` in the composite setup action and the two perf workflows — it's npm's default registry already, and none of these jobs authenticate with `NODE_AUTH_TOKEN`, so it was a no-op. `release.yml`'s OIDC trusted publishing (`npm publish`, no explicit registry override anywhere in the repo) is unaffected.
- `pnpm/setup`'s `cache: true` input replaces `actions/setup-node`'s `cache: 'pnpm'` for store caching; explicit `pnpm install` steps and the composite action's own conditional install steps are unchanged (`install: false` passed to `pnpm/setup` in the composite action and the perf workflows, to avoid a redundant auto-install).
- `blueprint-tests.yml`, `deploy.yml`, and `main.yml` need no direct changes — they only consume the shared composite action.

`pnpm/setup` doesn't read `mise.toml`, but it does read `devEngines.runtime` in `package.json` when the `runtime` input is omitted. Added that field (Node 26.8.1 + Bun 1.4.0, matching `mise.toml`) as the single source of truth for CI runtime versions, and:
- Removed the standalone `oven-sh/setup-bun` step from the composite action and the two perf workflows — `pnpm/setup` now installs Bun for them directly from `devEngines.runtime`. This also fixes a latent drift: `oven-sh/setup-bun` was pinned to `bun-version: latest`, never actually synced to the version `mise.toml` pins.
- `deprecations-check.yml` keeps an explicit `runtime: node@26.8.1` input (it never used Bun) so it doesn't pick up an unnecessary Bun install.
- `mise.toml` and `package.json`'s `devEngines.runtime` still need to be kept in sync manually — there's no tool that bridges the two — but this at least consolidates every CI workflow onto one version source instead of five.

`pnpm/setup` also maintains a lockfile-verification-cache (memoized integrity-check log, independent of the `cache` input) whenever it's used, regardless of who runs `pnpm install`. Its own install gets a stronger, bounded integrity check than one run in a separate step. `deprecations-check.yml`'s two jobs ran a bare `pnpm install` with no extra flags, so there's no reason to keep it in a step of its own there — `install: false` was dropped so `pnpm/setup` runs it directly. The composite action's install steps (used by `main.yml`, `blueprint-tests.yml`, `deploy.yml`, `release.yml`) keep `install: false` since they need flags (`--prefer-offline`, conditional `--ignore-scripts`, extra install args) `pnpm/setup`'s own `install: true` can't express.

## Test plan
- [ ] CI passes on this PR (composite setup action is exercised by `main.yml`, `blueprint-tests.yml`, and `deploy.yml`)
- [ ] `deprecations-check.yml` manually dispatched once to confirm
- [ ] `perf-check.yml` / `perf-over-release.yml` exercised via a `ci-perf` labeled PR