### PR TITLE
fix(ci): add missing v prefix to turborepo-gh-artifacts pin comment

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -136,7 +136,7 @@ runs:
 
     - name: 'Setup local TurboRepo server'
       if: ${{ inputs.repo-token }}
-      uses: felixmosh/turborepo-gh-artifacts@118f869397261f74bc39cb8565f2d02c0ed4209f # 4.1.1
+      uses: felixmosh/turborepo-gh-artifacts@118f869397261f74bc39cb8565f2d02c0ed4209f # v4.1.1
       with:
         repo-token: ${{ inputs.repo-token }}
 


### PR DESCRIPTION
## Summary

Renovate reported: `Failed to look up the following dependencies: Could not determine new digest for update (github-tags package felixmosh/turborepo-gh-artifacts)`.

`.github/actions/setup/action.yml` pins this action by SHA with a version comment for Renovate's `github-tags` digest lookup:

```
uses: felixmosh/turborepo-gh-artifacts@118f869397261f74bc39cb8565f2d02c0ed4209f # 4.1.1
```

Unlike every other SHA-pinned action in this file (`# v2.1.0`, `# v6.1.0`), the comment was missing the `v` prefix, while the actual upstream tag is `v4.1.1`. That mismatch is what broke Renovate's tag lookup for this dependency.

## Fix

Add the `v` prefix so the comment matches the real tag name, consistent with the other pins in the file:

```
uses: felixmosh/turborepo-gh-artifacts@118f869397261f74bc39cb8565f2d02c0ed4209f # v4.1.1
```

Verified `118f869397261f74bc39cb8565f2d02c0ed4209f` is in fact the commit `v4.1.1` resolves to upstream (`git ls-remote --tags`), so the pin itself is unchanged — this is purely a comment fix.

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALXNLsjPeBU3EAreTtWiqV

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALXNLsjPeBU3EAreTtWiqV)_