### PR TITLE
Notify remote-state changes per notification channel (fixes stale linksMode hasMany)

### DIFF
--- a/@types/ember-data-qunit-asserts/index.d.ts
+++ b/@types/ember-data-qunit-asserts/index.d.ts
@@ -27,14 +27,35 @@ interface WarpDriveAsserts {
    * Asserts that the given identifier has been notified of a change to the given bucket
    * and optional key the given number of times during the test.
    *
-   * Clears the notification count for the given identifier, bucket and key after the assertion
-   * is made so that it is easy to assert notification counts in between steps of a test.
+   * Clears the notification counts (total and per-channel) for the given identifier,
+   * bucket and key after the assertion is made so that it is easy to assert notification
+   * counts in between steps of a test. When also asserting per-channel counts for the
+   * same step via `notifiedOn`, make those assertions first.
    */
   notified(
     identifier: RequestKey | ResourceKey,
     bucket: NotificationType | CacheOperation,
     key: string | null,
     count: number
+  ): void;
+
+  /**
+   * Asserts that the given identifier has been notified of a change to the given bucket
+   * and optional key the given number of times *on the given notification channel*
+   * ('local', 'remote', or 'unscoped' for notify calls that carried no channel; an
+   * unscoped notify is delivered to every subscriber).
+   *
+   * Unlike `notified`, this does not clear any counts: it is a probe. Assert the
+   * per-channel counts first, then close out the step with `notified` (which clears
+   * both the total and the per-channel counts).
+   */
+  notifiedOn(
+    channel: 'local' | 'remote' | 'unscoped',
+    identifier: RequestKey | ResourceKey,
+    bucket: NotificationType | CacheOperation,
+    key: string | null,
+    count: number,
+    message?: string
   ): void;
 
   watchNotifications(store?: unknown): void;

--- a/packages/unpublished-test-infra/src/test-support/asserts/assert-notification.ts
+++ b/packages/unpublished-test-infra/src/test-support/asserts/assert-notification.ts
@@ -5,11 +5,19 @@ import type Assert from 'ember-data-qunit-asserts';
 import type { Store, DocumentCacheOperation, NotificationType } from '@warp-drive/core';
 import type { ResourceKey, RequestKey } from '@warp-drive/core/types/identifier';
 
-type Counter = { count: number; delivered: number; ignored: number };
+// 'unscoped' counts notify() calls that carried no channel; such calls are
+// delivered to every subscriber. See NotificationChannel in @warp-drive/core.
+type CountableChannel = 'local' | 'remote' | 'unscoped';
+type ChannelCounts = Record<CountableChannel, number>;
+type Counter = { count: number; delivered: number; ignored: number; channels: ChannelCounts };
 type NotificationStorage = Map<
   RequestKey | ResourceKey | 'document' | 'resource',
   Map<NotificationType | DocumentCacheOperation, Counter | Map<string | symbol, Counter>>
 >;
+
+function makeCounter(): Counter {
+  return { count: 0, delivered: 0, ignored: 0, channels: { local: 0, remote: 0, unscoped: 0 } };
+}
 
 function getCounter(
   context: TestContext,
@@ -31,7 +39,7 @@ function getCounter(
   let bucketStorage = identifierStorage.get(bucket);
   if (!bucketStorage) {
     if (bucket === 'added' || bucket === 'removed' || bucket === 'updated' || bucket === 'state') {
-      bucketStorage = { count: 0, delivered: 0, ignored: 0 };
+      bucketStorage = makeCounter();
     } else {
       bucketStorage = new Map();
     }
@@ -43,7 +51,7 @@ function getCounter(
     const _key = key || Symbol.for(bucket);
     counter = bucketStorage.get(_key)!;
     if (!counter) {
-      counter = { count: 0, delivered: 0, ignored: 0 };
+      counter = makeCounter();
       bucketStorage.set(_key, counter);
     }
   } else {
@@ -88,6 +96,7 @@ function setupNotifications(context: TestContext, store: Store) {
     for (const singleKey of keys) {
       const counter = getCounter(context, cacheKey, bucket, singleKey);
       counter.count++;
+      counter.channels[channel ?? 'unscoped']++;
 
       if (scheduled) {
         counter.delivered++;
@@ -127,6 +136,26 @@ export function configureNotificationsAssert(this: TestContext, assert: unknown)
     });
 
     counter.count = 0;
+    counter.channels = { local: 0, remote: 0, unscoped: 0 };
+  };
+
+  (assert as Assert).notifiedOn = function (
+    this: Assert,
+    channel: CountableChannel,
+    cacheKey: ResourceKey | RequestKey,
+    bucket: NotificationType | DocumentCacheOperation,
+    key: string | null,
+    count: number,
+    message?: string
+  ) {
+    const counter = getCounter(context, cacheKey, bucket, key);
+
+    this.pushResult({
+      result: counter.channels[channel] === count,
+      actual: counter.channels[channel],
+      expected: count,
+      message: `${message ? message + ' | ' : ''}Expected ${count} ${channel}-channel ${bucket} notifications for ${cacheKey.lid} ${key || ''}, got ${counter.channels[channel]}`,
+    });
   };
 
   (assert as Assert).clearNotifications = function () {

--- a/packages/unpublished-test-infra/src/test-support/asserts/assert-notification.ts
+++ b/packages/unpublished-test-infra/src/test-support/asserts/assert-notification.ts
@@ -70,7 +70,8 @@ function setupNotifications(context: TestContext, store: Store) {
   notifications.notify = function (
     cacheKey: ResourceKey | RequestKey,
     bucket: NotificationType | DocumentCacheOperation,
-    key?: string | Set<string> | null
+    key?: string | Set<string> | null,
+    channel?: 'local' | 'remote'
   ) {
     // `key` may be a `Set<string>` when many keys for the same cacheKey+bucket
     // are delivered in a single batched `notify` call (see NotificationManager
@@ -82,7 +83,7 @@ function setupNotifications(context: TestContext, store: Store) {
     const keys = key instanceof Set ? Array.from(key) : [key ?? null];
 
     // @ts-expect-error TS is bad at curried overloads
-    const scheduled = originalNotify.apply(notifications, [cacheKey, bucket, key]);
+    const scheduled = originalNotify.apply(notifications, [cacheKey, bucket, key, channel]);
 
     for (const singleKey of keys) {
       const counter = getCounter(context, cacheKey, bucket, singleKey);

--- a/packages/unpublished-test-infra/src/test-support/asserts/index.ts
+++ b/packages/unpublished-test-infra/src/test-support/asserts/index.ts
@@ -46,10 +46,31 @@ declare module '@warp-drive/diagnostic/-types' {
      * Asserts that the given identifier has been notified of a change to the given bucket
      * and optional key the given number of times during the test.
      *
-     * Clears the notification count for the given identifier, bucket and key after the assertion
-     * is made so that it is easy to assert notification counts in between steps of a test.
+     * Clears the notification counts (total and per-channel) for the given identifier,
+     * bucket and key after the assertion is made so that it is easy to assert notification
+     * counts in between steps of a test. When also asserting per-channel counts for the
+     * same step via `notifiedOn`, make those assertions first.
      */
     notified(
+      identifier: RequestKey | ResourceKey,
+      bucket: NotificationType | CacheOperation,
+      key: string | null,
+      count: number,
+      message?: string
+    ): void;
+
+    /**
+     * Asserts that the given identifier has been notified of a change to the given bucket
+     * and optional key the given number of times *on the given notification channel*
+     * ('local', 'remote', or 'unscoped' for notify calls that carried no channel; an
+     * unscoped notify is delivered to every subscriber).
+     *
+     * Unlike `notified`, this does not clear any counts: it is a probe. Assert the
+     * per-channel counts first, then close out the step with `notified` (which clears
+     * both the total and the per-channel counts).
+     */
+    notifiedOn(
+      channel: 'local' | 'remote' | 'unscoped',
       identifier: RequestKey | ResourceKey,
       bucket: NotificationType | CacheOperation,
       key: string | null,

--- a/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
+++ b/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
@@ -892,7 +892,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     );
   }
 
-  test('updateRelationship operation matching localState does not produce a notification for a committed removal (resetOnRemoteUpdate=false)', function (assert) {
+  test('updateRelationship operation matching localState notifies only the remote channel for a committed removal (resetOnRemoteUpdate=false)', function (assert) {
     class User extends Model {
       @attr declare name: string;
       @hasMany('comment', { async: false, inverse: 'user', resetOnRemoteUpdate: false }) declare comments: Comment[];
@@ -1008,8 +1008,8 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
       userIdentifier,
       'relationships',
       'comments',
-      0,
-      'We should have no notifciations after remote push matches local state'
+      1,
+      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
     );
 
     // push an update that does not match the local state
@@ -1041,7 +1041,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     assert.arrayStrictEquals(data4.data, [comment1Identifier, comment4Identifier], 'state is updated');
   });
 
-  test('updateRelationship operation matching localState does not produce a notification for a committed addition (resetOnRemoteUpdate=false)', function (assert) {
+  test('updateRelationship operation matching localState notifies only the remote channel for a committed addition (resetOnRemoteUpdate=false)', function (assert) {
     class User extends Model {
       @attr declare name: string;
       @hasMany('comment', { async: false, inverse: 'user', resetOnRemoteUpdate: false }) declare comments: Comment[];
@@ -1134,8 +1134,8 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
       userIdentifier,
       'relationships',
       'comments',
-      0,
-      'no notifications after remote push matches local state'
+      1,
+      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
     );
 
     // check state is still the same
@@ -1181,7 +1181,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     );
   });
 
-  test('updateRelationship operation matching localState does not produce a notification for a committed removal', function (assert) {
+  test('updateRelationship operation matching localState notifies only the remote channel for a committed removal', function (assert) {
     class User extends Model {
       @attr declare name: string;
       @hasMany('comment', { async: false, inverse: 'user', resetOnRemoteUpdate: true }) declare comments: Comment[];
@@ -1297,8 +1297,8 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
       userIdentifier,
       'relationships',
       'comments',
-      0,
-      'We should have no notifciations after remote push matches local state'
+      1,
+      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
     );
 
     // push an update that does not match the local state
@@ -1330,7 +1330,7 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     assert.arrayStrictEquals(data4.data, [comment1Identifier, comment4Identifier], 'state is updated');
   });
 
-  test('updateRelationship operation matching localState does not produce a notification for a committed addition', function (assert) {
+  test('updateRelationship operation matching localState notifies only the remote channel for a committed addition', function (assert) {
     class User extends Model {
       @attr declare name: string;
       @hasMany('comment', { async: false, inverse: 'user', resetOnRemoteUpdate: true }) declare comments: Comment[];
@@ -1423,8 +1423,8 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
       userIdentifier,
       'relationships',
       'comments',
-      0,
-      'no notifications after remote push matches local state'
+      1,
+      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
     );
 
     // check state is still the same

--- a/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
+++ b/tests/ember-data__graph/tests/integration/graph/diff-preservation-test.ts
@@ -964,6 +964,14 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // mutation should notify
+    assert.notifiedOn(
+      'local',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'the mutation notifies the local channel: only the local view changed'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
@@ -1004,12 +1012,28 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
       'state is still the same'
     );
 
+    assert.notifiedOn(
+      'remote',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'the remote channel is notified after a remote push that matches local state: the remote view changed (the commit landed)'
+    );
+    assert.notifiedOn(
+      'local',
+      userIdentifier,
+      'relationships',
+      'comments',
+      0,
+      'the local channel is not notified after a remote push that matches local state: the local view did not change'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
       'comments',
       1,
-      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
+      'exactly one notification total after a remote push that matches local state'
     );
 
     // push an update that does not match the local state
@@ -1028,6 +1052,14 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // we should have notifications
+    assert.notifiedOn(
+      'unscoped',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'both views changed, so the two channel schedules coalesce into a single unscoped notification'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
@@ -1130,12 +1162,28 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // we should have no notifications
+    assert.notifiedOn(
+      'remote',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'the remote channel is notified after a remote push that matches local state: the remote view changed (the commit landed)'
+    );
+    assert.notifiedOn(
+      'local',
+      userIdentifier,
+      'relationships',
+      'comments',
+      0,
+      'the local channel is not notified after a remote push that matches local state: the local view did not change'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
       'comments',
       1,
-      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
+      'exactly one notification total after a remote push that matches local state'
     );
 
     // check state is still the same
@@ -1164,6 +1212,14 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // we should have notifications
+    assert.notifiedOn(
+      'unscoped',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'both views changed, so the two channel schedules coalesce into a single unscoped notification'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
@@ -1253,6 +1309,14 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // mutation should notify
+    assert.notifiedOn(
+      'local',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'the mutation notifies the local channel: only the local view changed'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
@@ -1293,12 +1357,28 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
       'state is still the same'
     );
 
+    assert.notifiedOn(
+      'remote',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'the remote channel is notified after a remote push that matches local state: the remote view changed (the commit landed)'
+    );
+    assert.notifiedOn(
+      'local',
+      userIdentifier,
+      'relationships',
+      'comments',
+      0,
+      'the local channel is not notified after a remote push that matches local state: the local view did not change'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
       'comments',
       1,
-      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
+      'exactly one notification total after a remote push that matches local state'
     );
 
     // push an update that does not match the local state
@@ -1317,6 +1397,14 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // we should have notifications
+    assert.notifiedOn(
+      'unscoped',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'both views changed, so the two channel schedules coalesce into a single unscoped notification'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
@@ -1419,12 +1507,28 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // we should have no notifications
+    assert.notifiedOn(
+      'remote',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'the remote channel is notified after a remote push that matches local state: the remote view changed (the commit landed)'
+    );
+    assert.notifiedOn(
+      'local',
+      userIdentifier,
+      'relationships',
+      'comments',
+      0,
+      'the local channel is not notified after a remote push that matches local state: the local view did not change'
+    );
     assert.notified(
       userIdentifier,
       'relationships',
       'comments',
       1,
-      'one remote-channel notification after a remote push that matches local state: the remote view changed (the commit landed) while the local view did not'
+      'exactly one notification total after a remote push that matches local state'
     );
 
     // check state is still the same
@@ -1453,6 +1557,14 @@ module('Integration | Graph | Diff Preservation', function (hooks) {
     });
 
     // we should have notifications
+    assert.notifiedOn(
+      'unscoped',
+      userIdentifier,
+      'relationships',
+      'comments',
+      1,
+      'both views changed, so the two channel schedules coalesce into a single unscoped notification'
+    );
     assert.notified(
       userIdentifier,
       'relationships',

--- a/tests/json-api/tests/integration/cache/mutation-request-test.ts
+++ b/tests/json-api/tests/integration/cache/mutation-request-test.ts
@@ -134,25 +134,7 @@ module<CustomContext>('mutation-request', function (hooks) {
     assert.equal(user2?.id, 'id2', 'second record has correct id');
   });
 
-  // TODO: a `linksMode` hasMany's rendered array caches itself on the record's
-  // signal after its first read (see `getHasManyField`), so `graph.getData`/
-  // `computeLocalState` -- the only place a `CollectionEdge`'s `isDirty` flag
-  // and `localState` snapshot are ever refreshed -- is never called again for
-  // that field after the first access. A second (or later) remote update
-  // then diffs against that now-stale `localState`, which can make
-  // `diff.changed` (and, before it, `relationship.isDirty`) come out `false`
-  // even though membership genuinely changed, so the second update's
-  // notification never fires and the rendered array goes stale. Neither
-  // gating on `diff.changed` (correct for the general case, see
-  // `replaceRelatedRecordsRemote`) nor unconditionally on `diff.remoteOrderChanged`
-  // (which regresses tests/ember-data__graph's diff-preservation suite, since
-  // a remote update that merely catches up to an already-committed local
-  // change would then also (mis)report as "changed") resolves this on its
-  // own; fixing it needs the `linksMode` read path itself to keep the graph's
-  // local-state tracking in sync, which is a larger change than this test's
-  // surrounding rebase warrants. Left as `todo` (asserts real, currently
-  // failing behavior) rather than silently deleted or shipped red.
-  todo<CustomContext>('update hasMany with repeated patch', async function (assert) {
+  test<CustomContext>('update hasMany with repeated patch', async function (assert) {
     const { store } = this;
     const url = buildBaseURL({ resourcePath: 'api/user/1' });
 

--- a/tests/json-api/tests/integration/store/notification-channel-test.ts
+++ b/tests/json-api/tests/integration/store/notification-channel-test.ts
@@ -48,7 +48,7 @@ function flush(store: Store): void {
 }
 
 module('Integration | NotificationManager channels', function () {
-  test('a subscriber that omits channel behaves as "local": it receives every notification', function (assert) {
+  test('a subscriber that omits channel behaves as "local": it hears unscoped and local notifies, but not remote', function (assert) {
     const store = new TestStore();
     void store.cache; // trigger lazy createCache so _capabilities is populated
     const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
@@ -65,13 +65,14 @@ module('Integration | NotificationManager channels', function () {
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'local');
     assert.equal(calls, 2, 'received the local-channel notify');
 
-    // a local view is derived from remote state, so a remote change is always
-    // relevant to it: local (and defaulted) subscribers hear everything.
+    // a 'remote'-tagged notify declares "only the remote view changed"; a
+    // local-view subscriber re-pulls reconciled local state when notified,
+    // and that view did not change, so it is skipped.
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'remote');
-    assert.equal(calls, 3, 'received the remote-channel notify (local subscribers hear everything)');
+    assert.equal(calls, 2, 'did not receive the remote-channel notify (the local view did not change)');
   });
 
-  test('a subscriber scoped to "local" receives every notification, same as omitting the channel', function (assert) {
+  test('a subscriber scoped to "local" hears unscoped and local notifies, but not remote, same as omitting the channel', function (assert) {
     const store = new TestStore();
     void store.cache; // trigger lazy createCache so _capabilities is populated
     const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
@@ -85,13 +86,13 @@ module('Integration | NotificationManager channels', function () {
     );
 
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'remote');
-    assert.equal(calls, 1, 'received the remote-channel notify (a remote change also affects the local view)');
+    assert.equal(calls, 0, 'did not receive the remote-channel notify (the local view did not change)');
 
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'local');
-    assert.equal(calls, 2, 'received the local-channel notify');
+    assert.equal(calls, 1, 'received the local-channel notify');
 
     store._capabilities.notifyChange(identifier, 'attributes', 'name');
-    assert.equal(calls, 3, 'received the unscoped notify (unscoped reaches every subscriber)');
+    assert.equal(calls, 2, 'received the unscoped notify (unscoped reaches every subscriber)');
   });
 
   test('a subscriber scoped to "remote" hears unscoped and remote notifies, but not local', function (assert) {
@@ -117,7 +118,7 @@ module('Integration | NotificationManager channels', function () {
     assert.equal(calls, 2, 'received the remote-channel notify');
   });
 
-  test('the only skipped delivery is an explicit "local" notify to an explicit "remote" subscriber', function (assert) {
+  test('a scoped notify is delivered only to that channel; unscoped reaches both', function (assert) {
     const store = new TestStore();
     void store.cache;
     const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
@@ -149,11 +150,7 @@ module('Integration | NotificationManager channels', function () {
     assert.equal(remoteCalls, 1, 'remote subscriber did not receive the local-channel notify');
 
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'remote');
-    assert.equal(
-      localCalls,
-      3,
-      'local subscriber received the remote-channel notify (a remote change also affects the local view)'
-    );
+    assert.equal(localCalls, 2, 'local subscriber did not receive the remote-channel notify');
     assert.equal(remoteCalls, 2, 'remote subscriber received the remote-channel notify');
   });
 
@@ -253,9 +250,9 @@ module('Integration | NotificationManager channels', function () {
 
     const restore = deferFlushes(store);
     // the same key, touched twice before a single flush: once tagged 'local',
-    // once tagged 'remote'. The 'local' subscriber hears everything and the
-    // 'remote' subscriber matches the 'remote'-tagged touch, so each must be
-    // notified exactly once -- neither zero times nor twice.
+    // once tagged 'remote'. Each subscriber matches the touch tagged with its
+    // own channel, so each must be notified exactly once -- neither zero
+    // times nor twice.
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'local');
     store._capabilities.notifyChange(identifier, 'attributes', 'name', 'remote');
     restore();

--- a/warp-drive-packages/core/src/graph/-private/edges/collection.ts
+++ b/warp-drive-packages/core/src/graph/-private/edges/collection.ts
@@ -101,7 +101,17 @@ export function legacyGetCollectionRelationshipData(
   const payload: CollectionRelationship = {};
 
   if (source.state.hasReceivedData) {
-    payload.data = getRemoteState ? source.remoteState.slice() : computeLocalState(source);
+    // every access refreshes the edge's local-state tracking, remote-state reads
+    // included: `computeLocalState` is the only place `isDirty` is cleared and the
+    // `localState` snapshot re-derived, and `diffCollection` trusts that snapshot
+    // as "what an up-to-date reader currently sees" when deciding whether the next
+    // remote update changed anything. A reader that only ever consumes remote
+    // state (e.g. a non-editable `linksMode` ManyArray syncing via
+    // `getRemoteRelationship`) would otherwise leave the snapshot permanently
+    // stale after the first remote change, making a later genuine membership
+    // change diff as "unchanged" and never notify.
+    const localState = computeLocalState(source);
+    payload.data = getRemoteState ? source.remoteState.slice() : localState;
   }
 
   if (source.links) {

--- a/warp-drive-packages/core/src/graph/-private/edges/collection.ts
+++ b/warp-drive-packages/core/src/graph/-private/edges/collection.ts
@@ -101,17 +101,7 @@ export function legacyGetCollectionRelationshipData(
   const payload: CollectionRelationship = {};
 
   if (source.state.hasReceivedData) {
-    // every access refreshes the edge's local-state tracking, remote-state reads
-    // included: `computeLocalState` is the only place `isDirty` is cleared and the
-    // `localState` snapshot re-derived, and `diffCollection` trusts that snapshot
-    // as "what an up-to-date reader currently sees" when deciding whether the next
-    // remote update changed anything. A reader that only ever consumes remote
-    // state (e.g. a non-editable `linksMode` ManyArray syncing via
-    // `getRemoteRelationship`) would otherwise leave the snapshot permanently
-    // stale after the first remote change, making a later genuine membership
-    // change diff as "unchanged" and never notify.
-    const localState = computeLocalState(source);
-    payload.data = getRemoteState ? source.remoteState.slice() : localState;
+    payload.data = getRemoteState ? source.remoteState.slice() : computeLocalState(source);
   }
 
   if (source.links) {

--- a/warp-drive-packages/core/src/graph/-private/graph.ts
+++ b/warp-drive-packages/core/src/graph/-private/graph.ts
@@ -3,6 +3,7 @@ import { DEBUG } from '@warp-drive/core/build-config/env';
 import { assert } from '@warp-drive/core/build-config/macros';
 
 import type { Store } from '../../store/-private.ts';
+import type { NotificationChannel } from '../../store/-private/managers/notification-manager.ts';
 import type { CacheCapabilitiesManager, ResourceKey } from '../../types.ts';
 import { getOrSetGlobal, peekTransient, setTransient } from '../../types/-private.ts';
 import type { RelationshipDiff } from '../../types/cache.ts';
@@ -142,10 +143,13 @@ export class Graph {
    */
   declare _pushedUpdates: PendingOps;
   /**
-   * The set of {@link CollectionEdge}s that have local changes pending notification, scheduled
-   * via {@link Graph._scheduleLocalSync} and drained by {@link Graph._flushLocalQueue}.
+   * The {@link CollectionEdge}s that have changes pending notification, scheduled via
+   * {@link Graph._scheduleLocalSync} and drained by {@link Graph._flushLocalQueue}, each
+   * mapped to the {@link NotificationChannel} the notification should be scoped to —
+   * `null` when it must reach every subscriber (scheduled unscoped, or scheduled for
+   * both channels).
    */
-  declare _updatedRelationships: Set<CollectionEdge>;
+  declare _updatedRelationships: Map<CollectionEdge, NotificationChannel | null>;
   /**
    * The identifier of the current remote-update transaction, or `null` when no transaction is
    * in progress. Set by {@link Graph._flushRemoteQueue} and stamped onto edges via
@@ -173,7 +177,7 @@ export class Graph {
       hasMany: undefined,
       deletions: [],
     };
-    this._updatedRelationships = new Set();
+    this._updatedRelationships = new Map();
     this._transaction = null;
     this._removing = null;
     this.silenceNotifications = false;
@@ -615,12 +619,21 @@ export class Graph {
   }
 
   /**
-   * Marks a {@link CollectionEdge} as having local changes that need to be notified, and
-   * schedules a flush of the local sync queue (see {@link Graph._flushLocalQueue}) if one is not
-   * already pending.
+   * Marks a {@link CollectionEdge} as having changes that need to be notified on the given
+   * {@link NotificationChannel} (omitted = unscoped, reaching every subscriber), and schedules
+   * a flush of the sync queue (see {@link Graph._flushLocalQueue}) if one is not already
+   * pending. Scheduling the same edge for both channels (or once unscoped) coalesces into a
+   * single unscoped notification.
    */
-  _scheduleLocalSync(relationship: CollectionEdge): void {
-    this._updatedRelationships.add(relationship);
+  _scheduleLocalSync(relationship: CollectionEdge, channel?: NotificationChannel): void {
+    const pending = this._updatedRelationships;
+    if (!pending.has(relationship)) {
+      pending.set(relationship, channel ?? null);
+    } else if (pending.get(relationship) !== (channel ?? null)) {
+      // two different scopes (or a scope + unscoped) for the same edge merge
+      // into one unscoped notification rather than notifying twice.
+      pending.set(relationship, null);
+    }
     if (!this._willSyncLocal) {
       this._willSyncLocal = true;
       getStore(this.store)._schedule('sync', () => this._flushLocalQueue());
@@ -696,14 +709,14 @@ export class Graph {
 
     if (this.silenceNotifications) {
       this.silenceNotifications = false;
-      this._updatedRelationships = new Set();
+      this._updatedRelationships = new Map();
       return;
     }
 
     this._willSyncLocal = false;
     const updated = this._updatedRelationships;
-    this._updatedRelationships = new Set();
-    updated.forEach((rel) => notifyChange(this, rel));
+    this._updatedRelationships = new Map();
+    updated.forEach((channel, rel) => notifyChange(this, rel, channel ?? undefined));
   }
 
   /**

--- a/warp-drive-packages/core/src/graph/-private/operations/add-to-related-records.ts
+++ b/warp-drive-packages/core/src/graph/-private/operations/add-to-related-records.ts
@@ -58,10 +58,10 @@ export default function addToRelatedRecords(
   }
 
   // a purely local mutation (isRemote=false) has no remote implication, so
-  // remote-only readers don't need to be woken for it. 'remote' delivers to
-  // every subscriber (same as an omitted channel); passing it explicitly
-  // keeps this call monomorphic.
-  notifyChange(graph, relationship, isRemote ? 'remote' : 'local');
+  // remote-only readers don't need to be woken for it. A remote addition
+  // changes remote state and the reconciled local view alike, so it is
+  // notified unscoped, reaching every subscriber.
+  notifyChange(graph, relationship, isRemote ? undefined : 'local');
 }
 
 function addRelatedRecord(

--- a/warp-drive-packages/core/src/graph/-private/operations/remove-from-related-records.ts
+++ b/warp-drive-packages/core/src/graph/-private/operations/remove-from-related-records.ts
@@ -51,10 +51,10 @@ export default function removeFromRelatedRecords(
   }
 
   // a purely local mutation (isRemote=false) has no remote implication, so
-  // remote-only readers don't need to be woken for it. 'remote' delivers to
-  // every subscriber (same as an omitted channel); passing it explicitly
-  // keeps this call monomorphic.
-  notifyChange(graph, relationship, isRemote ? 'remote' : 'local');
+  // remote-only readers don't need to be woken for it. A remote removal
+  // changes remote state and the reconciled local view alike, so it is
+  // notified unscoped, reaching every subscriber.
+  notifyChange(graph, relationship, isRemote ? undefined : 'local');
 }
 
 function removeRelatedRecord(

--- a/warp-drive-packages/core/src/graph/-private/operations/replace-related-records.ts
+++ b/warp-drive-packages/core/src/graph/-private/operations/replace-related-records.ts
@@ -7,6 +7,7 @@ import { assert } from '@warp-drive/core/build-config/macros';
 
 import { _add, _removeLocal, _removeRemote, diffCollection } from '../-diff.ts';
 import { checkIfNew, isBelongsTo, isHasMany, notifyChange } from '../-utils.ts';
+import type { NotificationChannel } from '../../../store/-private/managers/notification-manager.ts';
 import type { ResourceKey } from '../../../types.ts';
 import type { ReplaceRelatedRecordsOperation } from '../../../types/graph.ts';
 import { assertPolymorphicType } from '../debug/assert-polymorphic-type.ts';
@@ -344,33 +345,39 @@ function replaceRelatedRecordsRemote(graph: Graph, op: ReplaceRelatedRecordsOper
     }
   }
 
-  // Gate directly on `diff.changed` rather than the `isDirty` false->true
-  // transition (`relationship.isDirty && !wasDirty`) that used to guard this.
-  // `diff.changed` is exactly "did this remote update, once reconciled
-  // against whatever local currently shows, produce an observably different
-  // local materialization" - which is precisely what should trigger a
-  // flush/notify, and it already accounts for the deprecated
-  // `resetOnRemoteUpdate`/`DEPRECATE_RELATIONSHIP_REMOTE_UPDATE_CLEARING_LOCAL_STATE`
-  // reconciliation rules (see `_compare` in -diff.ts).
+  // A remote update is notified per projection, on that projection's channel
+  // (see NotificationChannel's delivery matrix):
   //
-  // The old `isDirty`-transition gate is not equivalent: `isDirty` is only
-  // reset back to `false` by `computeLocalState`, so a reader that never
-  // calls it (e.g. a `linksMode` array, which reads relationship data
-  // straight from the graph) can leave `isDirty` latched `true` forever
-  // after the very first remote change - silently suppressing every
-  // subsequent genuine change for that relationship, since `!wasDirty` would
-  // always be `false` from then on. This was caught by
-  // `tests/json-api`'s "update hasMany with repeated patch" (a `linksMode`
-  // hasMany that must reconcile correctly across more than one remote
-  // update). Gating on `diff.changed` directly fixes that without the
-  // over-eager regression an earlier attempt at this fix caused: gating (or
-  // additionally gating) on `diff.remoteOrderChanged` instead flagged a
-  // remote push that merely catches up to what local already independently
-  // reflects (no observable difference for any consumer) as needing a
-  // flush, regressing tests/ember-data__graph's diff-preservation suite
-  // ("... does not produce a notification for a committed removal/addition").
+  // - `diff.remoteOrderChanged` is exactly "did remoteState's membership or
+  //   order change". Remote-only readers (e.g. a non-editable `linksMode`
+  //   ManyArray) re-pull remote state when notified, so they are notified on
+  //   the `'remote'` channel whenever it changes - including a push that
+  //   merely confirms an already-committed local mutation, since the remote
+  //   projection genuinely changes there too.
+  // - `diff.changed` is exactly "did this remote update, once reconciled
+  //   against whatever local currently shows, produce an observably different
+  //   local materialization" (it already accounts for the deprecated
+  //   `resetOnRemoteUpdate` reconciliation rules - see `_compare` in
+  //   -diff.ts). Local-view readers re-pull reconciled local state when
+  //   notified, so they are notified on the `'local'` channel; a push that
+  //   only confirms a committed local mutation leaves their view unchanged
+  //   and correctly stays silent for them.
+  //
+  // When both change, the two schedules coalesce into a single unscoped
+  // notification (see `Graph._scheduleLocalSync`).
+  //
+  // Neither gate consults `relationship.isDirty` or `localState` freshness
+  // beyond what the diff itself computed: the old `isDirty`-transition gate
+  // (`relationship.isDirty && !wasDirty`) latched `true` forever for readers
+  // that never run `computeLocalState`, and a single ungated/unscoped
+  // `diff.changed` notify let a stale `localState` snapshot (never refreshed
+  // by remote-only readers) suppress genuine remote changes - both caught by
+  // `tests/json-api`'s "update hasMany with repeated patch".
+  if (diff.remoteOrderChanged) {
+    flushCanonical(graph, relationship, 'remote');
+  }
   if (diff.changed) {
-    flushCanonical(graph, relationship);
+    flushCanonical(graph, relationship, 'local');
   }
 }
 
@@ -523,8 +530,8 @@ export function removeFromInverse(
   }
 }
 
-function flushCanonical(graph: Graph, rel: CollectionEdge) {
+function flushCanonical(graph: Graph, rel: CollectionEdge, channel?: NotificationChannel) {
   if (rel.accessed) {
-    graph._scheduleLocalSync(rel);
+    graph._scheduleLocalSync(rel, channel);
   }
 }

--- a/warp-drive-packages/core/src/reactive/-private/kind/has-many-field.ts
+++ b/warp-drive-packages/core/src/reactive/-private/kind/has-many-field.ts
@@ -28,9 +28,14 @@ export function getHasManyField(context: KindContext<LegacyHasManyField>): unkno
     }
     const { editable, resourceKey } = context;
     const { cache } = store;
-    const rawValue = cache.getRelationship(
-      resourceKey,
-      getFieldCacheKeyStrict(field)
+    // the editable copy renders reconciled local state; the readonly copy
+    // renders remote state (and re-pulls remote state when notified on the
+    // 'remote' channel), mirroring ManyArrayManager._syncArray and
+    // getBelongsToField.
+    const rawValue = (
+      editable
+        ? cache.getRelationship(resourceKey, getFieldCacheKeyStrict(field))
+        : cache.getRemoteRelationship(resourceKey, getFieldCacheKeyStrict(field))
     ) as CollectionResourceRelationship;
     if (!rawValue) {
       return null;

--- a/warp-drive-packages/core/src/reactive/-private/record.ts
+++ b/warp-drive-packages/core/src/reactive/-private/record.ts
@@ -253,11 +253,14 @@ export class ReactiveResource {
             break;
         }
       },
-      // PolarisMode's default immutable instance shows only remote state, so it
-      // subscribes 'remote' to skip purely-local edits it can't see. Legacy-mode
-      // schemas and any editable instance (including a checked-out PolarisMode
-      // copy) show a reconciled local view and so subscribe 'local' (the same
-      // as omitting the channel): they hear everything.
+      // Each copy subscribes to the channel of the projection it renders and
+      // re-pulls that projection when notified. PolarisMode's default immutable
+      // instance shows only remote state, so it subscribes 'remote' and is not
+      // woken for purely-local changes it can't see. Legacy-mode schemas and any
+      // editable instance (including a checked-out PolarisMode copy) show a
+      // reconciled local view and so subscribe 'local' (the same as omitting the
+      // channel) and are not woken for purely-remote changes (e.g. a push that
+      // merely confirms a committed local mutation) that leave their view as-is.
       context.legacy || context.editable ? 'local' : 'remote'
     );
 

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -2,6 +2,7 @@ import { LOG_METRIC_COUNTS, LOG_NOTIFICATIONS } from '@warp-drive/core/build-con
 import { assert } from '@warp-drive/core/build-config/macros';
 
 import { willSyncFlushWatchers } from '../../../signals/-private.ts';
+import { getOrSetGlobal } from '../../../types/-private.ts';
 import type { RequestKey, ResourceKey } from '../../../types/identifier.ts';
 import { log } from '../debug/utils.ts';
 import type { Store } from '../store-service.ts';
@@ -82,7 +83,7 @@ export type NotificationChannel = 'local' | 'remote';
  * regardless of what channel(s) the same key was also touched with, so its
  * presence in the set short-circuits channel filtering.
  */
-const UnscopedChannel = Symbol('unscoped');
+const UnscopedChannel: '___(unique) Symbol(UnscopedChannel)' = getOrSetGlobal('UnscopedChannel', Symbol('unscoped'));
 
 /**
  * The set of channels (if any) a given `'attributes'`/`'relationships'` touch

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -46,32 +46,24 @@ export type NotifyKeys = Set<string>;
  * a "local" view of the resource (its mutable/editable state), a "remote" view
  * (its last-known-persisted state), or both.
  *
- * Because a resource's local view is derived from its remote state (remote
- * state plus any pending local mutations), a change to remote state also
- * potentially changes what a local view shows -- but a purely local mutation
- * never changes what a remote-only view shows. Channel filtering is therefore
- * one-directional: the only notification a subscriber can opt out of is a
- * purely-local change, by subscribing `'remote'`.
- *
- * - Subscribing `'remote'` means "only tell me about changes that could
- *   affect remote state" -- used by a reader that only ever displays remote
- *   state (e.g. PolarisMode's default immutable record), so it isn't woken
- *   for purely-local edits it can't see anyway. Subscribing `'local'` and
- *   omitting the channel are the same thing: both receive every
- *   notification, exactly as every subscriber did before channels existed.
- * - Notifying `'local'` declares "only local state changed" -- the one tag
- *   that lets `'remote'` subscribers be skipped. Notifying `'remote'` or
- *   omitting the channel reaches every subscriber: an unscoped notify cannot
- *   guarantee the change was local-only, so it must assume it wasn't. This
- *   keeps every pre-channel `notify` callsite (and any custom cache that
- *   doesn't know about channels) fully compatible.
+ * Each view subscribes to its own channel and, when notified, re-pulls its own
+ * projection of the data: a remote-only reader (e.g. PolarisMode's default
+ * immutable record) subscribes `'remote'` and re-reads remote state; an
+ * editable/reconciled reader (a legacy record, or an editable checkout)
+ * subscribes `'local'` (the same as omitting the channel) and re-reads local
+ * state. A notifier that knows which projection changed tags the notification
+ * with that channel; each tag is delivered only to that channel's subscribers.
+ * A change affecting both projections is either notified unscoped or once per
+ * channel. An unscoped notify cannot guarantee which view changed, so it
+ * reaches every subscriber -- this keeps every pre-channel `notify` callsite
+ * (and any custom cache that doesn't know about channels) fully compatible.
  *
  * The full delivery matrix:
  *
  * | notify ↓ subscribe → | `'local'` | `'remote'` | omitted (= `'local'`) |
  * | -------------------- | --------- | ---------- | --------------------- |
  * | `'local'`            | ✅        | ❌         | ✅                    |
- * | `'remote'`           | ✅        | ✅         | ✅                    |
+ * | `'remote'`           | ❌        | ✅         | ❌                    |
  * | omitted              | ✅        | ✅         | ✅                    |
  *
  * Channel only applies to the `'attributes'` and `'relationships'`
@@ -214,13 +206,13 @@ function mergeIntoBuffer(
 /**
  * Given the set of channels a touch (or coalesced group of touches) was
  * recorded with, determines whether a subscriber scoped to `subscriberChannel`
- * should be delivered to. Only one combination is ever skipped (see the
- * delivery matrix on {@link NotificationChannel}): a `'remote'` subscriber
- * and a touch-set that was exclusively tagged `'local'`. A `'local'` (or
- * defaulted) subscriber receives everything.
+ * should be delivered to (see the delivery matrix on
+ * {@link NotificationChannel}): a subscriber hears a touch-set if any of its
+ * touches was unscoped or tagged with the subscriber's own channel; a
+ * touch-set exclusively tagged with the *other* channel is skipped.
  */
 function shouldDeliverToChannel(channels: ChannelSet, subscriberChannel: NotificationChannel): boolean {
-  return subscriberChannel !== 'remote' || channels.has(undefined) || channels.has('remote');
+  return channels.has(undefined) || channels.has(subscriberChannel);
 }
 
 function count(label: string) {
@@ -326,17 +318,17 @@ export class NotificationManager {
    * }
    * ```
    *
-   * A `channel` may be provided when subscribing to a `ResourceKey`. Its only
-   * effect is that a `'remote'` subscription skips `'attributes'`/`'relationships'`
-   * notifications explicitly tagged `'local'`; notifications for all other
-   * notification types are never filtered by channel and always reach the
-   * subscriber. Subscribing `'local'` and omitting the channel are the same
-   * thing: both receive every notification. See {@link NotificationChannel}.
+   * A `channel` may be provided when subscribing to a `ResourceKey`. Its
+   * effect is that the subscription skips `'attributes'`/`'relationships'`
+   * notifications explicitly tagged with the *other* channel; unscoped
+   * notifications, and notifications for all other notification types, always
+   * reach the subscriber. Subscribing `'local'` and omitting the channel are
+   * the same thing. See {@link NotificationChannel}.
    *
    * | notify ↓ subscribe → | `'local'` | `'remote'` | omitted (= `'local'`) |
    * | -------------------- | --------- | ---------- | --------------------- |
    * | `'local'`            | ✅        | ❌         | ✅                    |
-   * | `'remote'`           | ✅        | ✅         | ✅                    |
+   * | `'remote'`           | ❌        | ✅         | ❌                    |
    * | omitted              | ✅        | ✅         | ✅                    |
    *
    * @public
@@ -400,15 +392,16 @@ export class NotificationManager {
    * per key.
    *
    * A `channel` may be supplied for the `'attributes'`/`'relationships'`
-   * namespaces. Tagging a notification `'local'` declares "only local state
-   * changed", letting `'remote'`-scoped subscribers skip it. Notifying
-   * `'remote'` or omitting the channel reaches every subscriber regardless
-   * of its channel. See {@link NotificationChannel}.
+   * namespaces. Tagging a notification `'local'` declares "only the local
+   * (reconciled/editable) view changed"; tagging it `'remote'` declares "only
+   * the remote view changed". Each tag is delivered only to that channel's
+   * subscribers. Omitting the channel reaches every subscriber regardless of
+   * its channel. See {@link NotificationChannel}.
    *
    * | notify ↓ subscribe → | `'local'` | `'remote'` | omitted (= `'local'`) |
    * | -------------------- | --------- | ---------- | --------------------- |
    * | `'local'`            | ✅        | ❌         | ✅                    |
-   * | `'remote'`           | ✅        | ✅         | ✅                    |
+   * | `'remote'`           | ❌        | ✅         | ❌                    |
    * | omitted              | ✅        | ✅         | ✅                    |
    *
    * @private

--- a/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
+++ b/warp-drive-packages/core/src/store/-private/managers/notification-manager.ts
@@ -77,13 +77,20 @@ export type NotifyKeys = Set<string>;
 export type NotificationChannel = 'local' | 'remote';
 
 /**
- * The set of channels (if any) a given `'attributes'`/`'relationships'` touch
- * was tagged with while buffered. `undefined` is included in this set when at
- * least one of the coalesced touches was itself unscoped (no channel given),
- * since an unscoped touch always reaches every subscriber regardless of what
- * channel(s) it was also touched with.
+ * Well-known sentinel recorded in a {@link ChannelSet} for a touch that
+ * carried no channel. An unscoped touch always reaches every subscriber
+ * regardless of what channel(s) the same key was also touched with, so its
+ * presence in the set short-circuits channel filtering.
  */
-type ChannelSet = Set<NotificationChannel | undefined>;
+const UnscopedChannel = Symbol('unscoped');
+
+/**
+ * The set of channels (if any) a given `'attributes'`/`'relationships'` touch
+ * was tagged with while buffered. {@link UnscopedChannel} is included in this
+ * set when at least one of the coalesced touches was itself unscoped (no
+ * channel given).
+ */
+type ChannelSet = Set<NotificationChannel | typeof UnscopedChannel>;
 
 export interface NotificationCallback {
   (cacheKey: ResourceKey, notificationType: 'attributes' | 'relationships', key?: string): void;
@@ -131,8 +138,8 @@ function keyToString(key: string | NotifyKeys | null | undefined): string {
  * For `'attributes'`/`'relationships'`, a key (or channel) *does* matter, so
  * the bucket is one of:
  * - a `Map<string, ChannelSet>`: the normal case, mapping each specific key
- *   touched to the set of channels it was touched with (`undefined` in that
- *   set means at least one of those touches was itself unscoped).
+ *   touched to the set of channels it was touched with ({@link UnscopedChannel}
+ *   in that set means at least one of those touches was itself unscoped).
  * - a `ChannelSet` directly: a wildcard meaning "an unspecified set of keys
  *   changed" - a strict superset of any specific key list, per the existing
  *   contract of {@link CacheCapabilitiesManager.notifyChange} - tagged with
@@ -175,7 +182,7 @@ function mergeIntoBuffer(
         for (const ch of channelsForKey) channels.add(ch);
       }
     }
-    channels.add(channel);
+    channels.add(channel ?? UnscopedChannel);
     buffer.set(value, channels);
     return;
   }
@@ -183,7 +190,7 @@ function mergeIntoBuffer(
   if (existing instanceof Set) {
     // already a wildcard: specific keys can never downgrade it back to a
     // Map, but this touch's channel still needs to be folded in.
-    existing.add(channel);
+    existing.add(channel ?? UnscopedChannel);
     return;
   }
 
@@ -199,7 +206,7 @@ function mergeIntoBuffer(
       channels = new Set();
       map.set(k, channels);
     }
-    channels.add(channel);
+    channels.add(channel ?? UnscopedChannel);
   }
 }
 
@@ -212,7 +219,7 @@ function mergeIntoBuffer(
  * touch-set exclusively tagged with the *other* channel is skipped.
  */
 function shouldDeliverToChannel(channels: ChannelSet, subscriberChannel: NotificationChannel): boolean {
-  return channels.has(undefined) || channels.has(subscriberChannel);
+  return channels.has(UnscopedChannel) || channels.has(subscriberChannel);
 }
 
 function count(label: string) {

--- a/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
+++ b/warp-drive-packages/core/src/store/-types/q/cache-capabilities-manager.ts
@@ -136,15 +136,16 @@ export type CacheCapabilitiesManager = {
    * of the attribute or relationship that has been updated.
    *
    * `channel` may be provided for the `'attributes'`/`'relationships'`
-   * namespaces. Tagging a notification `'local'` declares "only local state
-   * changed", letting `'remote'`-scoped subscribers skip it. Notifying
-   * `'remote'` or omitting the channel reaches every subscriber regardless
-   * of its channel. See {@link NotificationChannel}.
+   * namespaces. Tagging a notification `'local'` declares "only the local
+   * (reconciled/editable) view changed"; tagging it `'remote'` declares "only
+   * the remote view changed". Each tag is delivered only to that channel's
+   * subscribers. Omitting the channel reaches every subscriber regardless of
+   * its channel. See {@link NotificationChannel}.
    *
    * | notify ↓ subscribe → | `'local'` | `'remote'` | omitted (= `'local'`) |
    * | -------------------- | --------- | ---------- | --------------------- |
    * | `'local'`            | ✅        | ❌         | ✅                    |
-   * | `'remote'`           | ✅        | ✅         | ✅                    |
+   * | `'remote'`           | ❌        | ✅         | ❌                    |
    * | omitted              | ✅        | ✅         | ✅                    |
    *
    * @public

--- a/warp-drive-packages/core/src/types/-private.ts
+++ b/warp-drive-packages/core/src/types/-private.ts
@@ -86,6 +86,8 @@ type GlobalKey =
   // @warp-drive/core/types/request
   | 'IS_FUTURE'
   | 'DOC'
+  // @warp-drive/core NotificationManager
+  | 'UnscopedChannel'
   // @warp-drive/core/reactive
   | 'ManagedArrayMap'
   | 'ManagedObjectMap'


### PR DESCRIPTION
## Description

Fixes #10494: a materialized `linksMode` hasMany went stale after repeated remote updates because the second update's diff compared against a `localState` snapshot that remote-only readers never refresh, so `diff.changed` came out `false` and no notification fired.

### The Problem

A `CollectionEdge`'s `localState` snapshot is only ever refreshed by `computeLocalState`, which only runs on the *local*-state read path. A readonly (non-editable) `linksMode` ManyArray renders and re-syncs from *remote* state, so after the first remote update the snapshot stays permanently stale — and the notification gate (`diff.changed`) trusted that snapshot as "what the app currently shows". A later remote change that happened to match the stale snapshot was judged to be no change, and the rendered array never updated.

### The Solution

Rather than making reads refresh the snapshot (the first iteration of this PR), notification correctness no longer depends on `localState` freshness for remote readers at all. With dual-channel notifications, each copy of a record subscribes to the channel of the projection it renders and re-pulls that projection when notified:

- The delivery matrix is now symmetric: a notify tagged `'remote'` is delivered only to `'remote'` subscribers, `'local'` only to `'local'`/default subscribers, and an unscoped notify still reaches everyone (pre-channel compatibility).
- `replaceRelatedRecordsRemote` notifies per projection: `'remote'` when `diff.remoteOrderChanged` (remote membership/order actually changed), `'local'` when `diff.changed` (the reconciled local view changed). When both change, the graph's flush queue — which now tracks the channel per edge — coalesces them into a single unscoped notification.
- A remote push that merely confirms a committed local mutation now notifies exactly the remote channel: the readonly projection genuinely changed (the commit landed) while the local view did not.
- `getHasManyField`'s readonly path now reads remote state, mirroring `getBelongsToField` and `ManyArrayManager._syncArray`, so the readonly `linksMode` hasMany renders, refreshes, and is notified about the same projection.
- Remote add/remove operations, which change both projections, notify unscoped instead of relying on the old "`'remote'` reaches every subscriber" behavior.

### Changes

- **core/graph**: per-channel notification gates in `replaceRelatedRecordsRemote`; channel-aware flush queue in `Graph`; unscoped notifies for remote add/remove ops
- **core/store**: symmetric channel delivery in `NotificationManager` (docs/matrices updated here and in `CacheCapabilitiesManager`)
- **core/reactive**: readonly hasMany initial read pulls remote state; subscription-channel comment updated
- **tests/json-api**: `todo` → `test` for "update hasMany with repeated patch" (now passes); channel-matrix tests updated to the symmetric contract
- **tests/ember-data__graph**: diff-preservation tests now expect exactly one remote-channel notification when a push confirms a committed mutation (still zero for the local view)
- **unpublished-test-infra**: `watchNotifications` no longer drops the `channel` argument when forwarding to the real `notify`

### Test Plan

All green locally on Node 26.8.1: `tests/json-api` (92 pass / 0 fail, including the previously-failing repeated-patch test), `tests/ember-data__graph` (143/143), `tests/legacy` (132 / 0), main-test-app (5344 / 0), `tests/core` (202 / 0), plus lint, format, and type checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4uRTAvfmeoeZVNjcqJ9os