### PR TITLE
chore(renovate): raise branchConcurrentLimit from 3 to 12

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,7 +53,7 @@
   },
   "rangeStrategy": "bump",
   "prHourlyLimit": 10,
-  "branchConcurrentLimit": 3,
+  "branchConcurrentLimit": 12,
   "vulnerabilityAlerts": {
     "labels": [":label: security"],
     "automerge": false,


### PR DESCRIPTION
## Summary
- Raise `branchConcurrentLimit` in `.github/renovate.json` from `3` to `12`, per request.

## Context
This value was capped to `3` in #10892 to reduce OOM/timeout risk on Mend's hosted runner, since each concurrent branch triggers a full `pnpm-lock.yaml` regeneration (63 workspace packages, ~1650 resolved deps) via a real `pnpm install` subprocess. That change noted it was unproven ("Unknown if this will be effective at fixing this issue.").

Raising the limit to 12 will let more Renovate branches process in parallel per scan; worth watching Mend's runner for recurrence of OOM/timeout issues after this lands.

## Test plan
- [ ] Confirm `.github/renovate.json` is valid (validated locally with `JSON.parse`)
- [ ] Monitor the next few Renovate scans for OOM/timeout issues on Mend's runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnYiay9Z1sf38Lv7aiNJ26

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnYiay9Z1sf38Lv7aiNJ26)_