### PR TITLE
chore(types): move all remaining packages to TypeScript 7 for check:types

### DIFF
--- a/packages/-warp-drive/package.json
+++ b/packages/-warp-drive/package.json
@@ -29,7 +29,7 @@
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
     "start": "node node_modules/tsdown/dist/run.mjs --watch",
-    "check:types": "tsc --noEmit"
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit"
   },
   "bin": {
     "warp-drive": "./dist/warp-drive.js",
@@ -68,6 +68,7 @@
     "@types/semver": "^7.8.0",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   }
 }

--- a/packages/active-record/package.json
+++ b/packages/active-record/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -52,6 +52,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "tsdown": "^0.22.14"
   },
   "ember": {

--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -15,7 +15,7 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -60,6 +60,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "tsdown": "^0.22.14"
   }
 }

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -20,7 +20,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit"
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit"
   },
   "exports": {
     ".": {
@@ -52,6 +52,7 @@
     "jscodeshift": "^17.4.0",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "winston": "^3.19.0"
   }
 }

--- a/packages/core-types/package.json
+++ b/packages/core-types/package.json
@@ -14,7 +14,7 @@
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -47,7 +47,8 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -15,7 +15,7 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -54,7 +54,8 @@
     "decorator-transforms": "^2.4.0",
     "ember-source": "catalog:",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -14,7 +14,7 @@
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -48,7 +48,8 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/holodeck/package.json
+++ b/packages/holodeck/package.json
@@ -34,7 +34,7 @@
     "ensure-cert": "./server/ensure-cert.js"
   },
   "scripts": {
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -64,7 +64,8 @@
     "@warp-drive/legacy": "workspace:*",
     "@warp-drive/core": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
-    "tsdown": "^0.22.14"
+    "tsdown": "^0.22.14",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "exports": {
     ".": {

--- a/packages/json-api/package.json
+++ b/packages/json-api/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -55,7 +55,8 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "expect-type": "^1.4.0",
-    "tsdown": "^0.22.14"
+    "tsdown": "^0.22.14",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/legacy-compat/package.json
+++ b/packages/legacy-compat/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -57,7 +57,8 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -15,7 +15,7 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -62,6 +62,7 @@
     "@warp-drive/internal-config": "workspace:*",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   }
 }

--- a/packages/request-utils/package.json
+++ b/packages/request-utils/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -67,7 +67,8 @@
     "ember-inflector": "6.0.0",
     "ember-source": "catalog:",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -49,7 +49,8 @@
     "@babel/preset-env": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
-    "tsdown": "^0.22.14"
+    "tsdown": "^0.22.14",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -52,7 +52,8 @@
     "@babel/preset-env": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
-    "tsdown": "^0.22.14"
+    "tsdown": "^0.22.14",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/schema-record/package.json
+++ b/packages/schema-record/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -52,7 +52,8 @@
     "@babel/preset-env": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
-    "tsdown": "^0.22.14"
+    "tsdown": "^0.22.14",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -15,7 +15,7 @@
   "directories": {},
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -61,6 +61,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -63,7 +63,8 @@
     "@warp-drive/internal-config": "workspace:*",
     "ember-source": "catalog:",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -63,7 +63,8 @@
     "@warp-drive/internal-config": "workspace:*",
     "ember-source": "catalog:",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/unpublished-test-infra/package.json
+++ b/packages/unpublished-test-infra/package.json
@@ -39,7 +39,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
-    "check:types": "tsc --noEmit"
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit"
   },
   "peerDependencies": {
     "@ember/test-helpers": "3.3.0 || ^4.0.4 || ^5.1.0",
@@ -79,7 +79,8 @@
     "qunit": "^2.26.0",
     "testem": "^3.20.1",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember": {
     "edition": "octane"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/active-record:
     dependencies:
@@ -501,6 +504,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/adapter:
     dependencies:
@@ -538,6 +544,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/codemods:
     dependencies:
@@ -575,6 +584,9 @@ importers:
       winston:
         specifier: ^3.19.0
         version: 3.19.0
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/core-types:
     dependencies:
@@ -603,6 +615,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/debug:
     dependencies:
@@ -646,6 +661,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/diagnostic:
     dependencies:
@@ -778,6 +796,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/holodeck:
     dependencies:
@@ -817,7 +838,10 @@ importers:
         version: file:warp-drive-packages/utilities(4ded94bf05a058c4d301833388abca58)
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14
+        version: 0.22.14(typescript@7.1.0-dev.20260821.1)
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/internal-exam:
     dependencies:
@@ -876,7 +900,10 @@ importers:
         version: 1.4.0
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14
+        version: 0.22.14(typescript@7.1.0-dev.20260821.1)
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/legacy-compat:
     dependencies:
@@ -914,6 +941,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/model:
     dependencies:
@@ -957,6 +987,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/request:
     dependencies:
@@ -984,7 +1017,10 @@ importers:
         version: file:tools/internal-config
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14
+        version: 0.22.14(typescript@7.1.0-dev.20260821.1)
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/request-utils:
     dependencies:
@@ -1025,6 +1061,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/rest:
     dependencies:
@@ -1055,7 +1094,10 @@ importers:
         version: file:tools/internal-config
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14
+        version: 0.22.14(typescript@7.1.0-dev.20260821.1)
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/schema:
     devDependencies:
@@ -1089,7 +1131,10 @@ importers:
         version: file:tools/internal-config
       tsdown:
         specifier: ^0.22.14
-        version: 0.22.14
+        version: 0.22.14(typescript@7.1.0-dev.20260821.1)
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/serializer:
     dependencies:
@@ -1130,6 +1175,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/store:
     dependencies:
@@ -1170,6 +1218,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/tracking:
     dependencies:
@@ -1207,6 +1258,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   packages/unpublished-eslint-rules: {}
 
@@ -1270,6 +1324,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   specs:
     dependencies:
@@ -1740,6 +1797,10 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
+    devDependencies:
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   tests/ember-data__graph:
     devDependencies:
@@ -1815,6 +1876,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
@@ -1911,6 +1975,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
@@ -1992,6 +2059,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
@@ -2226,6 +2296,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
@@ -2385,6 +2458,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1
@@ -2439,6 +2515,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1
@@ -2496,6 +2575,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1
@@ -2586,6 +2668,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
@@ -2868,6 +2953,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1(terser@5.50.0)
@@ -3042,6 +3130,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/core:
     dependencies:
@@ -3079,6 +3170,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/ember:
     dependencies:
@@ -3183,6 +3277,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/json-api:
     dependencies:
@@ -3226,6 +3323,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/legacy:
     dependencies:
@@ -3269,6 +3369,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/memory-alpha: {}
 
@@ -3323,6 +3426,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/schema-dsl:
     dependencies:
@@ -3354,6 +3460,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/svelte:
     dependencies:
@@ -3379,6 +3488,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       vite:
         specifier: 'catalog:'
         version: 8.2.1
@@ -3419,6 +3531,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/utilities:
     dependencies:
@@ -3453,6 +3568,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
 
   warp-drive-packages/vue:
     dependencies:
@@ -3490,6 +3608,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-7:
+        specifier: npm:typescript@7.1.0-dev.20260821.1
+        version: typescript@7.1.0-dev.20260821.1
       unplugin-vue:
         specifier: ^7.2.0
         version: 7.2.0(vue@3.5.41(typescript@5.9.3))
@@ -19382,7 +19503,7 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-plugin-dts@0.27.14(rolldown@1.2.3):
+  rolldown-plugin-dts@0.27.14(6af83f67b9c3228052bc453ece17b911):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -19391,6 +19512,8 @@ snapshots:
       yuku-ast: 0.8.4
       yuku-codegen: 0.8.4
       yuku-parser: 0.8.4
+    optionalDependencies:
+      typescript: 7.1.0-dev.20260821.1
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -20208,29 +20331,6 @@ snapshots:
       picomatch: 4.0.5
       typescript: 5.9.3
 
-  tsdown@0.22.14:
-    dependencies:
-      ansis: 4.3.1
-      cac: 7.0.0
-      defu: 6.1.7
-      empathic: 2.0.1
-      hookable: 6.1.1
-      import-without-cache: 0.4.0
-      obug: 2.1.4
-      picomatch: 4.0.5
-      rolldown: 1.2.3
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tree-kill: 1.2.2
-      unconfig-core: 7.5.0
-      verkit: 0.3.2
-    transitivePeerDependencies:
-      - '@typescript/native-preview'
-      - '@volar/typescript'
-      - oxc-resolver
-      - vue-tsc
-
   tsdown@0.22.14(5d0206a3438b9e0ec371eb579551ff9e):
     dependencies:
       ansis: 4.3.1
@@ -20275,6 +20375,31 @@ snapshots:
       verkit: 0.3.2
     optionalDependencies:
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@typescript/native-preview'
+      - '@volar/typescript'
+      - oxc-resolver
+      - vue-tsc
+
+  tsdown@0.22.14(typescript@7.1.0-dev.20260821.1):
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      defu: 6.1.7
+      empathic: 2.0.1
+      hookable: 6.1.1
+      import-without-cache: 0.4.0
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(6af83f67b9c3228052bc453ece17b911)
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+      unconfig-core: 7.5.0
+      verkit: 0.3.2
+    optionalDependencies:
+      typescript: 7.1.0-dev.20260821.1
     transitivePeerDependencies:
       - '@typescript/native-preview'
       - '@volar/typescript'

--- a/tests/ember-data__adapter/package.json
+++ b/tests/ember-data__adapter/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
@@ -64,5 +64,8 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "devDependencies": {
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   }
 }

