### PR TITLE
build(lint): close the last real .ts/.js eslint gap, reach true zero

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,6 +9,24 @@
     { "name": "mocha", "specifier": "eslint-plugin-mocha" }
   ],
   "categories": {},
+  // Needed for `no-undef` (see the `rules` map below). ESLint splits these into
+  // `globals.browser`/`globals.node`/`globals.nodeBuiltin` per file context (browser vs. node
+  // config files) via each package's `eslint.config.mjs`; oxlint's config isn't scoped that
+  // finely; we deliberately union both here rather than replicate that per-directory split, so
+  // `no-undef` won't false-positive on a node-context identifier used in a browser-context file
+  // (or vice versa) — a real but narrow loss compared to ESLint's stricter, context-aware check.
+  "env": {
+    "builtin": true,
+    "browser": true,
+    "node": true,
+    "qunit": true
+  },
+  "globals": {
+    // node's `--expose-gc` global, used by a couple of test packages
+    "gc": "readonly",
+    // packages/diagnostic's Bun-specific test runner path
+    "Bun": "readonly"
+  },
   "options": {
     "respectEslintDisableDirectives": true
   },
@@ -360,6 +378,20 @@
     "typescript/require-array-sort-compare": "off"
   },
   "overrides": [
+    {
+      // `no-undef`/`no-redeclare` are JS-only, scope-based checks with no understanding of
+      // TypeScript declaration merging (`interface Foo {}` + `declare class Foo {}`, a common
+      // mixin-typing idiom here) or ambient `declare global` blocks (e.g. `FastBoot`) — both
+      // fire false positives on `.ts`/`.tsx`. `tsc` (via each package's `check:types`) already
+      // catches genuine duplicate-identifier and undefined-identifier bugs there with full
+      // type/ambient-declaration awareness, so these two are scoped to plain `.js`, which has
+      // no such safety net.
+      "files": ["**/*.js"],
+      "rules": {
+        "no-redeclare": "error",
+        "no-undef": "error"
+      }
+    },
     {
       "files": ["packages/-ember-data/**"],
       "rules": {

--- a/tests/performance/routes/update-with-same-state-m2m.js
+++ b/tests/performance/routes/update-with-same-state-m2m.js
@@ -1,5 +1,5 @@
 /* oxlint-disable no-console */
-/* eslint-disable no-undef */
+/* oxlint-disable no-undef */
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
 

--- a/tools/internal-config/eslint/oxlint.js
+++ b/tools/internal-config/eslint/oxlint.js
@@ -12,24 +12,39 @@
 //
 // Keep this in sync with the enabled ("error"), non-type-aware rules in `.oxlintrc.json`'s
 // `rules` map.
+//
+// `no-redeclare`/`no-undef` are the one exception: oxlint only enables them for plain `.js`
+// (see `.oxlintrc.json`'s first `overrides` entry) since neither understands TypeScript
+// declaration merging or ambient `declare global` blocks and both false-positive on `.ts`/`.tsx`
+// as a result — `tsc` (via `check:types`) already catches the real bugs there with full
+// type/ambient-declaration awareness. Listing them here regardless is still correct: ESLint's own
+// typescript-eslint presets already turn both off for `.ts`/`.tsx` (no change there), and this
+// turns them off for `.js` where oxlint now owns them.
 export const OXLINT_OWNED_RULES = [
   // eslint core
+  'constructor-super',
   'eqeqeq',
   'for-direction',
+  'getter-return',
   'new-cap',
   'no-array-constructor',
   'no-async-promise-executor',
   'no-caller',
   'no-case-declarations',
+  'no-class-assign',
   'no-compare-neg-zero',
   'no-cond-assign',
   'no-console',
+  'no-const-assign',
   'no-constant-binary-expression',
   'no-constant-condition',
   'no-control-regex',
   'no-debugger',
   'no-delete-var',
+  'no-dupe-args',
+  'no-dupe-class-members',
   'no-dupe-else-if',
+  'no-dupe-keys',
   'no-duplicate-case',
   'no-empty',
   'no-empty-character-class',
@@ -40,21 +55,31 @@ export const OXLINT_OWNED_RULES = [
   'no-ex-assign',
   'no-extra-boolean-cast',
   'no-fallthrough',
+  'no-func-assign',
   'no-global-assign',
+  'no-import-assign',
   'no-invalid-regexp',
   'no-irregular-whitespace',
   'no-loss-of-precision',
   'no-misleading-character-class',
+  'no-new-native-nonconstructor',
   'no-nonoctal-decimal-escape',
+  'no-obj-calls',
   'no-prototype-builtins',
+  'no-redeclare',
   'no-regex-spaces',
   'no-restricted-globals',
   'no-restricted-imports',
   'no-self-assign',
+  'no-setter-return',
   'no-shadow-restricted-names',
   'no-sparse-arrays',
+  'no-this-before-super',
   'no-unassigned-vars',
+  'no-undef',
+  'no-unreachable',
   'no-unsafe-finally',
+  'no-unsafe-negation',
   'no-unsafe-optional-chaining',
   'no-unused-labels',
   'no-unused-private-class-members',
@@ -63,6 +88,7 @@ export const OXLINT_OWNED_RULES = [
   'no-useless-catch',
   'no-useless-escape',
   'no-var',
+  'no-with',
   'prefer-const',
   'prefer-spread',
   'preserve-caught-error',


### PR DESCRIPTION
1 of 3 in a series (see #10947, which just merged, for context: this is the "close the residual gap" step of removing ESLint from most of the repo — 2 more PRs to follow, stacked on this one).

## What

With #10947 merged, every plain `.ts`/`.js` file is down to 1 real active ESLint rule (`no-octal`) plus, for `.js` specifically, ~18 more `eslint:recommended` rules ESLint alone was still checking. I went through all of them:

- **16 were already redundant**: `no-const-assign`, `constructor-super`, `getter-return`, `no-dupe-class-members`, `no-dupe-keys`, `no-func-assign`, `no-import-assign`, `no-new-native-nonconstructor`, `no-obj-calls`, `no-setter-return`, `no-this-before-super`, `no-unreachable`, `no-unsafe-negation`, `no-with`, `no-class-assign`, and (indirectly, via `no-redeclare`'s duplicate-parameter detection) `no-dupe-args`. All already enabled in `.oxlintrc.json` — just never added to `OXLINT_OWNED_RULES`, the same handoff-list gap this whole series keeps finding. Added them all.
- **`no-undef`/`no-redeclare` needed real verification**, not just a blind add. Enabling both repo-wide surfaced 51 findings — 100% on `.ts`/`.tsx`, 100% false positives:
  - `no-redeclare` doesn't understand TypeScript declaration merging (`interface Foo {}` + `declare class Foo {}`, a mixin-typing idiom used throughout this codebase) and flags the class as redeclaring the interface.
  - `no-undef` doesn't see ambient `declare global` blocks declared in other files (e.g. `FastBoot`), so any file referencing that global fails.

  `tsc` (via each package's `check:types`) already catches genuine bugs of both kinds with full type/ambient-declaration awareness that a syntax-only linter can't replicate. So instead of trying to make oxlint TS-aware here, I scoped both rules to `.js` only via a new `.oxlintrc.json` override — verified a full repo pass produces zero new findings at that scope, only on the `.js` side where there's no `tsc` safety net.
- Added oxlint's `env`/`globals` config (`browser`+`node`+`qunit`+`builtin`, plus the couple of custom globals ESLint already declares: `gc`, `Bun`) so `no-undef` has real global visibility instead of flagging every ambient identifier.

## Fallout

One stale suppression: `tests/performance/routes/update-with-same-state-m2m.js` had a whole-file `/* eslint-disable no-undef */` guarding a real, deliberately-undeclared profiling global (`getWarpDriveMetricCounts`, injected manually during profiling sessions). Converted to `oxlint-disable`, verified oxlint reproduces the identical 5 findings when the suppression is removed.

## Test plan

- [x] `eslint --print-config` on representative `.ts` and `.js` files both now show exactly 1 active rule (`no-octal`) — true zero real ESLint enforcement on plain sources, matching the goal for this series.
- [x] Repo-wide `eslint-disable` sweep for every newly-handed-off rule name found exactly one stale comment (handled above).
- [x] `tools/internal-config/oxlint/run.sh` (full repo pass) is byte-identical to the pre-change baseline at every step, including after enabling `no-undef`/`no-redeclare` scoped to `.js`.
- [x] Confirmed via temporary removal + re-run that oxlint's `no-redeclare` also independently catches duplicate function parameters (`no-dupe-args`'s case), so folding that rule in is safe.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYFFJUz3zCcmXRoah3SsQp)_