### PR TITLE
fix(release): repair chalk→styleText casts, drop turbo cache in release workflow

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -101,7 +101,7 @@ runs:
     # restore-key so every run still starts from the most recently saved
     # state regardless of which prior run wrote it.
     - name: 'Restore Turbo Remote-Cache Proxy Disk Cache'
-      if: ${{ inputs.repo-token }}
+      if: ${{ inputs.repo-token && inputs.DISABLE_TURBO_CACHE != 'true' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/turbo-cache
@@ -135,7 +135,7 @@ runs:
           turbo-local-cache-
 
     - name: 'Setup local TurboRepo server'
-      if: ${{ inputs.repo-token }}
+      if: ${{ inputs.repo-token && inputs.DISABLE_TURBO_CACHE != 'true' }}
       uses: felixmosh/turborepo-gh-artifacts@118f869397261f74bc39cb8565f2d02c0ed4209f # v4.1.1
       with:
         repo-token: ${{ inputs.repo-token }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -125,7 +125,7 @@ runs:
     # start by restoring *some* same-commit save -- typically install's,
     # since it finishes first -- before adding its own entries on top.
     - name: 'Restore Turbo Local Build Cache'
-      if: ${{ inputs.install == 'true' }}
+      if: ${{ inputs.install == 'true' && inputs.DISABLE_TURBO_CACHE != 'true' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo/cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install: true
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_TURBO_CACHE: true
       - name: Make sure git user is setup
         run: |
           git config --local user.email ${{ secrets.GH_DEPLOY_EMAIL }}
@@ -217,7 +217,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install: true
-          repo-token: ${{ secrets.GH_DEPLOY_TOKEN }}
+          DISABLE_TURBO_CACHE: true
       - name: Get most recent beta version
         id: version
         if: github.event.inputs.beta_kind == 'mirror'
@@ -288,7 +288,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install: true
-          repo-token: ${{ secrets.GH_DEPLOY_TOKEN }}
+          DISABLE_TURBO_CACHE: true
       - name: Publish New Release
         # If we are not reversioning
         # Then we do the default patch increment from the current branch state.
@@ -392,7 +392,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install: true
-          repo-token: ${{ secrets.GH_DEPLOY_TOKEN }}
+          DISABLE_TURBO_CACHE: true
       - name: Publish New LTS Release
         # We always increment from the branch state
         run: bun release publish ${{ github.event.inputs.channel }} --publish=${{ github.event.inputs.skipPublish != 'true' }} --dry-run=${{ github.event.inputs.dryRun }}
@@ -428,7 +428,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install: true
-          repo-token: ${{ secrets.GH_DEPLOY_TOKEN }}
+          DISABLE_TURBO_CACHE: true
       - name: Make sure git user is setup
         run: |
           git config --local user.email ${{ secrets.GH_DEPLOY_EMAIL }}

--- a/tools/release/core/promote/index.ts
+++ b/tools/release/core/promote/index.ts
@@ -96,7 +96,7 @@ export async function updateTags(
     `✅ ` +
       styleText(
         'cyan',
-        `Moved ${styleText('greenBright', packages.size)} 📦 packages to ${styleText('magenta', distTag)} channel`
+        `Moved ${styleText('greenBright', String(packages.size))} 📦 packages to ${styleText('magenta', distTag)} channel`
       )
   );
 }

--- a/tools/release/core/publish/steps/bump-versions.ts
+++ b/tools/release/core/publish/steps/bump-versions.ts
@@ -82,7 +82,7 @@ export async function updateWorkspaceVersionsForPublish(
       await pkg.file.write();
     } else {
       console.log(
-        styleText('grey', `\tNo workspace:* dependencies to update for ${styleText('cyan', pkg.pkgData.name)}`)
+        styleText('gray', `\tNo workspace:* dependencies to update for ${styleText('cyan', pkg.pkgData.name)}`)
       );
     }
   }
@@ -135,5 +135,5 @@ export async function restorePackagesForDryRun(
   //   await pkg.file.write();
   // }
 
-  console.log(`\t♻️ ` + styleText('grey', `Successfully Restored Versions for DryRun`));
+  console.log(`\t♻️ ` + styleText('gray', `Successfully Restored Versions for DryRun`));
 }

--- a/tools/release/core/publish/steps/generate-tarballs.ts
+++ b/tools/release/core/publish/steps/generate-tarballs.ts
@@ -63,12 +63,12 @@ export async function verifyTarballs(
     const mirrorTarballExists = mirrorTarballPath ? fs.existsSync(mirrorTarballPath) : false;
 
     if (tarballExists) {
-      results.push(styleText('grey', `\t✅ Tarball exists for package ${styleText('green', pkg.pkgData.name)}`));
+      results.push(styleText('gray', `\t✅ Tarball exists for package ${styleText('green', pkg.pkgData.name)}`));
       const missingBinFiles = findMissingBinFiles(tarballPath);
       if (missingBinFiles.length > 0) {
         results.push(
           styleText(
-            'grey',
+            'gray',
             `\t❌ Bin entries of ${styleText('red', pkg.pkgData.name)} point at files missing from its tarball: ${missingBinFiles.join(', ')}`
           )
         );
@@ -77,7 +77,7 @@ export async function verifyTarballs(
     } else {
       results.push(
         styleText(
-          'grey',
+          'gray',
           `\t❌ Tarball ${tarballPath} does not exist for package ${styleText('red', pkg.pkgData.name)}`
         )
       );
@@ -86,14 +86,14 @@ export async function verifyTarballs(
 
     if (!typesTarballPath) {
       results.push(
-        styleText('grey', `\t✖️ Types tarball path is missing for package ${styleText('yellow', pkg.pkgData.name)}`)
+        styleText('gray', `\t✖️ Types tarball path is missing for package ${styleText('yellow', pkg.pkgData.name)}`)
       );
     } else if (typesTarballExists) {
-      results.push(styleText('grey', `\t✅ Types tarball exists for package ${styleText('green', pkg.pkgData.name)}`));
+      results.push(styleText('gray', `\t✅ Types tarball exists for package ${styleText('green', pkg.pkgData.name)}`));
     } else {
       results.push(
         styleText(
-          'grey',
+          'gray',
           `\t❌ Types tarball ${typesTarballPath} does not exist for package ${styleText('red', pkg.pkgData.name)}`
         )
       );
@@ -102,14 +102,14 @@ export async function verifyTarballs(
 
     if (!mirrorTarballPath) {
       results.push(
-        styleText('grey', `\t✖️ Mirror tarball path is missing for package ${styleText('yellow', pkg.pkgData.name)}`)
+        styleText('gray', `\t✖️ Mirror tarball path is missing for package ${styleText('yellow', pkg.pkgData.name)}`)
       );
     } else if (mirrorTarballExists) {
-      results.push(styleText('grey', `\t✅ Mirror tarball exists for package ${styleText('green', pkg.pkgData.name)}`));
+      results.push(styleText('gray', `\t✅ Mirror tarball exists for package ${styleText('green', pkg.pkgData.name)}`));
     } else {
       results.push(
         styleText(
-          'grey',
+          'gray',
           `\t❌ Mirror tarball ${mirrorTarballPath} does not exist for package ${styleText('red', pkg.pkgData.name)}`
         )
       );
@@ -677,7 +677,7 @@ async function restoreTypesStrategyChanges(pkg: Package, _strategy: APPLIED_STRA
   process.stdout.write(
     `\t\t♻️ ` +
       styleText(
-        'grey',
+        'gray',
         `Successfully Restored Assets Modified for Types Strategy During Publish in ${styleText('cyan', pkg.pkgData.name)}\n`
       )
   );

--- a/tools/release/core/publish/steps/print-strategy.ts
+++ b/tools/release/core/publish/steps/print-strategy.ts
@@ -13,7 +13,7 @@ export const COLORS_BY_STRATEGY: Record<TYPE_STRATEGY, 'red' | 'yellow' | 'green
 
 export function convertToLabel(name: string) {
   if (name === 'N/A') {
-    return styleText('grey', name);
+    return styleText('gray', name);
   }
   return '✅';
 }
@@ -32,7 +32,7 @@ export function colorName(name: string) {
   } else if (name.startsWith('@ember-data/')) {
     return styleText('cyanBright', '@ember-data/') + styleText('yellow', name.substring(12));
   } else if (name === 'N/A') {
-    return styleText('grey', name);
+    return styleText('gray', name);
   }
   return styleText('cyan', name);
 }
@@ -87,13 +87,13 @@ export async function printStrategy(config: Map<string, string | number | boolea
       colorName(name),
       convertToLabel(applied.mirrorPublishTo),
       convertToLabel(applied.typesPublishTo),
-      styleText('grey', applied.fromVersion),
+      styleText('gray', applied.fromVersion),
       styleText(COLORS_BY_STRATEGY[applied.stage], applied.toVersion),
       styleText(COLORS_BY_STRATEGY[applied.stage], applied.stage),
       styleText(COLORS_BY_STRATEGY[applied.types], applied.types),
       styleText('magentaBright', applied.distTag),
       styleText('cyanBright', 'public'),
-      styleText('grey', applied.pkgDir),
+      styleText('gray', applied.pkgDir),
     ]);
   });
   const groups = new Map<string, string[][]>();
@@ -108,13 +108,13 @@ export async function printStrategy(config: Map<string, string | number | boolea
       colorName(name),
       colorName(applied.mirrorPublishTo),
       colorName(applied.typesPublishTo),
-      styleText('grey', applied.fromVersion),
+      styleText('gray', applied.fromVersion),
       styleText(COLORS_BY_STRATEGY[applied.stage], applied.toVersion),
       styleText(COLORS_BY_STRATEGY[applied.stage], applied.stage),
       styleText(COLORS_BY_STRATEGY[applied.types], applied.types),
-      styleText('grey', 'N/A'),
+      styleText('gray', 'N/A'),
       styleText('yellow', 'private'),
-      styleText('grey', applied.pkgDir),
+      styleText('gray', applied.pkgDir),
     ]);
   });
   groups.forEach((group) => {
@@ -124,10 +124,10 @@ export async function printStrategy(config: Map<string, string | number | boolea
 
   printTable(
     styleText(
-      'grey',
-      `${styleText('white', 'Release Strategy')} for ${styleText('cyan', config.get('increment'))} bump in ${styleText(
+      'gray',
+      `${styleText('white', 'Release Strategy')} for ${styleText('cyan', String(config.get('increment')))} bump in ${styleText(
         'cyan',
-        config.get('channel')
+        String(config.get('channel'))
       )} channel`
     ),
     tableRows

--- a/tools/release/core/publish/steps/publish-packages.ts
+++ b/tools/release/core/publish/steps/publish-packages.ts
@@ -157,7 +157,9 @@ export async function publishPackages(
     }
   }
 
-  console.log(`✅ ` + styleText('cyan', `published ${styleText('greenBright', publishCount)} 📦 packages to npm`));
+  console.log(
+    `✅ ` + styleText('cyan', `published ${styleText('greenBright', String(publishCount))} 📦 packages to npm`)
+  );
   if (errors.length > 0) {
     console.log(styleText('red', `🚫 ${errors.length} errors occurred while publishing packages to npm`));
     for (const error of errors) {

--- a/tools/release/core/release-notes/steps/confirm-changelogs.ts
+++ b/tools/release/core/release-notes/steps/confirm-changelogs.ts
@@ -12,7 +12,7 @@ export async function confirmCommitChangelogs(
   const dryRun = config.get('dry_run') as boolean;
 
   if (config.get('commit') === false) {
-    console.log(styleText('grey', `\t➠ Skipped commit of changelogs.`));
+    console.log(styleText('gray', `\t➠ Skipped commit of changelogs.`));
     return;
   }
 
@@ -34,9 +34,9 @@ export async function confirmCommitChangelogs(
 
     if (config.get('upstream')) {
       await exec(['sh', '-c', `git push`]);
-      console.log(styleText('grey', `\t✅ pushed changelog commit to upstream.`));
+      console.log(styleText('gray', `\t✅ pushed changelog commit to upstream.`));
     } else {
-      console.log(styleText('grey', `\t➠ Skipped push of changelogs.`));
+      console.log(styleText('gray', `\t➠ Skipped push of changelogs.`));
     }
   }
 }

--- a/tools/release/help/-utils.ts
+++ b/tools/release/help/-utils.ts
@@ -1,4 +1,4 @@
-import { styleText } from 'node:util';
+import { styleText, type InspectColor } from 'node:util';
 
 export function getCharLength(str: string | undefined): number {
   if (!str) {
@@ -89,7 +89,7 @@ export function getNumTabs(str: string) {
 /**
  * colorizes a string based on color<<>> syntax
  * where color is one of the following:
- * - gr (grey)
+ * - gr (gray)
  * - bg (brightGreen)
  * - bm (brightMagenta)
  * - cy (cyan)
@@ -100,8 +100,8 @@ export function getNumTabs(str: string) {
  * color`This is gr<<grey>> and this is bg<<bright green>> and this is bm<<bright magenta>> and this is cy<<cyan>> and this is ye<<yellow>>`
  */
 export function color(str: string) {
-  const colors = {
-    gr: 'grey',
+  const colors: Record<string, InspectColor> = {
+    gr: 'gray',
     gb: 'greenBright',
     mb: 'magentaBright',
     cy: 'cyan',
@@ -138,12 +138,12 @@ export function rebalanceLines(str: string, max_length = 75): string {
       continue;
     }
     if (line.trim() === '---') {
-      lines[i] = styleText('grey', getPadding(max_length, '-'));
+      lines[i] = styleText('gray', getPadding(max_length, '-'));
       inContext = false;
       continue;
     }
     if (line.trim() === '===') {
-      lines[i] = styleText('grey', getPadding(max_length, '='));
+      lines[i] = styleText('gray', getPadding(max_length, '='));
       inContext = false;
       continue;
     }

--- a/tools/release/help/docs.ts
+++ b/tools/release/help/docs.ts
@@ -20,7 +20,7 @@ function getDefaultValueDescriptor(value: unknown) {
       return styleText('cyan', `Function`);
     }
   } else {
-    return styleText('grey', 'N/A');
+    return styleText('gray', 'N/A');
   }
 }
 
@@ -29,15 +29,15 @@ function buildOptionDoc(flag: Flag, index: number): string {
   const flag_shape =
     styleText('magentaBright', flag.positional ? `<${flag.flag}>` : `--${flag.flag}`) +
     (flag.required ? styleText('yellow', styleText('italic', ` required`)) : '');
-  const flag_aliases_str = styleText('grey', flag_aliases?.join(', ') || 'N/A');
-  const flag_mispellings_str = styleText('grey', flag_mispellings?.join(', ') || 'N/A');
+  const flag_aliases_str = styleText('gray', flag_aliases?.join(', ') || 'N/A');
+  const flag_mispellings_str = styleText('gray', flag_mispellings?.join(', ') || 'N/A');
 
   return `${flag_shape} ${styleText('greenBright', flag.name)}
   ${indent(description, 1)}
   ${styleText('yellow', 'default')}: ${getDefaultValueDescriptor(flag.default_value)}
   ${styleText('yellow', 'aliases')}: ${flag_aliases_str}
   ${styleText('yellow', 'alt')}: ${flag_mispellings_str}
-  ${styleText('grey', 'Examples')}:
+  ${styleText('gray', 'Examples')}:
   ${examples
     .map((example) => {
       if (typeof example === 'string') {

--- a/tools/release/index.ts
+++ b/tools/release/index.ts
@@ -56,12 +56,12 @@ async function main() {
   if (cmdString !== 'latest_for') {
     write(
       styleText(
-        'grey',
+        'gray',
         `\n\t${styleText(
           'bold',
           styleText('greenBright', 'Warp') + styleText('magentaBright', 'Drive')
         )} | Automated Release\n\t==============================`
-      ) + styleText('grey', `\n\tengine: ${styleText('cyan', 'bun@' + Bun.version)}\n`)
+      ) + styleText('gray', `\n\tengine: ${styleText('cyan', 'bun@' + Bun.version)}\n`)
     );
   }
 

--- a/tools/release/utils/cmd.ts
+++ b/tools/release/utils/cmd.ts
@@ -113,7 +113,7 @@ class CLICondenser {
       await rd.commit();
     }
     process.stdout.write(
-      `\t☑️\t${styleText('grey', cmd)} in ${styleText('greenBright', path.relative(process.cwd(), this.cwd) || '<root>')}\n`
+      `\t☑️\t${styleText('gray', cmd)} in ${styleText('greenBright', path.relative(process.cwd(), this.cwd) || '<root>')}\n`
     );
 
     return output;
@@ -138,12 +138,12 @@ export async function exec(cmd: string[] | string | CMD, dryRun: boolean = false
 
   if (dryRun) {
     console.log(
-      `\t` + styleText('grey', `Would Run: ${Array.isArray(mainCommand) ? mainCommand.join(' ') : mainCommand}`)
+      `\t` + styleText('gray', `Would Run: ${Array.isArray(mainCommand) ? mainCommand.join(' ') : mainCommand}`)
     );
   } else if (!isCmdWithConfig || (!cmd.condense && !cmd.silent)) {
     console.log(
       `\t` +
-        styleText('grey', `Running: ${args.join(' ')} in ${styleText('green', path.relative(process.cwd(), cwd))}\t...`)
+        styleText('gray', `Running: ${args.join(' ')} in ${styleText('green', path.relative(process.cwd(), cwd))}\t...`)
     );
   }
 

--- a/tools/release/utils/git.ts
+++ b/tools/release/utils/git.ts
@@ -73,7 +73,7 @@ export async function getGitState(options: Map<string, boolean | string | number
           ? base +
               styleText('yellow', '\n\t\tPassed option: ') +
               styleText('white', '--dangerously-force') +
-              styleText('grey', ' :: ignoring unclean git working tree')
+              styleText('gray', ' :: ignoring unclean git working tree')
           : base
       );
       if (!isHelp) {
@@ -83,11 +83,11 @@ export async function getGitState(options: Map<string, boolean | string | number
     } else {
       console.log(
         styleText('red', '💥 Git working tree is not clean. 💥 \n\t') +
-          styleText('grey', 'Use ') +
+          styleText('gray', 'Use ') +
           styleText('white', '--dangerously-force') +
-          styleText('grey', ' to ignore this warning and publish anyway\n') +
+          styleText('gray', ' to ignore this warning and publish anyway\n') +
           styleText('yellow', '⚠️  Publishing from an unclean working state may result in a broken release ⚠️\n\n') +
-          styleText('grey', `Status:\n${status}`)
+          styleText('gray', `Status:\n${status}`)
       );
       process.exit(1);
     }
@@ -101,17 +101,17 @@ export async function getGitState(options: Map<string, boolean | string | number
             ? base +
                 styleText('yellow', '\n\t\tPassed option: ') +
                 styleText('white', '--dangerously-force') +
-                styleText('grey', ' :: ignoring unsynced git branch')
+                styleText('gray', ' :: ignoring unsynced git branch')
             : base
         );
       } else {
         console.log(
           styleText('red', '💥 Local Git branch is not in sync with origin branch. 💥 \n\t') +
-            styleText('grey', 'Use ') +
+            styleText('gray', 'Use ') +
             styleText('white', '--dangerously-force') +
-            styleText('grey', ' to ignore this warning and publish anyway\n') +
+            styleText('gray', ' to ignore this warning and publish anyway\n') +
             styleText('yellow', '⚠️  Publishing from an unsynced working state may result in a broken release ⚠️') +
-            styleText('grey', `Status:\n${status}`)
+            styleText('gray', `Status:\n${status}`)
         );
         process.exit(1);
       }
@@ -137,7 +137,7 @@ export async function getGitState(options: Map<string, boolean | string | number
           ? base +
               styleText('yellow', '\n\t\tPassed option: ') +
               styleText('white', '--dangerously-force') +
-              styleText('grey', ' :: ignoring unexpected branch')
+              styleText('gray', ' :: ignoring unexpected branch')
           : base
       );
     } else {
@@ -146,9 +146,9 @@ export async function getGitState(options: Map<string, boolean | string | number
           'red',
           `💥 Expected to publish the release-channel '${channel}' from the git branch '${expectedBranch}', but found '${foundBranch}' 💥 \n\t`
         ) +
-          styleText('grey', 'Use ') +
+          styleText('gray', 'Use ') +
           styleText('white', '--dangerously-force') +
-          styleText('grey', ' to ignore this warning and publish anyway\n') +
+          styleText('gray', ' to ignore this warning and publish anyway\n') +
           styleText('yellow', '⚠️  Publishing from an incorrect branch may result in a broken release ⚠️')
       );
       process.exit(1);


### PR DESCRIPTION
## Summary

This fixes the crash seen in the [canary publish job](https://github.com/warp-drive-data/warp-drive/actions/runs/33924747529/job/101190695036#step:8:17803), plus removes wasted turbo-cache overhead from the release workflow:

- **`publishPackages()` crashed after any publish failure.** It passed a `number` (`publishCount`) straight to `styleText()`. Node's `util.styleText` throws a `TypeError` on non-string input (unlike `chalk`, which stringified freely), so the crash happened right after logging the real error — a `npm publish` `ENEEDAUTH` in the log above — masking it behind a confusing secondary stack trace.
- **The same chalk→styleText migration left `'grey'`** (a chalk-only alias) used throughout `tools/release`. `styleText` only accepts the American spelling `'gray'` as a valid `InspectColor`, so every one of those calls was also broken. Fixed all instances `tsc` could find in `tools/release` (45 occurrences across 10 files), plus two more un-stringified values passed as colorized text (`core/promote/index.ts`, `core/publish/steps/print-strategy.ts`).
- **Dropped turbo's build-cache restore/save and the felixmosh remote-cache proxy setup** from every job in `release.yml`. These jobs now pass `DISABLE_TURBO_CACHE: true` to `./.github/actions/setup`, which forces a fresh build (`TURBO_FORCE`) and skips downloading/uploading cache artifacts — since the build is always forced here, that cache traffic was pure overhead.

## Test plan

- [x] `tsc --noEmit` on `tools/release` — down from 53 pre-existing errors to 4 unrelated ones (a `Response.text()` type conflict, pre-existing and out of scope for this PR)
- [x] `oxfmt` run on all touched files
- [x] YAML validated for both edited workflow/action files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7)_