### PR TITLE
build(lint): close residual oxlint/eslint handoff gaps

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -200,6 +200,7 @@
     ],
     "no-unused-labels": "error",
     "no-unused-private-class-members": "error",
+    "no-useless-assignment": "error",
     "no-useless-backreference": "error",
     "no-useless-catch": "error",
     "no-useless-escape": [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -782,11 +782,60 @@
         "tests/framework-vue/**",
         "tests/json-api/**",
         "tests/legacy/**",
-        "tests/performance/**",
         "warp-drive-packages/svelte/**"
       ],
       "rules": {
         "no-restricted-imports": ["error"]
+      }
+    },
+    {
+      "files": ["tests/performance/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              "@ember/-internals/metal",
+              "@ember/application/namespace",
+              "@ember/array",
+              "@ember/array/proxy",
+              "@ember/component",
+              "@ember/component/helper",
+              "@ember/controller",
+              "@ember/debug",
+              "@ember/debug/data-adapter",
+              "@ember/edition-utils",
+              "@ember/object/compat",
+              "@ember/object/computed",
+              "@ember/object/evented",
+              "@ember/object/internals",
+              "@ember/object/mixin",
+              "@ember/object/promise-proxy-mixin",
+              "@ember/object/proxy",
+              "@ember/owner",
+              "@ember/routing",
+              "@ember/runloop",
+              "@ember/string",
+              "@ember/test-helpers",
+              "@ember/test-waiters",
+              "@ember/utils",
+              "@ember/version",
+              "@glimmer/component",
+              "@glimmer/env",
+              "@glimmer/runtime",
+              "@glimmer/tracking",
+              "@glimmer/tracking/primitives/cache",
+              "@glimmer/validator",
+              "ember-inflector",
+              "ember-qunit",
+              "ember-source",
+              "ember-source/types",
+              "ember",
+              "qunit",
+              "testem"
+            ]
+          }
+        ]
       }
     },
     {

--- a/packages/adapter/eslint.config.mjs
+++ b/packages/adapter/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
   globalIgnores(),
 
   // browser (js) ================
-  js.browser({
+  ...js.browser({
     srcDirs: ['src'],
     allowedImports: ['@ember/object', '@ember/application', '@ember/service', '@ember/debug', '@ember/object/mixin'],
   }),

--- a/packages/internal-exam/eslint.config.mjs
+++ b/packages/internal-exam/eslint.config.mjs
@@ -9,9 +9,13 @@ export default [
   globalIgnores(),
 
   // browser (js) ================ (bundled into the app by vite)
-  js.browser({
+  // this package is deliberately excluded from oxlint's scan (see
+  // tools/internal-config/oxlint/scoped-dirs.txt's header comment), so ESLint keeps enforcing
+  // the full rule set here rather than deferring to oxlint.
+  ...js.browser({
     files: ['src/index.js', 'src/-private/**/*.js'],
     allowedImports: ['@ember/debug', 'ember-qunit', 'qunit'],
+    oxlintScoped: false,
   }),
 
   // node (module) ================ (the CLI/orchestration side)

--- a/packages/serializer/eslint.config.mjs
+++ b/packages/serializer/eslint.config.mjs
@@ -13,7 +13,7 @@ export default [
   globalIgnores(),
 
   // browser (js) ================
-  js.browser({
+  ...js.browser({
     srcDirs: ['src'],
     allowedImports: externals,
   }),

--- a/packages/store/eslint.config.mjs
+++ b/packages/store/eslint.config.mjs
@@ -12,7 +12,7 @@ export default [
   // all ================
   globalIgnores(),
 
-  js.browser({
+  ...js.browser({
     srcDirs: ['src'],
     allowedImports: externals,
   }),

--- a/tests/blueprints/eslint.config.mjs
+++ b/tests/blueprints/eslint.config.mjs
@@ -10,7 +10,7 @@ export default [
   globalIgnores(),
 
   // browser (js/ts) ================
-  js.browser({
+  ...js.browser({
     srcDirs: ['fixtures'],
     allowedImports: ['qunit'],
     rules: {

--- a/tests/dont-write-new-tests-here/eslint.config.mjs
+++ b/tests/dont-write-new-tests-here/eslint.config.mjs
@@ -35,7 +35,7 @@ export default [
   globalIgnores(),
 
   // browser (js) ================
-  js.browser({
+  ...js.browser({
     dirname: import.meta.dirname,
     srcDirs: ['app', 'tests'],
     allowedImports: AllowedImports,

--- a/tests/dont-write-new-tests-here/tests/integration/adapter/record-persistence-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/adapter/record-persistence-test.js
@@ -74,7 +74,7 @@ module('integration/adapter/record_persistence - Persisting Records', function (
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('application');
 
-    // eslint-disable-next-line prefer-const
+    // oxlint-disable-next-line prefer-const
     let tom;
 
     adapter.createRecord = function (_store, type, snapshot) {
@@ -347,7 +347,7 @@ module('integration/adapter/record_persistence - Persisting Records', function (
     const store = this.owner.lookup('service:store');
     const adapter = store.adapterFor('application');
 
-    // eslint-disable-next-line prefer-const
+    // oxlint-disable-next-line prefer-const
     let tom;
 
     adapter.createRecord = function (_store, type, snapshot) {

--- a/tests/dont-write-new-tests-here/tests/integration/adapter/store-adapter-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/adapter/store-adapter-test.js
@@ -117,7 +117,9 @@ module('integration/adapter/store-adapter - DS.Store and DS.Adapter integration 
       });
     };
 
+    // oxlint-disable-next-line no-useless-assignment -- read as `tom.save()` below before being reassigned
     let tom = store.createRecord('person', { name: 'Tom Dale' });
+    // oxlint-disable-next-line no-useless-assignment -- read as `yehuda.save()` below before being reassigned
     let yehuda = store.createRecord('person', { name: 'Yehuda Katz' });
 
     [tom, yehuda] = await Promise.all([tom.save(), yehuda.save()]);

--- a/tests/dont-write-new-tests-here/tests/integration/debug-adapter-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/debug-adapter-test.js
@@ -174,7 +174,7 @@ module('integration/debug-adapter - DebugAdapter', function (hooks) {
 
     // reset — deliberately cleared so a watcher callback that fails to fire shows up
     // as a failing assertion below rather than a stale pass from the previous round
-    // eslint-disable-next-line no-useless-assignment
+    // oxlint-disable-next-line no-useless-assignment
     addedRecords = updatedRecords = [];
 
     post = store.createRecord('post', { id: '2', title: 'New Post' });
@@ -206,7 +206,7 @@ module('integration/debug-adapter - DebugAdapter', function (hooks) {
 
     // reset — deliberately cleared so a watcher callback that fails to fire shows up
     // as a failing assertion below rather than a stale pass from the previous round
-    // eslint-disable-next-line no-useless-assignment
+    // oxlint-disable-next-line no-useless-assignment
     addedRecords = updatedRecords = [];
 
     post.unloadRecord();

--- a/tests/dont-write-new-tests-here/tests/integration/record-array-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/record-array-test.js
@@ -207,7 +207,7 @@ module('integration/live-array', function (hooks) {
 
     assert.strictEqual(recordArray.length, 0, 'initial length 0');
 
-    // eslint-disable-next-line no-unused-vars
+    // oxlint-disable-next-line no-unused-vars
     const [one, two, three] = store.push({
       data: [
         { type: 'person', id: '1', attributes: { name: 'Chris' } },

--- a/tests/dont-write-new-tests-here/tests/integration/records/unload-test.js
+++ b/tests/dont-write-new-tests-here/tests/integration/records/unload-test.js
@@ -1848,7 +1848,7 @@ module('integration/unload - Unloading Records', function (hooks) {
 
     const boats = await person.boats;
 
-    // eslint-disable-next-line prefer-const
+    // oxlint-disable-next-line prefer-const
     let [boat2, boat3] = boats.slice();
     await Promise.all([boat2.person, boat3.person]);
 

--- a/tests/dont-write-new-tests-here/tests/unit/model-test.js
+++ b/tests/dont-write-new-tests-here/tests/unit/model-test.js
@@ -1193,7 +1193,7 @@ module('unit/model - Model', function (hooks) {
 
     test('changedAttributes() works while the record is being updated', async function (assert) {
       assert.expect(1);
-      // eslint-disable-next-line prefer-const
+      // oxlint-disable-next-line prefer-const
       let cat;
 
       class Mascot extends Model {
@@ -1276,7 +1276,7 @@ module('unit/model - Model', function (hooks) {
 
     test('@attr decorator works without parens', async function (assert) {
       assert.expect(1);
-      // eslint-disable-next-line prefer-const
+      // oxlint-disable-next-line prefer-const
       let cat;
 
       class Mascot extends Model {

--- a/tests/ember-data__adapter/eslint.config.mjs
+++ b/tests/ember-data__adapter/eslint.config.mjs
@@ -12,7 +12,7 @@ export default [
   globalIgnores(),
 
   // browser (js/ts) ================
-  js.browser({
+  ...js.browser({
     srcDirs: ['tests'],
     allowedImports: ['@ember/application'],
   }),

--- a/tests/ember-data__model/eslint.config.mjs
+++ b/tests/ember-data__model/eslint.config.mjs
@@ -12,7 +12,7 @@ export default [
   globalIgnores(),
 
   // browser (js) ================
-  js.browser({
+  ...js.browser({
     srcDirs: ['tests'],
     allowedImports: ['@ember/application'],
   }),

--- a/tests/ember-data__request/eslint.config.mjs
+++ b/tests/ember-data__request/eslint.config.mjs
@@ -12,7 +12,7 @@ export default [
   globalIgnores(),
 
   // browser (js) ================
-  js.browser({
+  ...js.browser({
     srcDirs: ['tests'],
     allowedImports: ['@ember/application'],
   }),

--- a/tests/legacy/eslint.config.mjs
+++ b/tests/legacy/eslint.config.mjs
@@ -36,7 +36,7 @@ export default [
   globalIgnores(),
 
   // browser (js) ================
-  js.browser({
+  ...js.browser({
     dirname: import.meta.dirname,
     srcDirs: ['app', 'tests'],
     allowedImports: AllowedImports,

--- a/tests/performance/eslint.config.mjs
+++ b/tests/performance/eslint.config.mjs
@@ -9,7 +9,7 @@ export default [
   globalIgnores(),
 
   // browser (js/ts) ================
-  js.browser({
+  ...js.browser({
     dirname: import.meta.dirname,
     srcDirs: ['models', 'mixins', 'routes', 'services'],
     allowedImports: ['@ember/application', '@ember/object', '@ember/routing/route', '@ember/service'],

--- a/tests/performance/mixins/record-mixin-a.js
+++ b/tests/performance/mixins/record-mixin-a.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr, belongsTo } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-b.js
+++ b/tests/performance/mixins/record-mixin-b.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr, belongsTo, hasMany } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-c.js
+++ b/tests/performance/mixins/record-mixin-c.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr, hasMany } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-d.js
+++ b/tests/performance/mixins/record-mixin-d.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr, hasMany } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-e.js
+++ b/tests/performance/mixins/record-mixin-e.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-f.js
+++ b/tests/performance/mixins/record-mixin-f.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-g.js
+++ b/tests/performance/mixins/record-mixin-g.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-h.js
+++ b/tests/performance/mixins/record-mixin-h.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-i.js
+++ b/tests/performance/mixins/record-mixin-i.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr } from '@warp-drive/legacy/model';

--- a/tests/performance/mixins/record-mixin-j.js
+++ b/tests/performance/mixins/record-mixin-j.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import Mixin from '@ember/object/mixin';
 
 import { attr } from '@warp-drive/legacy/model';

--- a/tests/performance/routes/update-with-same-state-m2m.js
+++ b/tests/performance/routes/update-with-same-state-m2m.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* oxlint-disable no-console */
 /* eslint-disable no-undef */
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';

--- a/tools/internal-config/eslint/browser.js
+++ b/tools/internal-config/eslint/browser.js
@@ -4,6 +4,8 @@ import prettier from 'eslint-config-prettier';
 
 import * as imports from './imports.js';
 import * as isolation from './isolation.js';
+import * as oxlint from './oxlint.js';
+import { splitByExtension } from './split-files.js';
 import * as ts from './typescript.js';
 
 // function resolve(name) {
@@ -42,7 +44,18 @@ export function rules(config = {}) {
   );
 }
 
-/** @return {import('eslint').Linter.FlatConfig} */
+/**
+ * Returns `[base]`, plus a trailing override turning off oxlint's already-covered rules for the
+ * non-template-tag subset of `base.files`. oxlint's parser can't scan `.gjs` (see `.oxlintrc.json`'s
+ * `ignorePatterns`), so `.gjs` files stay on the full rule set from `base` — the override only
+ * matches the plain `.js` patterns split out of `base.files`.
+ *
+ * Pass `oxlintScoped: false` for packages excluded from `tools/internal-config/oxlint/scoped-dirs.txt`
+ * entirely (see that file's header comment, e.g. `packages/internal-exam`) — oxlint never scans
+ * these, so ESLint must keep enforcing the full rule set there too.
+ *
+ * @return {import('eslint').Linter.FlatConfig[]}
+ */
 export function browser(config = {}) {
   config.files = Array.isArray(config.files) ? config.files : ['**/*.{js,gjs}'];
   const base = ts.browser(config);
@@ -51,5 +64,18 @@ export function browser(config = {}) {
   base.rules = rules(config);
   base.plugins = imports.plugins();
 
-  return base;
+  const result = [base];
+
+  if (config.oxlintScoped !== false) {
+    const { plain } = splitByExtension(base.files);
+
+    if (plain.length) {
+      result.push({
+        files: plain,
+        rules: oxlint.disabledRules(),
+      });
+    }
+  }
+
+  return result;
 }

--- a/tools/internal-config/eslint/oxlint.js
+++ b/tools/internal-config/eslint/oxlint.js
@@ -58,6 +58,7 @@ export const OXLINT_OWNED_RULES = [
   'no-unsafe-optional-chaining',
   'no-unused-labels',
   'no-unused-private-class-members',
+  'no-useless-assignment',
   'no-useless-backreference',
   'no-useless-catch',
   'no-useless-escape',
@@ -87,6 +88,7 @@ export const OXLINT_OWNED_RULES = [
   // note above about excluding anything that needs type information.
   '@typescript-eslint/adjacent-overload-signatures',
   '@typescript-eslint/consistent-type-imports',
+  '@typescript-eslint/no-array-constructor',
   '@typescript-eslint/no-duplicate-enum-values',
   '@typescript-eslint/no-empty-object-type',
   '@typescript-eslint/no-explicit-any',
@@ -94,6 +96,7 @@ export const OXLINT_OWNED_RULES = [
   '@typescript-eslint/no-extraneous-class',
   '@typescript-eslint/no-import-type-side-effects',
   '@typescript-eslint/no-inferrable-types',
+  '@typescript-eslint/no-loop-func',
   '@typescript-eslint/no-misused-new',
   '@typescript-eslint/no-namespace',
   '@typescript-eslint/no-non-null-asserted-nullish-coalescing',

--- a/warp-drive-packages/core/src/request/-private/fetch.ts
+++ b/warp-drive-packages/core/src/request/-private/fetch.ts
@@ -236,7 +236,7 @@ const Fetch = {
           isStreaming = true;
           stream = new TransformStream();
           // Listen for the abort event on the AbortSignal
-          // eslint-disable-next-line @typescript-eslint/no-loop-func
+          // oxlint-disable-next-line no-loop-func
           context.request.signal?.addEventListener('abort', () => {
             if (!isStreaming) {
               return;

--- a/warp-drive-packages/legacy/src/serializer/rest.ts
+++ b/warp-drive-packages/legacy/src/serializer/rest.ts
@@ -335,7 +335,7 @@ const RESTSerializer: any = (JSONSerializer as typeof EmberObject).extend({
       }
 
       if (isSingle) {
-        // eslint-disable-next-line @typescript-eslint/no-loop-func
+        // oxlint-disable-next-line no-loop-func
         data.forEach((resource) => {
           /*
             Figures out if this is the primary record or not.


### PR DESCRIPTION
## What

After #10946 landed (oxlint on `tests/`, qunit/mocha via jsPlugins), I checked how many files in oxlint's scope still run *any* real ESLint rule, using `eslint --print-config` on representative files rather than reading the config logic by hand.

**Part 1 — 3 residual rules on `.ts` files.** Every "fully handed off" plain `.ts` file converged on exactly 4 residual active rules: `no-octal`, `no-useless-assignment`, `@typescript-eslint/no-array-constructor`, `@typescript-eslint/no-loop-func`. `no-octal` has no oxlint equivalent (and is effectively unreachable anyway — ES modules are strict mode, so legacy octal literals are a hard `SyntaxError`). The other 3 are rules oxlint already implements and enforces via `.oxlintrc.json` — they just were never added to the ESLint-side handoff list (`OXLINT_OWNED_RULES` in `tools/internal-config/eslint/oxlint.js`), so ESLint kept re-checking them redundantly. This PR enables `no-useless-assignment` in `.oxlintrc.json` and adds all 3 to `OXLINT_OWNED_RULES`.

**Part 2 — plain `.js` files got zero handoff at all.** While verifying the fix above, I found `.js` files don't even get the *existing* handoff: `js.browser()` (`tools/internal-config/eslint/browser.js`) computes `base = ts.browser(config)` (which merges in `oxlint.disabledRules()`), then immediately discards that by doing `base.rules = rules(config)`. Every plain `.js` file across 11 packages/tests directories was running the *full* `OXLINT_OWNED_RULES` set through ESLint on top of oxlint's real pass — none of the win from #10946 applied to them. `js.browser()` now returns `[base, override]`, where `override` re-disables those rules for just the non-`.gjs` subset of the matched files (oxlint's parser can't scan `.gjs`, so that extension keeps the full rule set from `base`, verified byte-identical `--print-config` output before/after). All 11 call sites now spread the result (`...js.browser({...})`).

`packages/internal-exam` opts out via a new `oxlintScoped: false` config flag: it's explicitly excluded from `tools/internal-config/oxlint/scoped-dirs.txt` (oxlint never scans it), so turning off ESLint's copy there would have been a real coverage loss, not a safe handoff — confirmed by checking it has live `no-console` suppressions that only ESLint currently guards.

**A genuine gap found along the way.** `no-restricted-imports` was already in `OXLINT_OWNED_RULES`, but oxlint's `tests/performance/**` override in `.oxlintrc.json` was a bare `"error"` with no `paths` option — a no-op. I confirmed this concretely: temporarily removed an existing `eslint-disable-next-line no-restricted-imports` suppression in `tests/performance/mixins/record-mixin-a.js` and ran oxlint — it did not catch the restricted `@ember/object/mixin` import ESLint was catching. Split `tests/performance/**` into its own override with the same `paths` list ESLint's `isolation.js` enforces there (re-verified oxlint now catches it), then converted the 10 now-actually-covered suppressions in `tests/performance/mixins` to `oxlint-disable`.

## Fallout (stale `eslint-disable` comments converted to `oxlint-disable`)

- `tests/dont-write-new-tests-here/tests/integration/adapter/store-adapter-test.js`: new suppression — `let tom`/`let yehuda` are read via `.save()` before being reassigned by destructuring; confirmed real ESLint's own `no-useless-assignment` implementation doesn't flag this (oxlint-only false-ish positive).
- `warp-drive-packages/legacy/src/serializer/rest.ts`, `warp-drive-packages/core/src/request/-private/fetch.ts`: `@typescript-eslint/no-loop-func` → `no-loop-func` (oxlint enforces the bare, non-namespaced rule per `.oxlintrc.json`).
- `tests/dont-write-new-tests-here/tests/{integration,unit}/**`: `prefer-const` (×5), `no-unused-vars` (×1), `no-useless-assignment` (×2).
- `tests/performance/mixins/record-mixin-{a..j}.js`: `no-restricted-imports` (×10, only after fixing the oxlint config gap above).
- `tests/performance/routes/update-with-same-state-m2m.js`: `no-console` (whole-file `oxlint-disable`, verified oxlint supports block-level directives too).

## Test plan

- [x] `eslint --print-config` on representative `.ts` files confirms the active-rule count drops from 4 to 1 (only `no-octal` remains).
- [x] `eslint --print-config` on a representative `.js` test file drops from 73 active rules to 19 (all genuinely outside `OXLINT_OWNED_RULES`, e.g. `no-undef`, `no-const-assign`).
- [x] Same check on a `.gjs` file in the same package: byte-identical `--print-config` output before/after the `browser.js` change — confirms `.gjs` is unaffected.
- [x] `packages/internal-exam` (`oxlintScoped: false`) still shows `no-console` as active — confirms the opt-out works.
- [x] `tools/internal-config/oxlint/run.sh` (full repo pass) is byte-identical to the pre-change baseline after every step.
- [x] `eslint --no-cache` on every file with a converted comment passes clean (no unused-directive errors).
- [x] Manually confirmed the `tests/performance/**` `no-restricted-imports` gap and fix by toggling the suppression and re-running oxlint before/after the `.oxlintrc.json` change.