--- a/tests/ember-data__graph/package.json
+++ b/tests/ember-data__graph/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
@@ -50,6 +50,7 @@
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   },
   "ember": {

--- a/tests/ember-data__model/package.json
+++ b/tests/ember-data__model/package.json
@@ -18,7 +18,7 @@
     "sync": "echo \"syncing\"",
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "_temporarily_deactivated_build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "_temporarily_deactivated_test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
@@ -56,6 +56,7 @@
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   },
   "ember": {

--- a/tests/ember-data__request/package.json
+++ b/tests/ember-data__request/package.json
@@ -20,7 +20,7 @@
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
     "_temporarily_deactivated_build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "_temporarily_deactivated_test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
     "test:start": "bun ./diagnostic.js --serve --no-launch"
@@ -51,6 +51,7 @@
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   },
   "ember": {

--- a/tests/ember-data__request/tests/integration/immutability-test.ts
+++ b/tests/ember-data__request/tests/integration/immutability-test.ts
@@ -53,8 +53,6 @@ module('RequestManager | Immutability', function () {
       request<T>(context: RequestContext, next: NextFn<T>) {
         const headers = new Headers(context.request.headers);
         headers.append('house', 'home');
-        // @ts-expect-error Types are wrong: Property 'entries' does not exist on type 'Headers'.
-        // oxlint-disable-next-line typescript/no-unsafe-assignment, typescript/no-unsafe-call
         return Promise.resolve<T>([...headers.entries()] as T);
       },
     };

--- a/tests/experiments/package.json
+++ b/tests/experiments/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
@@ -63,6 +63,7 @@
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   },
   "ember": {

--- a/tests/framework-react/package.json
+++ b/tests/framework-react/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
@@ -46,6 +46,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   }
 }

