### PR TITLE
fix(docs): silence TS 6.0 baseUrl deprecation breaking the canary docs build

### DIFF
--- a/warp-drive-packages/ember/typedoc.tsconfig.json
+++ b/warp-drive-packages/ember/typedoc.tsconfig.json
@@ -33,6 +33,10 @@
     "declarationMap": true,
     "inlineSourceMap": true,
     "inlineSources": true,
+    // TypeScript 6.0 deprecated `baseUrl` (removal planned for 7.0); this repo's `typescript`
+    // override is pinned to the classic 6.x line, so silence the deprecation until the `paths`
+    // entry below (which needs `baseUrl` to resolve) is migrated off it.
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "types": ["@glint/ember-tsc/types", "ember-source/types"],
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary

The `canary.warp-drive.io deployment` workflow's `build` job has been failing on every push to `main` since [#10957](https://github.com/warp-drive-data/warp-drive/pull/10957) bumped the workspace `typescript` override from `5.9.3` to `6.0.3`.

TypeScript 6.0 turns the `baseUrl` compiler-option deprecation notice into a hard `TS5101` error (removal is planned for 7.0). `warp-drive-packages/ember/typedoc.tsconfig.json` still sets `baseUrl` (needed to resolve its `paths` entry for `@glimmer/validator`), so `typedoc`'s conversion of the `@warp-drive/ember` package failed outright with:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
  Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

This took down typedoc's whole run (`Failed to convert one or more packages, result will not be merged together`), which is why the `Generate Artifact` step (`pnpm run build` in `docs-viewer`) has been exiting non-zero on every `main` push since the bump — see e.g. [run 33549266795](https://github.com/warp-drive-data/warp-drive/actions/runs/33549266795).

- Adds `"ignoreDeprecations": "6.0"` to `warp-drive-packages/ember/typedoc.tsconfig.json`, exactly as TypeScript's own error message suggests, until that `paths`/`baseUrl` usage is migrated away.

## Test plan

- [x] Reproduced the failure locally: `pnpm install` + `pnpm run build` in `docs-viewer` (on Node 26.8.1, matching this repo's `devEngines.runtime` pin used by the workflow) fails with the same `TS5101` error and `Failed to convert one or more packages` on unmodified `main`.
- [x] With the fix applied, the same build completes with exit code `0` (`Found 0 errors and 229 warnings`) and produces the full `docs-viewer/docs.warp-drive.io/.vitepress/dist` artifact.
- [x] `pnpm exec prettier --check warp-drive-packages/ember/typedoc.tsconfig.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iBKYRWDPG4GeoZ6hTNwkg

---
_Generated by [Claude Code](https://claude.ai/code/session_016iBKYRWDPG4GeoZ6hTNwkg)_