### PR TITLE
Remove ember-addon.externals from package.json files

### DIFF
--- a/packages/tracking/package.json
+++ b/packages/tracking/package.json
@@ -46,12 +46,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 2,
-    "externals": [
-      "@ember/-internals",
-      "@ember/-internals/metal",
-      "@glimmer/validator"
-    ]
+    "version": 2
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/warp-drive-packages/ember/package.json
+++ b/warp-drive-packages/ember/package.json
@@ -78,12 +78,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 2,
-    "externals": [
-      "@ember/-internals",
-      "@ember/-internals/metal",
-      "@glimmer/validator"
-    ]
+    "version": 2
   },
   "ember": {
     "edition": "octane"

--- a/warp-drive-packages/react/package.json
+++ b/warp-drive-packages/react/package.json
@@ -67,8 +67,7 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 2,
-    "externals": []
+    "version": 2
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Summary

- Removes the `externals` array from the `ember-addon` block in `packages/tracking/package.json`, `warp-drive-packages/ember/package.json`, and `warp-drive-packages/react/package.json`.
- `ember-addon.version` is kept; only the `externals` key is dropped.

This is a reboot of #10457. Merging this PR should close that one.

## Test plan

- [x] `node -e "JSON.parse(...)"` on each edited `package.json` to confirm valid JSON
- [x] Diff matches the original PR #10457 exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPC6moesNuVvVg7Xxf66MW

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPC6moesNuVvVg7Xxf66MW)_