--- a/tests/framework-svelte/package.json
+++ b/tests/framework-svelte/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
@@ -42,6 +42,7 @@
     "decorator-transforms": "^2.4.0",
     "svelte": "^5.56.9",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   }
 }

--- a/tests/framework-vue/package.json
+++ b/tests/framework-vue/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
@@ -43,6 +43,7 @@
     "babel-plugin-debug-macros": "^2.0.0",
     "decorator-transforms": "^2.4.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:",
     "vue": "^3.5.41",
     "vue-tsc": "^3.3.10"

--- a/tests/json-api/package.json
+++ b/tests/json-api/package.json
@@ -20,7 +20,7 @@
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
     "test:start": "bun ./diagnostic.js --serve --no-launch"
@@ -52,6 +52,7 @@
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   },
   "ember": {

--- a/tests/utilities/package.json
+++ b/tests/utilities/package.json
@@ -19,7 +19,7 @@
     "build:tests": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --outDir dist-test",
     "build:production": "export IS_TESTING=true; export NODE_ENV=production; vite build --outDir dist-test",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "test": "export IS_TESTING=true; export NODE_ENV=development; bun ./diagnostic.js",
     "test:production": "export IS_TESTING=true; export NODE_ENV=production; bun ./diagnostic.js",
     "start": "export IS_TESTING=true; export NODE_ENV=development; vite build -m development --watch --outDir dist-test",
@@ -60,6 +60,7 @@
     "ember-strict-application-resolver": "^0.1.1",
     "terser": "^5.50.0",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   },
   "ember": {

--- a/warp-drive-packages/build-config/package.json
+++ b/warp-drive-packages/build-config/package.json
@@ -19,7 +19,7 @@
     "sync": "echo \"syncing\"",
     "_temporarily_deactivated_lint": "eslint . --quiet --cache --cache-strategy=content",
     "start": "node node_modules/tsdown/dist/run.mjs --watch",
-    "check:types": "tsc --noEmit"
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit"
   },
   "type": "module",
   "files": [
@@ -58,6 +58,7 @@
     "@types/semver": "^7.8.0",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   }
 }

