### PR TITLE
Defer relationship notifications to store transaction notify phase

### DIFF
--- a/tests/json-api/tests/integration/cache/notification-batch-test.ts
+++ b/tests/json-api/tests/integration/cache/notification-batch-test.ts
@@ -202,7 +202,7 @@ module('Integration | NotificationManager batch notifications', function () {
     store.notifications.unsubscribe(token);
   });
 
-  test('relationship changes on the same identifier are flushed to `notify` as a single batch', function (assert) {
+  test('relationship changes on the same identifier are delivered exactly once per changed relationship', function (assert) {
     const store = new RelationshipTestStore();
 
     const doc = store.cache.put(
@@ -237,35 +237,14 @@ module('Integration | NotificationManager batch notifications', function () {
       }
     );
 
-    // spy on the underlying NotificationManager#notify to count how many times
-    // it is actually invoked for this identifier's 'relationships' namespace.
-    // Before this change, `CacheCapabilitiesManager#_flushNotifications` called
-    // `notify` once per pending relationship key; now it should call it once
-    // per identifier, carrying every pending key for that identifier at once.
-    // Also confirm the pending keys `Set<string>` collected by
-    // `CacheCapabilitiesManager#_pendingNotifies` is passed to `notify` as a
-    // `Set`, not converted to an array first (the relationships flush path
-    // already had a `Set` on hand, so there is no reason to convert it).
-    let notifyCallCount = 0;
-    let batchKeyWasSet = false;
-    const originalNotify = store.notifications.notify.bind(store.notifications);
-    store.notifications.notify = (
-      cacheKey: ResourceKey | RequestKey,
-      type: NotificationType | CacheOperation | DocumentCacheOperation,
-      key?: string | NotifyKeys | null
-    ) => {
-      if (cacheKey === identifier && type === 'relationships') {
-        notifyCallCount++;
-        if (key instanceof Set) {
-          batchKeyWasSet = true;
-        }
-      }
-      return (originalNotify as (cacheKey: unknown, type: unknown, key: unknown) => boolean)(cacheKey, type, key);
-    };
-
     // a single upsert that changes two different relationships on the same
     // record at once, simulating the N*M hot-path (here N=1 record, M=2
-    // changed relationships) called out in https://github.com/emberjs/data/issues/9667
+    // changed relationships) called out in https://github.com/emberjs/data/issues/9667.
+    // The per-key `notifyChange` calls the graph emits for this pass through
+    // `CacheCapabilitiesManager` straight into `NotificationManager`, whose
+    // buffer coalesces them into a single flush deferred to the end of the
+    // store transaction — subscribers must still see exactly one notification
+    // per changed relationship, delivered synchronously before upsert returns.
     store.cache.upsert(
       identifier,
       {
@@ -285,21 +264,10 @@ module('Integration | NotificationManager batch notifications', function () {
       true
     );
 
-    store.notifications.notify = originalNotify;
-
     assert.deepEqual(
       seenKeys.sort(),
       ['bestFriend', 'friends'].sort(),
       'we were notified exactly once for each relationship that actually changed'
-    );
-    assert.equal(
-      notifyCallCount,
-      1,
-      'both relationship keys were flushed to notify() in a single batched call, not once per key'
-    );
-    assert.true(
-      batchKeyWasSet,
-      'the pending-keys Set collected for this identifier was passed to notify() as a Set, without being converted to an array first'
     );
 
     store.notifications.unsubscribe(token);

--- a/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/cache-capabilities-manager.ts
@@ -15,18 +15,10 @@ export interface CacheCapabilitiesManager {
 }
 export class CacheCapabilitiesManager implements StoreWrapper {
   /** @internal */
-  declare private _willNotify: boolean;
-
-  /** @internal */
-  declare private _pendingNotifies: Map<ResourceKey, Map<string, Set<NotificationChannel | undefined>>>;
-
-  /** @internal */
   declare _store: Store;
 
   constructor(_store: Store) {
     this._store = _store;
-    this._willNotify = false;
-    this._pendingNotifies = new Map();
   }
 
   get cacheKeyManager(): CacheKeyManager {
@@ -36,82 +28,6 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   /** @deprecated use {@link CacheCapabilitiesManager.cacheKeyManager} */
   get identifierCache(): CacheKeyManager {
     return this.cacheKeyManager;
-  }
-
-  /** @internal */
-  private _scheduleNotification(identifier: ResourceKey, key: string, channel: NotificationChannel | undefined): void {
-    let pending = this._pendingNotifies.get(identifier);
-
-    if (!pending) {
-      pending = new Map();
-      this._pendingNotifies.set(identifier, pending);
-    }
-    let channels = pending.get(key);
-    if (!channels) {
-      channels = new Set();
-      pending.set(key, channels);
-    }
-    channels.add(channel);
-
-    if (this._willNotify === true) {
-      return;
-    }
-
-    this._willNotify = true;
-    // it's possible a cache adhoc notifies us,
-    // in which case we sync flush
-    if (this._store._cbs) {
-      this._store._schedule('notify', () => this._flushNotifications());
-    } else {
-      // TODO @runspired determine if relationship mutations should schedule
-      // into join/run vs immediate flush
-      this._flushNotifications();
-    }
-  }
-
-  /** @internal */
-  private _flushNotifications(): void {
-    if (this._willNotify === false) {
-      return;
-    }
-
-    const pending = this._pendingNotifies;
-    this._pendingNotifies = new Map();
-    this._willNotify = false;
-
-    // deliver all relationship keys pending for a given identifier as a single
-    // batch instead of one `notify` call per key: subscribers still receive one
-    // notification per key (in Set-insertion order), but the per-call overhead
-    // (subscriber lookups, buffer scheduling, etc) that `notify` would otherwise
-    // repeat for every key is paid only once per identifier. This mirrors the
-    // same N*M concern `attributes` notifications have (the json-api Cache
-    // batches a record's changed attribute keys into a single `notifyChange`
-    // Set for the same reason): a single push/mutation pass can dirty many
-    // relationships across many records at once, and each of those records
-    // funnels through this same per-identifier `pending` Set.
-    //
-    // Keys touched with more than one distinct channel during this window
-    // (e.g. once unscoped and once on `'local'`) are re-grouped by channel
-    // below so that each distinct channel is still handed off to `notify` as
-    // a single `Set<string>` batch call (never one call per key) -- `notify`'s
-    // own buffer (see NotificationManager) is what dedupes/coalesces these
-    // per-channel batches back down to a single delivery per subscriber.
-    pending.forEach((channelsByKey, identifier) => {
-      const keysByChannel = new Map<NotificationChannel | undefined, Set<string>>();
-      channelsByKey.forEach((channels, key) => {
-        channels.forEach((channel) => {
-          let keys = keysByChannel.get(channel);
-          if (!keys) {
-            keys = new Set();
-            keysByChannel.set(channel, keys);
-          }
-          keys.add(key);
-        });
-      });
-      keysByChannel.forEach((keys, channel) => {
-        this._store.notifications.notify(identifier, 'relationships', keys, channel);
-      });
-    });
   }
 
   notifyChange(identifier: ResourceKey, namespace: 'added' | 'removed', key: null): void;
@@ -136,13 +52,6 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   ): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier) || isRequestKey(identifier));
 
-    // TODO do we still get value from this?
-    if (namespace === 'relationships' && key) {
-      assert(`Expected a single relationship key`, typeof key === 'string');
-      this._scheduleNotification(identifier as ResourceKey, key, channel);
-      return;
-    }
-
     // @ts-expect-error
     this._store.notifications.notify(identifier, namespace, key, channel);
   }
@@ -163,7 +72,6 @@ export class CacheCapabilitiesManager implements StoreWrapper {
   disconnectRecord(identifier: ResourceKey): void {
     assert(`Expected a stable identifier`, isResourceKey(identifier));
     this._store._instanceCache.disconnect(identifier);
-    this._pendingNotifies.delete(identifier);
   }
 }
 

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -294,6 +294,8 @@ export class NotificationManager {
   /** @internal */
   declare private _hasFlush: boolean;
   /** @internal */
+  declare private _hasTransactionFlush: boolean;
+  /** @internal */
   declare private _onFlushCB?: () => void;
 
   constructor(store: Store) {
@@ -301,6 +303,7 @@ export class NotificationManager {
     this.isDestroyed = false;
     this._buffered = new Map();
     this._hasFlush = false;
+    this._hasTransactionFlush = false;
     this._cache = new Map();
   }
 
@@ -466,7 +469,26 @@ export class NotificationManager {
         count(`notify ${'type' in cacheKey ? cacheKey.type : '<document>'} ${value} ${keyToString(key)}`);
       }
 
-      if (!this._scheduleNotify()) {
+      // relationship notifications that arrive while a store transaction
+      // (store._run / store._join) is active — e.g. while the graph is still
+      // syncing relationship state — are deferred into the transaction's
+      // notify phase rather than dispatched mid-mutation. The notify phase
+      // runs synchronously at the end of the transaction, so this never
+      // delays delivery past the current calling context. All other
+      // namespaces flush immediately (below): several consumers depend on
+      // e.g. `'state'` notifications being delivered before a subsequent
+      // teardown within the same transaction unsubscribes them.
+      let scheduled = false;
+      if (value === 'relationships' && this.store._cbs) {
+        if (!this._hasTransactionFlush) {
+          this._hasTransactionFlush = true;
+          this.store._schedule('notify', () => this._flushTransaction());
+        }
+      } else {
+        scheduled = this._scheduleNotify();
+      }
+
+      if (!scheduled) {
         if (LOG_NOTIFICATIONS) {
           log(
             'notify',
@@ -521,28 +543,66 @@ export class NotificationManager {
     return true;
   }
 
+  /**
+   * The deferred flush scheduled into a store transaction's notify phase
+   * when a `'relationships'` notification arrives mid-transaction (see
+   * {@link NotificationManager.notify}). Runs synchronously at the end of
+   * the transaction, once the graph has finished syncing.
+   *
+   * @internal
+   */
+  private _flushTransaction(): void {
+    this._hasTransactionFlush = false;
+    // a request/push window (_enableAsyncFlush) ends in an explicit
+    // _flush() of its own; leave delivery to it rather than flushing
+    // mid-window.
+    if (this.store._enableAsyncFlush && !willSyncFlushWatchers()) {
+      this._hasFlush = true;
+      return;
+    }
+    this._flush();
+  }
+
   /** @internal */
   _flush(): void {
     const buffered = this._buffered;
     if (buffered.size) {
-      this._buffered = new Map();
-      for (const [cacheKey, states] of buffered) {
-        // `states` iterates in the order each namespace first fired during
-        // this flush window (see `mergeIntoBuffer`).
-        for (const [value, bucket] of states) {
-          if (bucket === null) {
-            // @ts-expect-error overload doesn't narrow within body
-            _flushNotification(this._cache, cacheKey, value, null);
-          } else if (bucket instanceof Set) {
-            // wildcard: one notification, key `null`, filtered by the union
-            // of channels any of the coalesced keyless touches carried.
-            // @ts-expect-error overload doesn't narrow within body
-            _flushNotification(this._cache, cacheKey, value, null, bucket);
-          } else {
-            for (const [key, channels] of bucket) {
-              // @ts-expect-error overload doesn't narrow within body
-              _flushNotification(this._cache, cacheKey, value, key, channels);
+      if (this._hasTransactionFlush) {
+        // a transaction-deferred relationships flush is still pending (see
+        // `notify`): deliver everything else now but withhold relationship
+        // buckets — they are owed to the transaction's notify phase and must
+        // not be dispatched mid-mutation. Extract before delivering so that
+        // notifies triggered by subscriber callbacks merge into the buffer
+        // cleanly rather than into a collection being iterated.
+        const pending: Array<
+          [
+            RequestKey | ResourceKey,
+            NotificationType | DocumentCacheOperation,
+            Map<string, ChannelSet> | ChannelSet | null,
+          ]
+        > = [];
+        for (const [cacheKey, states] of buffered) {
+          for (const [value, bucket] of states) {
+            if (value === 'relationships') {
+              continue;
             }
+            pending.push([cacheKey, value, bucket]);
+            states.delete(value);
+          }
+          if (states.size === 0) {
+            buffered.delete(cacheKey);
+          }
+        }
+        for (const [cacheKey, value, bucket] of pending) {
+          this._deliver(cacheKey, value, bucket);
+        }
+      } else {
+        this._buffered = new Map();
+        for (const [cacheKey, states] of buffered) {
+          // `states` iterates in the order each namespace first fired during
+          // this flush window (see `mergeIntoBuffer`).
+          for (const [value, bucket] of states) {
+            this._deliver(cacheKey, value, bucket);
           }
         }
       }
@@ -551,6 +611,28 @@ export class NotificationManager {
     this._hasFlush = false;
     this._onFlushCB?.();
     this._onFlushCB = undefined;
+  }
+
+  /** @internal */
+  private _deliver(
+    cacheKey: RequestKey | ResourceKey,
+    value: NotificationType | DocumentCacheOperation,
+    bucket: Map<string, ChannelSet> | ChannelSet | null
+  ): void {
+    if (bucket === null) {
+      // @ts-expect-error overload doesn't narrow within body
+      _flushNotification(this._cache, cacheKey, value, null);
+    } else if (bucket instanceof Set) {
+      // wildcard: one notification, key `null`, filtered by the union
+      // of channels any of the coalesced keyless touches carried.
+      // @ts-expect-error overload doesn't narrow within body
+      _flushNotification(this._cache, cacheKey, value, null, bucket);
+    } else {
+      for (const [key, channels] of bucket) {
+        // @ts-expect-error overload doesn't narrow within body
+        _flushNotification(this._cache, cacheKey, value, key, channels);
+      }
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
Related RFC https://github.com/emberjs/rfcs/pull/1232 

Note this is not currently intended to be the implementation of that RFC, but contains groundwork exploration of moving towards transactions that will be used to inform the RFCs design.

## Summary

Refactors notification handling to defer `'relationships'` notifications that arrive during store transactions (within `store._run` or `store._join`) to the transaction's notify phase, rather than flushing them immediately mid-mutation. This ensures the graph can finish syncing relationship state before subscribers are notified.

## Changes

### NotificationManager
- Added `_hasTransactionFlush` flag to track pending transaction-deferred flushes
- Modified `notify()` to detect `'relationships'` notifications arriving while `store._cbs` is active and schedule them into the transaction's notify phase via `store._schedule('notify', ...)`
- Added `_flushTransaction()` method to handle the deferred flush at the end of the transaction
- Refactored `_flush()` to handle partial flushes when a transaction-deferred relationships flush is still pending, extracting and delivering non-relationship notifications while preserving relationship buckets for the transaction's notify phase
- Extracted notification delivery logic into a new `_deliver()` helper method

### CacheCapabilitiesManager
- Removed `_willNotify`, `_pendingNotifies`, `_scheduleNotification()`, and `_flushNotifications()` methods
- Removed special-case batching logic for relationship notifications — this is now handled directly by NotificationManager's buffer and transaction scheduling
- Simplified `notifyChange()` to pass all notifications directly to `store.notifications.notify()`
- Removed cleanup of `_pendingNotifies` in `disconnectRecord()`

### Tests
- Updated test expectations in `notification-batch-test.ts` to reflect that relationship notifications are now delivered per-key rather than batched into a single `notify()` call
- Removed assertions about `notify()` call counts and Set types, as the batching now happens at the buffer level rather than at the `notify()` call level

## Rationale

The previous approach batched relationship notifications at the `CacheCapabilitiesManager` level before passing them to `NotificationManager`. This change moves that responsibility entirely to `NotificationManager`, which can now defer relationship notifications to the transaction's notify phase while allowing other notification types to flush immediately. This ensures:

1. Relationship state syncing completes before subscribers are notified
2. Other notification types (e.g., `'state'`) are still delivered immediately, as consumers depend on this timing
3. Subscribers still receive exactly one notification per changed relationship, delivered synchronously before the transaction returns

## Test Plan

Existing tests pass. The `notification-batch-test.ts` test has been updated to verify that subscribers receive exactly one notification per changed relationship, which is the key invariant this change maintains.

https://claude.ai/code/session_017CMTUUPwpZXGjqCM8nUDrP