### PR TITLE
fix: preserve cache policy type in `useRecommendedStore`

### DIFF
--- a/warp-drive-packages/core/src/index.ts
+++ b/warp-drive-packages/core/src/index.ts
@@ -145,7 +145,9 @@ export declare class ConfiguredStore<
      */
     cache: Cache;
   },
+  Policy extends CachePolicy = CachePolicy,
 > extends Store {
+  lifetimes: Policy;
   // get cache(): T extends OptionsWithCache<infer R> ? R : never;
   createCache(capabilities: CacheCapabilitiesManager): T['cache'];
 }
@@ -257,6 +259,18 @@ export declare class ConfiguredStore<
  * explicitly, so a handler relying on it should treat it as optional (as
  * `LoggingHandler` does above).
  */
+export function useRecommendedStore<T extends Cache, Policy extends CachePolicy>(
+  options: StoreSetupOptions<T> & { policy: Policy },
+  StoreKlass?: typeof Store
+): typeof ConfiguredStore<{ cache: T }, Policy>;
+export function useRecommendedStore<T extends Cache>(
+  options: StoreSetupOptions<T> & { policy?: undefined },
+  StoreKlass?: typeof Store
+): typeof ConfiguredStore<{ cache: T }, DefaultCachePolicy>;
+export function useRecommendedStore<T extends Cache>(
+  options: StoreSetupOptions<T>,
+  StoreKlass?: typeof Store
+): typeof ConfiguredStore<{ cache: T }>;
 export function useRecommendedStore<T extends Cache>(
   options: StoreSetupOptions<T>,
   StoreKlass: typeof Store = Store

--- a/warp-drive-packages/core/src/store/-private/use-recommended-store.type-test.ts
+++ b/warp-drive-packages/core/src/store/-private/use-recommended-store.type-test.ts
@@ -1,11 +1,24 @@
 import { expectTypeOf } from 'expect-type';
 
-import { useRecommendedStore } from '../../index.ts';
+import { type CachePolicy, type StoreSetupOptions, useRecommendedStore } from '../../index.ts';
 import type { DefaultCachePolicy } from '../../store.ts';
 import type { CacheCapabilitiesManager } from '../../types.ts';
 import type { Cache } from '../../types/cache.ts';
 
 declare const TestCache: new (capabilities: CacheCapabilitiesManager) => Cache;
+declare const StoreOptions: StoreSetupOptions;
+
+class CustomCachePolicy implements CachePolicy {
+  readonly custom = true;
+
+  isHardExpired(): boolean {
+    return false;
+  }
+
+  isSoftExpired(): boolean {
+    return false;
+  }
+}
 
 //////////////////////////////////
 //////////////////////////////////
@@ -20,4 +33,33 @@ declare const TestCache: new (capabilities: CacheCapabilitiesManager) => Cache;
   type Store = InstanceType<typeof Store>;
 
   expectTypeOf<Store['lifetimes']>().toEqualTypeOf<DefaultCachePolicy>();
+}
+
+//////////////////////////////////
+//////////////////////////////////
+// useRecommendedStore with a custom cache policy
+//////////////////////////////////
+//////////////////////////////////
+{
+  const Store = useRecommendedStore({
+    cache: TestCache,
+    policy: new CustomCachePolicy(),
+  });
+
+  type Store = InstanceType<typeof Store>;
+
+  expectTypeOf<Store['lifetimes']>().toEqualTypeOf<CustomCachePolicy>();
+}
+
+//////////////////////////////////
+//////////////////////////////////
+// useRecommendedStore with widened options
+//////////////////////////////////
+//////////////////////////////////
+{
+  const Store = useRecommendedStore(StoreOptions);
+
+  type Store = InstanceType<typeof Store>;
+
+  expectTypeOf<Store['lifetimes']>().toEqualTypeOf<CachePolicy>();
 }

--- a/warp-drive-packages/core/src/store/-private/use-recommended-store.type-test.ts
+++ b/warp-drive-packages/core/src/store/-private/use-recommended-store.type-test.ts
@@ -1,0 +1,23 @@
+import { expectTypeOf } from 'expect-type';
+
+import { useRecommendedStore } from '../../index.ts';
+import type { DefaultCachePolicy } from '../../store.ts';
+import type { CacheCapabilitiesManager } from '../../types.ts';
+import type { Cache } from '../../types/cache.ts';
+
+declare const TestCache: new (capabilities: CacheCapabilitiesManager) => Cache;
+
+//////////////////////////////////
+//////////////////////////////////
+// useRecommendedStore
+//////////////////////////////////
+//////////////////////////////////
+{
+  const Store = useRecommendedStore({
+    cache: TestCache,
+  });
+
+  type Store = InstanceType<typeof Store>;
+
+  expectTypeOf<Store['lifetimes']>().toEqualTypeOf<DefaultCachePolicy>();
+}


### PR DESCRIPTION
## Summary

Preserves the cache policy type exposed by stores created with `useRecommendedStore`.

When `policy` is omitted, `lifetimes` is now typed as `DefaultCachePolicy`, matching the policy installed at runtime. When a concrete custom policy is provided, its type is preserved. Calls using already-widened `StoreSetupOptions` continue to expose the conservative `CachePolicy` type.

The runtime behavior of `useRecommendedStore` is unchanged.

## Coverage

- verifies that the default `lifetimes` type is `DefaultCachePolicy`;
- verifies that a concrete custom cache policy retains its inferred type;
- verifies that widened `StoreSetupOptions` retains the `CachePolicy` contract;
- keeps existing `ConfiguredStore<{ cache: T }>` usages source-compatible by defaulting its policy generic to `CachePolicy`.