--- a/warp-drive-packages/build-config/tsconfig.json
+++ b/warp-drive-packages/build-config/tsconfig.json
@@ -39,7 +39,8 @@
     "allowJs": false,
     "erasableSyntaxOnly": true,
     "isolatedDeclarations": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["node"]
   },
   "references": []
 }

--- a/warp-drive-packages/core/package.json
+++ b/warp-drive-packages/core/package.json
@@ -16,7 +16,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "sync": "echo \"syncing\"",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
@@ -55,7 +55,8 @@
     "ember-source": "catalog:",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/warp-drive-packages/experiments/package.json
+++ b/warp-drive-packages/experiments/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
@@ -74,7 +74,8 @@
     "@warp-drive/core": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "keywords": [
     "ember-addon"

--- a/warp-drive-packages/experiments/src/storage/storage.ts
+++ b/warp-drive-packages/experiments/src/storage/storage.ts
@@ -107,12 +107,6 @@ function isStorageUnavailableError(error: unknown): boolean {
 
 export type EffectStorageEvent = CacheStorageEvent | StorageEvent;
 
-declare global {
-  interface WindowEventMap {
-    storage: CustomEvent<CacheStorageEvent> | StorageEvent;
-  }
-}
-
 /**
  * A reactive wrapper around the Web Storage API (localStorage/sessionStorage)
  * that provides signal-based access to storage items and length.
@@ -157,7 +151,7 @@ class ReactiveStorage implements Storage {
 
     // bind to localStorage events to trigger reactivity
     if (!this._memoryOnly) {
-      window.addEventListener('storage', (event: StorageEvent | CustomEvent<CacheStorageEvent>) => {
+      window.addEventListener('storage', ((event: StorageEvent | CustomEvent<CacheStorageEvent>) => {
         const data = 'detail' in event ? event.detail : event;
 
         // Only react to changes in the same storage area
@@ -170,7 +164,7 @@ class ReactiveStorage implements Storage {
             effect(data);
           }
         }
-      });
+      }) as EventListener);
     }
   }
 

--- a/warp-drive-packages/json-api/package.json
+++ b/warp-drive-packages/json-api/package.json
@@ -16,7 +16,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "sync": "echo \"syncing\"",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
@@ -56,7 +56,8 @@
     "decorator-transforms": "^2.4.0",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/warp-drive-packages/legacy/package.json
+++ b/warp-drive-packages/legacy/package.json
@@ -16,7 +16,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "sync": "echo \"syncing\"",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
@@ -57,7 +57,8 @@
     "ember-source": "catalog:",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/warp-drive-packages/legacy/src/model/-private/attr.type-test.ts
+++ b/warp-drive-packages/legacy/src/model/-private/attr.type-test.ts
@@ -89,10 +89,7 @@ expectTypeOf(attr<ExampleDateTransform>('date', {
 /* prettier-ignore */
 expectTypeOf(
   // @ts-expect-error
-  attr(
-    'string',
-    { defaultValue: ({}) }
-  )
+  attr('string', { defaultValue: ({}) })
 ).toEqualTypeOf<DataDecorator>();
 
 /* prettier-ignore */

--- a/warp-drive-packages/react/package.json
+++ b/warp-drive-packages/react/package.json
@@ -22,7 +22,7 @@
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
@@ -63,7 +63,8 @@
     "decorator-transforms": "^2.4.0",
     "react": "^19.2.8",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/warp-drive-packages/schema-dsl/package.json
+++ b/warp-drive-packages/schema-dsl/package.json
@@ -16,7 +16,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "sync": "echo \"syncing\"",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
@@ -57,7 +57,8 @@
     "@warp-drive/internal-config": "workspace:*",
     "@warp-drive/core": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "packageManager": "pnpm@12.0.0"
 }

--- a/warp-drive-packages/svelte/package.json
+++ b/warp-drive-packages/svelte/package.json
@@ -18,7 +18,7 @@
     "prepack": "svelte-package",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "vite"
   },
   "files": [
@@ -52,6 +52,7 @@
     "@warp-drive/core": "workspace:*",
     "svelte": "^5.56.9",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "vite": "catalog:"
   }
 }

