### PR TITLE
ci: scope lint-cache glob to real workspace paths instead of **

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -213,12 +213,30 @@ runs:
       with:
         # Type-check (tsconfig.tsbuildinfo) and lint (.eslintcache) artifacts are
         # produced per-package by turbo rather than at the repo root, so these
-        # paths must be globbed to cover every workspace package. Prettier still
-        # runs once from the repo root, so `.prettier-cache` stays un-globbed.
+        # paths must cover every workspace package. This used to be a `**` glob,
+        # but @actions/glob's walk for that isn't scoped to skip node_modules,
+        # so it was walking this repo's entire (thousands-of-directories) tree
+        # on every save -- most of this step's ~30s. Enumerating the real
+        # workspace roots (matching pnpm-workspace.yaml's `packages` list) skips
+        # that walk entirely. oxlint/oxfmt have no cache of their own to add
+        # here (neither tool has a `--cache` flag as of this writing). Prettier
+        # still runs once from the repo root (see `lint:prettier`), so
+        # `.prettier-cache` stays un-globbed -- if that ever changes to a
+        # per-package invocation, glob it the same way as the paths below.
+        #
+        # Update this list when a new package gains a `check:types`/`lint`
+        # script -- an outdated entry here just means a colder cache for that
+        # one package, not an error.
         path: |
           .prettier-cache
-          **/.eslintcache
-          **/tsconfig.tsbuildinfo
+          packages/*/.eslintcache
+          packages/*/tsconfig.tsbuildinfo
+          warp-drive-packages/*/.eslintcache
+          warp-drive-packages/*/tsconfig.tsbuildinfo
+          tests/*/.eslintcache
+          tests/*/tsconfig.tsbuildinfo
+          specs/.eslintcache
+          specs/tsconfig.tsbuildinfo
         key: lint-${{ github.head_ref }}-${{ inputs.ref }}
         restore-keys: |
           lint-${{ github.head_ref }}


### PR DESCRIPTION
## What

The `lint` job's "Restore Lint Caches" step (`.github/actions/setup/action.yml`) was spending ~30s of its ~34s save phase in `@actions/glob` resolving `**/.eslintcache` and `**/tsconfig.tsbuildinfo`. Neither pattern is scoped to skip `node_modules` (~12,000 directories, 689MB in this repo), so every save walked essentially the whole tree.

Confirmed the actual tar+upload isn't the bottleneck: the real save output was `Sent 871111 of 871111 (100.0%), 5.4 MBs/sec` — under a second of real transfer for the compressed payload. (Verified that 871KB isn't suspiciously small for ~17MB of source tsbuildinfo/eslintcache either: gzip -9 alone gets the same files to 12:1, so zstd's ~19.5:1 is in line, not a sign of missing data.)

Replaces both `**` patterns with explicit globs against the real workspace roots (`packages/*`, `warp-drive-packages/*`, `tests/*`, `specs`, matching `pnpm-workspace.yaml`'s `packages` list) — none of which can touch `node_modules`.

## Also checked

- **oxlint/oxfmt cache files**: neither tool has a `--cache` flag at all (checked `--help` for both) — there's nothing of theirs to add to this cache entry.
- **Whether Prettier is per-package**: no — `lint:prettier` is a single root-level invocation (`prettier --cache --cache-location=.prettier-cache ... '**/*.{gjs,gts}'`), so `.prettier-cache` correctly stays un-globbed, same as before.

## Test plan

- [x] New globs match the exact same 79 real `.eslintcache`/`tsconfig.tsbuildinfo` files the old `**` patterns matched (`packages/*`, `tests/*`, `warp-drive-packages/*`, `specs` — cross-checked against a real repo-wide `find`, no misses).
- [x] `.github/actions/setup/action.yml` validated as well-formed YAML after the edit.
- [ ] Will confirm the actual CI time improvement once this runs for real — the theory here is glob-walk cost, not something reproducible locally against a real GitHub Actions cache-save invocation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYFFJUz3zCcmXRoah3SsQp)_