### PR TITLE
docs: Add @since and @public tags to pagination APIs

### DIFF
--- a/docs-viewer/src/site-utils.ts
+++ b/docs-viewer/src/site-utils.ts
@@ -645,7 +645,13 @@ function extractSinceBadges(content: string): { content: string; moduleSince: st
     }
 
     const existing = badgesByHeadingLine.get(parent.index) ?? { level: parent.level, badges: [] };
-    existing.badges.push(sinceBadgeMarkup(version));
+    const badge = sinceBadgeMarkup(version);
+    // A callable interface/type's doc comment is copied onto both the interface reflection and
+    // its call signature, producing two `#### Since` sections that both resolve to this same
+    // parent heading -- skip the duplicate rather than rendering the badge twice.
+    if (!existing.badges.includes(badge)) {
+      existing.badges.push(badge);
+    }
     badgesByHeadingLine.set(parent.index, existing);
   }
 

--- a/warp-drive-packages/core/src/signals/page-cache.ts
+++ b/warp-drive-packages/core/src/signals/page-cache.ts
@@ -1,6 +1,3 @@
-/**
- * @module @warp-drive/ember
- */
 import { assert } from '@warp-drive/core/build-config/macros';
 
 import type { ReactiveDocument } from '../reactive.ts';
@@ -65,6 +62,8 @@ type Links = {
  * }
  * ```
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PageCache<RT = unknown, E = unknown> {

--- a/warp-drive-packages/core/src/signals/pagination-cache.ts
+++ b/warp-drive-packages/core/src/signals/pagination-cache.ts
@@ -198,7 +198,6 @@ export class PaginationCache<RT = unknown, E = unknown> {
    */
   @memoized
   get pages(): Iterable<Readonly<PageCache<RT, E>>> {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {
@@ -221,7 +220,6 @@ export class PaginationCache<RT = unknown, E = unknown> {
    */
   @memoized
   get data(): Iterable<ContentItem<RT>> {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {

--- a/warp-drive-packages/core/src/signals/pagination-cache.ts
+++ b/warp-drive-packages/core/src/signals/pagination-cache.ts
@@ -198,6 +198,7 @@ export class PaginationCache<RT = unknown, E = unknown> {
    */
   @memoized
   get pages(): Iterable<Readonly<PageCache<RT, E>>> {
+    // oxlint-disable-next-line typescript/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {
@@ -220,6 +221,7 @@ export class PaginationCache<RT = unknown, E = unknown> {
    */
   @memoized
   get data(): Iterable<ContentItem<RT>> {
+    // oxlint-disable-next-line typescript/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {

--- a/warp-drive-packages/core/src/signals/pagination-cache.ts
+++ b/warp-drive-packages/core/src/signals/pagination-cache.ts
@@ -1,6 +1,3 @@
-/**
- * @module @warp-drive/ember
- */
 import { assert } from '@warp-drive/build-config/macros';
 
 import type { ReactiveDocument } from '../reactive.ts';
@@ -13,14 +10,20 @@ const PaginationCacheMap = new Map<string, PaginationCache>();
 
 /**
  * A hint function for extracting the `currentPage` and `totalPages` from a loaded
- * document. Provided by the consumer via `<Paginate @pageHints={{...}} />` when the
- * response does not expose these values through the default `meta` locations.
+ * document, for when the response does not expose these values through the
+ * default `meta` locations. Provided by the consumer via `<Paginate />`'s
+ * `@pageHints` arg:
+ *
+ * ```gts
+ * <Paginate @pageHints={{...}} />
+ * ```
  *
  * Since these values are attached to the shared {@link PaginationCache}, the hint is
  * a property of the *collection*, not the component. Every `<Paginate />` sharing a
  * collection must provide the same function reference — define it once at module
  * scope and import it everywhere.
  *
+ * @since 5.9.0
  * @public
  */
 export interface PageHints {
@@ -32,6 +35,7 @@ export interface PageHints {
  * document `meta`, matching the behavior used before `pageHints` was configurable.
  * Used whenever the consumer does not provide a `pageHints` function.
  *
+ * @since 5.9.0
  * @public
  */
 export const defaultPageHints: PageHints = (document) => {
@@ -50,6 +54,8 @@ export const defaultPageHints: PageHints = (document) => {
  * interact with — the cache itself is plumbing shared between the pagination
  * classes.
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PaginationCache<RT = unknown, E = unknown> {
@@ -234,9 +240,8 @@ export class PaginationCache<RT = unknown, E = unknown> {
  * `first` or `self` link). Returns the same instance for the same key for the
  * lifetime of the module.
  *
+ * @since 5.9.0
  * @public
- * @static
- * @for @warp-drive/ember
  */
 export function getPaginationCache<RT, E>(key: string): PaginationCache<RT, E> {
   let cache = PaginationCacheMap.get(key);
@@ -254,9 +259,8 @@ export function getPaginationCache<RT, E>(key: string): PaginationCache<RT, E> {
  * Primarily intended for test isolation, since the cache is keyed by url and
  * otherwise persists for the lifetime of the module.
  *
+ * @since 5.9.0
  * @public
- * @static
- * @for @warp-drive/ember
  */
 export function clearPaginationCache(): void {
   PaginationCacheMap.clear();

--- a/warp-drive-packages/core/src/signals/pagination-links-subscription.ts
+++ b/warp-drive-packages/core/src/signals/pagination-links-subscription.ts
@@ -4,6 +4,7 @@ import { getPaginationLinks } from './pagination-links.ts';
 import type { PagedPaginationState } from './pagination-state.ts';
 import { DISPOSE } from './request-subscription.ts';
 
+// oxlint-disable-next-line no-unused-vars
 export interface PaginationLinksSubscription<RT, E> {
   /**
    * The method to call when the component this subscription is attached to

--- a/warp-drive-packages/core/src/signals/pagination-links-subscription.ts
+++ b/warp-drive-packages/core/src/signals/pagination-links-subscription.ts
@@ -4,7 +4,6 @@ import { getPaginationLinks } from './pagination-links.ts';
 import type { PagedPaginationState } from './pagination-state.ts';
 import { DISPOSE } from './request-subscription.ts';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface PaginationLinksSubscription<RT, E> {
   /**
    * The method to call when the component this subscription is attached to

--- a/warp-drive-packages/core/src/signals/pagination-links-subscription.ts
+++ b/warp-drive-packages/core/src/signals/pagination-links-subscription.ts
@@ -31,6 +31,8 @@ export interface PaginationLinksSubscriptionArgs<RT, E> {
  * `<Paginate />` component, so they stay in sync as pages load and the active
  * page changes.
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PaginationLinksSubscription<RT, E> {
@@ -66,6 +68,14 @@ export class PaginationLinksSubscription<RT, E> {
  * Creates the {@link PaginationLinksSubscription} a links component (such as
  * `<EachLink />`) uses to derive its links from a {@link PagedPaginationState}.
  *
+ * ```ts
+ * const subscription = createPaginationLinksSubscription({ pages: paginationState });
+ *
+ * subscription.paginationLinks; // the derived PaginationLinks
+ * subscription[DISPOSE](); // tear down when the owning component unmounts
+ * ```
+ *
+ * @since 5.9.0
  * @public
  */
 export function createPaginationLinksSubscription<RT, E>(

--- a/warp-drive-packages/core/src/signals/pagination-links.ts
+++ b/warp-drive-packages/core/src/signals/pagination-links.ts
@@ -22,6 +22,8 @@ const PaginationLinksCache = new WeakMap<PagedPaginationState, PaginationLinks>(
  * </EachLink>
  * ```
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class RealPaginationLink {
@@ -75,6 +77,8 @@ export class RealPaginationLink {
  * </EachLink>
  * ```
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PlaceholderPaginationLink {
@@ -132,6 +136,8 @@ export class PlaceholderPaginationLink {
  * </EachLink>
  * ```
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class RelationalPaginationLink {
@@ -223,6 +229,8 @@ export type PaginationLink = RealPaginationLink | PlaceholderPaginationLink;
  * - {@link PlaceholderPaginationLink}
  * - {@link RelationalPaginationLink}
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PaginationLinks<RT = unknown, E = unknown> {
@@ -357,6 +365,9 @@ export class PaginationLinks<RT = unknown, E = unknown> {
  *   }
  * }
  * ```
+ *
+ * @since 5.9.0
+ * @public
  */
 export function getPaginationLinks<RT, E>(state: PagedPaginationState<RT, E>): Readonly<PaginationLinks<RT, E>> {
   let links = PaginationLinksCache.get(state);

--- a/warp-drive-packages/core/src/signals/pagination-state.ts
+++ b/warp-drive-packages/core/src/signals/pagination-state.ts
@@ -221,7 +221,6 @@ export class PaginationState<RT = unknown, E = unknown>
    */
   @memoized
   get pages(): Iterable<Readonly<PageCache<RT, E>>> {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {
@@ -262,7 +261,6 @@ export class PaginationState<RT = unknown, E = unknown>
    */
   @memoized
   get data(): Iterable<ContentItem<RT>> {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {

--- a/warp-drive-packages/core/src/signals/pagination-state.ts
+++ b/warp-drive-packages/core/src/signals/pagination-state.ts
@@ -1,6 +1,3 @@
-/**
- * @module @warp-drive/ember
- */
 import { assert } from '@warp-drive/build-config/macros';
 
 import type { RequestManager, Store } from '../index.ts';
@@ -107,6 +104,8 @@ export type PaginationStateFor<RT = unknown, E = unknown, M extends PaginateMode
  * Instances are created via {@link getPaginationState} (or by the `<Paginate />`
  * component on your behalf), never constructed directly.
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PaginationState<RT = unknown, E = unknown>
@@ -636,9 +635,8 @@ const PaginationStateCache = new WeakMap<Future<unknown>, PaginationState>();
  * await pages.loadNext();
  * ```
  *
+ * @since 5.9.0
  * @public
- * @static
- * @for @warp-drive/ember
  */
 export function getPaginationState<RT, E>(request: Future<RT>, pageHints?: PageHints): PaginationState<RT, E> {
   let state = PaginationStateCache.get(request);

--- a/warp-drive-packages/core/src/signals/pagination-state.ts
+++ b/warp-drive-packages/core/src/signals/pagination-state.ts
@@ -221,6 +221,7 @@ export class PaginationState<RT = unknown, E = unknown>
    */
   @memoized
   get pages(): Iterable<Readonly<PageCache<RT, E>>> {
+    // oxlint-disable-next-line typescript/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {
@@ -261,6 +262,7 @@ export class PaginationState<RT = unknown, E = unknown>
    */
   @memoized
   get data(): Iterable<ContentItem<RT>> {
+    // oxlint-disable-next-line typescript/no-this-alias
     const self = this;
     return {
       *[Symbol.iterator]() {

--- a/warp-drive-packages/core/src/signals/pagination-subscription.ts
+++ b/warp-drive-packages/core/src/signals/pagination-subscription.ts
@@ -98,6 +98,7 @@ export interface PaginateArgs<RT, E> extends PaginationSubscriptionArgs<RT, E> {
   store?: Store | RequestManager;
 }
 
+// oxlint-disable-next-line no-unused-vars
 export interface PaginationSubscription<RT, E> {
   /**
    * The method to call when the component this subscription is attached to

--- a/warp-drive-packages/core/src/signals/pagination-subscription.ts
+++ b/warp-drive-packages/core/src/signals/pagination-subscription.ts
@@ -98,7 +98,6 @@ export interface PaginateArgs<RT, E> extends PaginationSubscriptionArgs<RT, E> {
   store?: Store | RequestManager;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface PaginationSubscription<RT, E> {
   /**
    * The method to call when the component this subscription is attached to

--- a/warp-drive-packages/core/src/signals/pagination-subscription.ts
+++ b/warp-drive-packages/core/src/signals/pagination-subscription.ts
@@ -112,6 +112,8 @@ export interface PaginationSubscription<RT, E> {
  * {@link RequestSubscription} (loading/error state, autorefresh, disposal) and
  * the per-component {@link PaginationState} that it hands to the component.
  *
+ * @since 5.9.0
+ * @public
  * @hideconstructor
  */
 export class PaginationSubscription<RT, E> {
@@ -394,6 +396,14 @@ defineSignal(PaginationSubscription.prototype, '_navRequest', null);
  * manage its request lifecycle and pagination state. Pass the result back into
  * the component via `@subscription` to manage the lifecycle externally.
  *
+ * ```ts
+ * const subscription = createPaginationSubscription(store, { request });
+ *
+ * subscription.paginationState; // the per-component PaginationState
+ * subscription[DISPOSE](); // tear down when the owning component unmounts
+ * ```
+ *
+ * @since 5.9.0
  * @public
  */
 export function createPaginationSubscription<RT, E>(

--- a/warp-drive-packages/ember/src/-private/each-link.gts
+++ b/warp-drive-packages/ember/src/-private/each-link.gts
@@ -87,8 +87,10 @@ interface EachLinkSignature<RT, E> {
  * Since the links all read from the shared page graph, they update as pages
  * load and as the active page changes.
  *
- * @class <EachLink />
+ * @since 5.9.0
  * @public
+ * @badge Component
+ * @title <EachLink />
  */
 export class EachLink<RT, E> extends Component<EachLinkSignature<RT, E>> {
   /** @internal */

--- a/warp-drive-packages/ember/src/-private/paginate.gts
+++ b/warp-drive-packages/ember/src/-private/paginate.gts
@@ -241,8 +241,10 @@ interface PaginateSignature<RT, E, M extends PaginateMode = 'paged'> {
  * with `createPaginationSubscription` and pass it via `@subscription` — the
  * component then uses it instead of creating and disposing its own.
  *
- * @class <Paginate />
+ * @since 5.9.0
  * @public
+ * @badge Component
+ * @title <Paginate />
  */
 export class Paginate<RT, E, M extends PaginateMode = 'paged'> extends Component<PaginateSignature<RT, E, M>> {
   /**


### PR DESCRIPTION
## Description

This PR improves the documentation for the pagination signal APIs by:

1. **Adding `@since 5.9.0` tags** to all public pagination-related classes and functions to indicate when they were introduced
2. **Adding `@public` tags** to ensure proper visibility in generated API documentation
3. **Removing obsolete `@module` tags** from pagination-cache.ts and pagination-state.ts that were incorrectly scoped to `@warp-drive/ember`
4. **Removing redundant JSDoc tags** (`@static`, `@for`) from function documentation
5. **Improving JSDoc formatting** with better code examples and clearer descriptions:
   - Enhanced `PageHints` interface documentation with GTS code example
   - Added usage examples to `createPaginationLinksSubscription` and `createPaginationSubscription`
   - Updated component documentation with `@badge Component` and `@title` tags for better rendering
6. **Fixing duplicate badge rendering** in docs-viewer by deduplicating `@since` badges that appear on both interface and call signature reflections

### Files Changed

- `warp-drive-packages/core/src/signals/pagination-cache.ts`
- `warp-drive-packages/core/src/signals/pagination-state.ts`
- `warp-drive-packages/core/src/signals/page-cache.ts`
- `warp-drive-packages/core/src/signals/pagination-links.ts`
- `warp-drive-packages/core/src/signals/pagination-links-subscription.ts`
- `warp-drive-packages/core/src/signals/pagination-subscription.ts`
- `warp-drive-packages/ember/src/-private/paginate.gts`
- `warp-drive-packages/ember/src/-private/each-link.gts`
- `docs-viewer/src/site-utils.ts`

## Test Plan

Preview the updated API documentation:
- Run `pnpm preview` in the root
- Navigate to the pagination APIs section
- Verify that all pagination classes and functions display the `@since 5.9.0` badge
- Verify that component documentation renders correctly with the new `@badge Component` and `@title` tags
- Confirm no duplicate badges appear in the documentation

https://claude.ai/code/session_012tdsFYAoiPFKU9p8QRq1Uc