### PR TITLE
fix(docs): point memory-alpha API page edit link at its skills source

### DIFF
--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -521,9 +521,16 @@ function cleanSidebarItems(items: SidebarItem[], isPrimitive = false): SidebarIt
 // can point the "Edit this page" link at the original source instead of the generated .md.
 const DEFINED_IN_PATTERN = /^Defined in: (?:\[([^:\]]+):\d+\]|([^:\n]+):\d+)/m;
 
-function buildFrontmatter(content: string): string {
+// Packages with no source code (readme-only typedoc entries) never emit a "Defined in" line,
+// so their generated pages fall back to the generated api/ path. Map those pages to the real
+// markdown source that should be edited instead.
+const EDIT_SOURCE_OVERRIDES: Record<string, string> = {
+  '@warp-drive/memory-alpha/index.md': 'warp-drive-packages/memory-alpha/skills/index.md',
+};
+
+function buildFrontmatter(content: string, file: string): string {
   const match = DEFINED_IN_PATTERN.exec(content);
-  const editSource = match?.[1] ?? match?.[2];
+  const editSource = EDIT_SOURCE_OVERRIDES[file] ?? match?.[1] ?? match?.[2];
   return `---
 outline:
   level: [2, 3]${editSource ? `\neditSource: ${editSource}` : ''}
@@ -953,7 +960,7 @@ export async function postProcessApiDocs() {
     }
 
     // insert frontmatter
-    newContent = buildFrontmatter(newContent) + newContent;
+    newContent = buildFrontmatter(newContent, file) + newContent;
 
     // if the content has a modules list, we remove it
     if (newContent.includes('## Modules')) {


### PR DESCRIPTION
## Summary
- The `/api/@warp-drive/memory-alpha/` page's "Edit this page" link pointed at the generated `api/@warp-drive/memory-alpha/index.md`, since that package has no source code and typedoc never emits a "Defined in" line for it to derive `editSource` from.
- Added a small override map in `postProcessApiDocs`'s frontmatter builder so this page's edit link points at `warp-drive-packages/memory-alpha/skills/index.md` instead.

## Test plan
- [x] Ran typedoc against just `warp-drive-packages/memory-alpha` in isolation and confirmed the generated page has no "Defined in" line (confirming the root cause).
- [x] Verified the override map key matches the exact relative path (`@warp-drive/memory-alpha/index.md`) that `postProcessApiDocs` iterates over.
- [ ] CI docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)