### PR TITLE
docs(memory-alpha): give humans the same skill decision tree as agents

### DIFF
--- a/warp-drive-packages/memory-alpha/skills/contributors/_meta.json
+++ b/warp-drive-packages/memory-alpha/skills/contributors/_meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Contributors",
   "items": ["fix-at-the-source"],
+  "webIndex": "overview",
   "files": {
     "index": { "draft": true },
     "fix-at-the-source": { "title": "Fix at the Source" }

--- a/warp-drive-packages/memory-alpha/skills/contributors/overview.md
+++ b/warp-drive-packages/memory-alpha/skills/contributors/overview.md
@@ -1,0 +1,10 @@
+# WarpDrive Contributor Skills
+
+Skills for contributing to WarpDrive's own codebase, not for consuming `@warp-drive/*` packages
+as a dependency in an app.
+
+| If you need to... | Go to |
+| --- | --- |
+| Fix a bug, add a guard, or add a fallback in WarpDrive's internals (`Store`, cache, graph, reactive signals, record arrays) | [Fix at the Source](/skills/contributors/fix-at-the-source.md) |
+
+If nothing above matches, the skill you need doesn't exist yet in this category.

--- a/warp-drive-packages/memory-alpha/skills/overview.md
+++ b/warp-drive-packages/memory-alpha/skills/overview.md
@@ -12,7 +12,16 @@ away-team incident that torched the original — so it can be installed into any
 consumed by an MCP server, a Claude Code skill, or adapted into tool-specific instruction files
 (Cursor rules, Copilot instructions, etc.).
 
-Browse the categories in the sidebar to get started. If you're an AI agent rather than a human
-reader, don't start here — read the package's `skills/index.md` (or its
+Find the row below that matches what you're doing, or browse the categories in the sidebar.
+
+| If you need to... | Go to |
+| --- | --- |
+| Define a resource's shape — fields, relationships, identity — for the `Store` | [Define a Resource Schema](/skills/schemas/define-a-resource-schema.md) |
+| Fetch or query remote data through the `Store` so it's cached and reactive | [Fetch and Cache Data](/skills/requests/fetch-and-cache-data.md) |
+| You're contributing to WarpDrive itself, not just consuming it as a dependency | [Contributor Skills](/skills/contributors/index.md) |
+
+This is the same routing table an AI agent uses to find a skill — it just links out to readable
+pages instead of naming files to read. If you're an AI agent rather than a human reader, don't
+start here — read the package's `skills/index.md` (or its
 [README](https://www.npmjs.com/package/@warp-drive/memory-alpha)) instead, which routes you
 directly to the one file you need without loading this page or any directory listing.


### PR DESCRIPTION
## Summary
- The skills landing page (`/skills/`) told humans to just browse the sidebar, with no way to jump straight to the skill matching their task — unlike the agent-facing `skills/index.md`, which routes agents via a decision table.
- Added a linked version of that same routing table to the human-facing `overview.md` (root skills landing page).
- The routing table's "contributing to WarpDrive" row points at `/skills/contributors/`, which previously had no human-facing page at all (its `index.md` is agent-only/draft). Added a `contributors/overview.md` with the equivalent human-linked table, wired up via the existing `webIndex` mechanism in `_meta.json` (same pattern already used for the root skills page).

## Test plan
- [x] Ran the full `pnpm run build` in `docs-viewer` and inspected the generated `dist/skills/index.html` and `dist/skills/contributors/index.html` — all three table links resolve to real generated pages (`/skills/schemas/define-a-resource-schema`, `/skills/requests/fetch-and-cache-data`, `/skills/contributors/` → `/skills/contributors/fix-at-the-source`).
- [x] Confirmed the agent-facing `skills/index.md` and `contributors/index.md` files (read by AI agents from the npm package) are untouched — only the human `overview.md` pages changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)