--- a/warp-drive-packages/tc39-proposal-signals/package.json
+++ b/warp-drive-packages/tc39-proposal-signals/package.json
@@ -17,7 +17,7 @@
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
@@ -48,6 +48,7 @@
     "@warp-drive/core": "workspace:*",
     "@warp-drive/internal-config": "workspace:*",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   }
 }

--- a/warp-drive-packages/utilities/package.json
+++ b/warp-drive-packages/utilities/package.json
@@ -16,7 +16,7 @@
     "build:pkg": "node node_modules/tsdown/dist/run.mjs && node node_modules/tsdown/dist/run.mjs -c ./tsdown.config-cjs.mjs",
     "prepack": "pnpm run build:pkg",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "sync": "echo \"syncing\"",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
@@ -58,7 +58,8 @@
     "decorator-transforms": "^2.4.0",
     "expect-type": "^1.4.0",
     "tsdown": "^0.22.14",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1"
   },
   "ember-addon": {
     "main": "addon-main.cjs",

--- a/warp-drive-packages/vue/package.json
+++ b/warp-drive-packages/vue/package.json
@@ -23,7 +23,7 @@
     "prepack": "pnpm run build:pkg",
     "sync": "echo \"syncing\"",
     "lint": "eslint . --quiet --cache --cache-strategy=content",
-    "check:types": "tsc --noEmit",
+    "check:types": "node ./node_modules/typescript-7/bin/tsc --noEmit",
     "start": "node node_modules/tsdown/dist/run.mjs --watch"
   },
   "files": [
@@ -62,6 +62,7 @@
     "decorator-transforms": "^2.4.0",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3",
+    "typescript-7": "npm:typescript@7.1.0-dev.20260821.1",
     "unplugin-vue": "^7.2.0",
     "vue": "^3.5.41",
     "vue-tsc": "^3.3.10"


### PR DESCRIPTION
## Summary

- Extends the TS 7.1 nightly (`typescript-7`, `npm:typescript@7.1.0-dev.20260821.1`) already used for `.gts`/`.gjs` content-mapper checking in six packages (#10935) to every other package's `check:types` script, replacing classic `tsc` 5.9.3 there. The classic `typescript` dependency stays in place everywhere and continues to back ESLint's type-aware parsing and other tooling — only the `check:types` compiler swaps.
- 40 packages under `packages/*`, `warp-drive-packages/*`, and `tests/*` now run `node ./node_modules/typescript-7/bin/tsc --noEmit` for `check:types` instead of the classic `tsc --noEmit`.
- Fixes three real diagnostic differences surfaced by the switch:
  - `@warp-drive/build-config` needed an explicit `"types": ["node"]` in its `tsconfig.json` — TS 7 doesn't auto-include `@types/node` the way classic tsc does when `types` is left unset.
  - `@warp-drive/experiments`'s global `WindowEventMap` augmentation for a custom `"storage"` event no longer merges cleanly against TS 7's DOM lib; replaced with a local cast at the single call site instead of widening the global type.
  - Two `@ts-expect-error` directives (`warp-drive-packages/legacy`, `ember-data__request`) went unused under TS 7: one because TS 7 attributes a multi-line call expression's diagnostic to a different line than classic tsc (fixed by collapsing the expression onto one line so the directive still applies); the other because TS 7 ships a newer DOM lib that correctly types `Headers.entries()`, which classic TS 5.9.3's bundled lib is simply missing — the workaround is removed outright since the underlying type gap is gone.

## Test plan

- [x] `pnpm check:types` — all 83 tasks pass
- [x] `pnpm lint` — all 86 tasks pass
- [x] `pnpm lint:oxlint` — clean
- [x] `pnpm lint:oxfmt` / `pnpm lint:prettier` — clean
- [x] `pnpm install` — all `build:pkg` tasks succeed (isolated-declarations builds are unaffected by this change)

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BP7MDSg8C6ZJ799ypdv63L)_