### PR TITLE
fix(release): publish via pnpm's native publish, OIDC-only

### DIFF
--- a/guides/contributing/RELEASE.md
+++ b/guides/contributing/RELEASE.md
@@ -21,25 +21,20 @@ all recent planning discussions and work is properly accounted for.
 
 ## Getting Setup To Do A Release
 
-In order to release WarpDrive you must have commit rights to `warp-drive-data/warp-drive` on GITHUB.
-Everything else is handled by automation.
+In order to release WarpDrive you must have commit rights to `warp-drive-data/warp-drive` on
+GitHub, along with permission to trigger the `0. Release` workflow. Everything else is handled
+by automation.
 
-In the event you do need to perform a manual release, you must also have permission
-to push to protected branches, and access tokens for npm and github with permissions
-to the related package scopes. For more information about manual releases run 
-`bun release about` in the repository.
+Publishing to npm requires npm's [Trusted Publishing](https://docs.npmjs.com/trusted-publishers/)
+(OIDC), which is only available from within that GitHub Actions workflow -- there is no manual
+or local publish path, and no npm account, access token, or 2FA setup is needed to perform a
+release. For more information run `bun release about` in the repository.
 
-For manual releases, you will need to ensure at least the following:
+If you want to run a release step locally for review (e.g. a `--dry-run`, or generating a
+release strategy) rather than actually publishing, you will additionally need:
 
-- You have `commit` rights to `ember-data` on GitHub
-- You have an account on `npm` and it belongs to the `ember-data` and `warp-drive` organizations on NPM
-- You have `publish` rights within the `ember-data` and `warp-drive` organizations on NPM
-- You have configured your NPM account to use `2fa` (two factor authentication)
-- You have logged into your NPM account on your machine (typically sessions preserve nearly forever once you have)
-- You have configured `GITHUB_AUTH` token for `lerna-changelog` to be able to gather info for the release notes.
-- You have installed `bun`, `pnpm` and `node` globally (or better, via `mise`)
-- the remote `origin` is `git@github.com:warp-drive-data/warp-drive.git`,
--`origin/main` `origin/beta` `origin/release` etc. need to be the upstreams of the local `main` `beta` `release` branches etc.
+- `bun`, `pnpm` and `node` installed globally (or better, via `mise`)
+- A `GITHUB_AUTH` token configured for `lerna-changelog`, to gather info for the release notes
 
 ## Release Order
 

--- a/tools/release/core/promote/index.ts
+++ b/tools/release/core/promote/index.ts
@@ -7,9 +7,7 @@ import { promote_flags_config } from '../../utils/flags-config.ts';
 import { GIT_TAG, getAllPackagesForGitTag, getGitState, pushLTSTagToRemoteBranch } from '../../utils/git.ts';
 import { Package } from '../../utils/package.ts';
 import { parseRawFlags } from '../../utils/parse-args.ts';
-import { question } from '../publish/steps/confirm-strategy.ts';
 import { colorName } from '../publish/steps/print-strategy.ts';
-import { RETRY_TRUSTED_PUBLISHING } from '../publish/steps/publish-packages.ts';
 
 export async function promoteToLTS(args: string[]) {
   // get user supplied config
@@ -50,40 +48,16 @@ export async function updateTags(
   packages: Map<string, SEMVER_VERSION>
 ) {
   const distTag = config.get('tag') as string;
-  const NODE_AUTH_TOKEN = process.env.NODE_AUTH_TOKEN;
-  const CI = process.env.CI;
-  let token: string | undefined;
-
-  // allow OTP token usage locally
-  if (!CI) {
-    if (!NODE_AUTH_TOKEN) {
-      console.log(
-        styleText(
-          'red',
-          '🚫 NODE_AUTH_TOKEN not found in ENV. NODE_AUTH_TOKEN is required in ENV to publish from CI. Exiting...'
-        )
-      );
-      process.exit(1);
-    }
-
-    const result = await question(
-      `\n${styleText('cyan', 'NODE_AUTH_TOKEN')} found in ENV.\nPublish ${config.get('increment')} release in ${config.get(
-        'channel'
-      )} channel to the ${config.get('tag')} tag on the npm registry? ${styleText('yellow', '[y/n]')}:`
-    );
-    const input = result.trim().toLowerCase();
-    if (input !== 'y' && input !== 'yes') {
-      console.log(styleText('red', '🚫 Publishing not confirmed. Exiting...'));
-      process.exit(1);
-    }
-
-    token = await getOTPToken(distTag);
-  }
-
   const dryRun = config.get('dry_run') as boolean;
-  let error: Error | null = null;
+  const errors: Error[] = [];
+
   for (const [pkgName, version] of packages) {
-    [token, error] = await updateDistTag(pkgName, version, distTag, dryRun, token);
+    const error = await updateDistTag(pkgName, version, distTag, dryRun);
+    if (error) {
+      console.log(styleText('red', `\t🚫 Error updating dist-tag for ${colorName(pkgName)}: ${error.message}`));
+      errors.push(error);
+      continue;
+    }
     console.log(
       styleText(
         'green',
@@ -96,22 +70,16 @@ export async function updateTags(
     `✅ ` +
       styleText(
         'cyan',
-        `Moved ${styleText('greenBright', String(packages.size))} 📦 packages to ${styleText('magenta', distTag)} channel`
+        `Moved ${styleText('greenBright', String(packages.size - errors.length))} 📦 packages to ${styleText('magenta', distTag)} channel`
       )
   );
-}
-
-async function getOTPToken(distTag: string, reprompt?: boolean) {
-  const prompt = reprompt
-    ? `The provided OTP token has expired. Please enter a new OTP token: `
-    : `\nℹ️ ${styleText(
-        'cyan',
-        'NODE_AUTH_TOKEN'
-      )} not found in ENV.\n\nConfiguring NODE_AUTH_TOKEN is the preferred mechanism by which to publish. Alternatively you may continue using an OTP token.\n\nUpdating ${distTag} tag on the npm registry.\n\nEnter your OTP token: `;
-
-  let token = await question(prompt);
-
-  return token.trim();
+  if (errors.length > 0) {
+    console.log(styleText('red', `🚫 ${errors.length} errors occurred while updating dist-tags`));
+    for (const error of errors) {
+      console.log(styleText('red', error.message));
+    }
+    throw new Error(`${errors.length} errors occurred while updating dist-tags.`);
+  }
 }
 
 export async function updateDistTag(
@@ -119,32 +87,28 @@ export async function updateDistTag(
   version: string,
   distTag: string,
   dryRun: boolean,
-  otp?: string
-): Promise<[string | undefined, Error | null]> {
-  let cmd = `npm dist-tag add ${pkg}@${version} ${distTag}`;
+  isRetry = false
+): Promise<Error | null> {
+  const cmd = `pnpm dist-tag add ${pkg}@${version} ${distTag}`;
 
-  if (otp && otp !== RETRY_TRUSTED_PUBLISHING) {
-    cmd += ` --otp=${otp}`;
-  }
-
+  // pnpm's dist-tag command has no --dry-run flag, so a dry run skips
+  // executing it entirely rather than passing an unsupported flag through.
   if (dryRun) {
-    cmd += ' --dry-run';
+    console.log(styleText('gray', `\t[dry-run] would run: ${cmd}`));
+    return null;
   }
 
   try {
     await exec({ cmd, condense: true });
   } catch (e) {
     const error = !(e instanceof Error) ? new Error(e as string) : e;
-    if (otp && otp !== RETRY_TRUSTED_PUBLISHING) {
-      if (error.message.includes('E401') || error.message.includes('EOTP')) {
-        otp = await getOTPToken(distTag, true);
-        return updateDistTag(pkg, version, distTag, dryRun, otp);
-      }
-    } else if (!otp) {
-      return updateDistTag(pkg, version, distTag, dryRun, RETRY_TRUSTED_PUBLISHING);
+    // A GitHub Actions OIDC token can go stale between packages in a long
+    // promote loop; one retry is enough to get a fresh one negotiated.
+    if (!isRetry && error.message.includes('E401')) {
+      return updateDistTag(pkg, version, distTag, dryRun, true);
     }
-    return [otp === RETRY_TRUSTED_PUBLISHING ? '' : otp, error];
+    return error;
   }
 
-  return [otp === RETRY_TRUSTED_PUBLISHING ? '' : otp, null];
+  return null;
 }

--- a/tools/release/core/publish/steps/publish-packages.ts
+++ b/tools/release/core/publish/steps/publish-packages.ts
@@ -2,7 +2,6 @@ import { styleText } from 'node:util';
 
 import { exec } from '../../../utils/cmd.ts';
 import { APPLIED_STRATEGY, Package } from '../../../utils/package.ts';
-import { question } from './confirm-strategy.ts';
 // import { updateDistTag } from '../../promote';
 
 export async function publishPackages(
@@ -10,46 +9,12 @@ export async function publishPackages(
   packages: Map<string, Package>,
   strategy: Map<string, APPLIED_STRATEGY>
 ) {
-  const NODE_AUTH_TOKEN = process.env.NODE_AUTH_TOKEN;
-  const CI = process.env.CI;
-  let token: string | undefined;
-
-  // allow OTP token usage locally
-  if (!CI) {
-    if (!NODE_AUTH_TOKEN) {
-      console.log(
-        styleText(
-          'red',
-          '🚫 NODE_AUTH_TOKEN not found in ENV. NODE_AUTH_TOKEN is required in ENV to publish from CI. Exiting...'
-        )
-      );
-      process.exit(1);
-    }
-    const result = await question(
-      `\n${styleText('cyan', 'NODE_AUTH_TOKEN')} found in ENV.\nPublish ${config.get('increment')} release in ${config.get(
-        'channel'
-      )} channel to the ${config.get('tag')} tag on the npm registry? ${styleText('yellow', '[y/n]')}:`
-    );
-    const input = result.trim().toLowerCase();
-    if (input !== 'y' && input !== 'yes') {
-      console.log(styleText('red', '🚫 Publishing not confirmed. Exiting...'));
-      process.exit(1);
-    }
-    token = await getOTPToken(config);
-  }
-
+  const dryRun = config.get('dry_run') as boolean;
   let publishCount = 0;
-  let error: Error | null = null;
   const errors: Error[] = [];
   for (const [, strat] of strategy) {
     const pkg = packages.get(strat.name)!;
-    [token, error] = await publishPackage(
-      config,
-      strat.distTag,
-      pkg.tarballPath,
-      config.get('dry_run') as boolean,
-      token
-    );
+    let error = await publishPackage(strat.distTag, pkg.tarballPath, dryRun);
     if (error) {
       console.log(
         styleText('red', `\t🚫 Error publishing ${styleText('cyan', pkg.pkgData.name)} to npm: ${error.message}`)
@@ -62,29 +27,24 @@ export async function publishPackages(
     // TODO - only do this if its a stable release
     // TODO - moving to OIDC breaks this, bring it back once npm adds the feature
     // if (strat.stage === 'alpha' || strat.stage === 'beta') {
-    //   [token, error] = await updateDistTag(
+    //   error = await updateDistTag(
     //     strat.name,
     //     pkg.pkgData.version,
     //     'latest',
-    //     config.get('dry_run') as boolean,
-    //     token
+    //     config.get('dry_run') as boolean
     //   );
     //   if (error) {
     //     console.log(
-    //       styleText('red', `\t🚫 Error updating dist-tag for ${styleText('cyan', pkg.pkgData.name)} to latest: ${error.message}`)
+    //       styleText('red',
+    //         `\t🚫 Error updating dist-tag for ${styleText('cyan', pkg.pkgData.name)} to latest: ${error.message}`
+    //       )
     //     );
     //     errors.push(error);
     //   }
     // }
 
     if (strat.mirrorPublish) {
-      [token, error] = await publishPackage(
-        config,
-        strat.distTag,
-        pkg.mirrorTarballPath,
-        config.get('dry_run') as boolean,
-        token
-      );
+      error = await publishPackage(strat.distTag, pkg.mirrorTarballPath, dryRun);
       if (error) {
         console.log(
           styleText(
@@ -100,12 +60,11 @@ export async function publishPackages(
       // TODO - only do this if its a stable release
       // TODO - moving to OIDC breaks this, bring it back once npm adds the feature
       // if (strat.stage === 'alpha' || strat.stage === 'beta') {
-      //   [token, error] = await updateDistTag(
+      //   error = await updateDistTag(
       //     strat.mirrorPublishTo,
       //     pkg.pkgData.version,
       //     'latest',
-      //     config.get('dry_run') as boolean,
-      //     token
+      //     config.get('dry_run') as boolean
       //   );
       //   if (error) {
       //     console.log(
@@ -118,13 +77,7 @@ export async function publishPackages(
       // }
     }
     if (strat.typesPublish) {
-      [token, error] = await publishPackage(
-        config,
-        strat.distTag,
-        pkg.typesTarballPath,
-        config.get('dry_run') as boolean,
-        token
-      );
+      error = await publishPackage(strat.distTag, pkg.typesTarballPath, dryRun);
       if (error) {
         console.log(
           styleText(
@@ -140,12 +93,11 @@ export async function publishPackages(
       // TODO - only do this if its a stable release
       // TODO - moving to OIDC breaks this, bring it back once npm adds the feature
       // if (strat.stage === 'alpha' || strat.stage === 'beta') {
-      //   [token, error] = await updateDistTag(
+      //   error = await updateDistTag(
       //     strat.typesPublishTo,
       //     pkg.pkgData.version,
       //     'latest',
-      //     config.get('dry_run') as boolean,
-      //     token
+      //     config.get('dry_run') as boolean
       //   );
       //   if (error) {
       //     console.log(
@@ -169,37 +121,13 @@ export async function publishPackages(
   }
 }
 
-export async function getOTPToken(config: Map<string, string | number | boolean | null>, reprompt?: boolean) {
-  const prompt = reprompt
-    ? `The provided OTP token has expired. Please enter a new OTP token: `
-    : `\nℹ️ ${styleText(
-        'cyan',
-        'NODE_AUTH_TOKEN'
-      )} not found in ENV.\n\nConfiguring NODE_AUTH_TOKEN is the preferred mechanism by which to publish. Alternatively you may continue using an OTP token.\n\nPublishing ${config.get(
-        'increment'
-      )} release in ${config.get('channel')} channel to the ${config.get(
-        'tag'
-      )} tag on the npm registry.\n\nEnter your OTP token: `;
-
-  let token = await question(prompt);
-
-  return token.trim();
-}
-
-export const RETRY_TRUSTED_PUBLISHING = 'RETRY DUE TO STALE OIDC TOKEN';
-
 async function publishPackage(
-  config: Map<string, string | number | boolean | null>,
   distTag: string,
   tarball: string,
   dryRun: boolean,
-  otp?: string
-): Promise<[string | undefined, Error | null]> {
-  let cmd = `npm publish ${tarball} --tag=${distTag} --access=public`;
-
-  if (otp && otp !== RETRY_TRUSTED_PUBLISHING) {
-    cmd += ` --otp=${otp}`;
-  }
+  isRetry = false
+): Promise<Error | null> {
+  let cmd = `pnpm publish ${tarball} --tag=${distTag} --access=public --provenance --no-git-checks`;
 
   if (dryRun) {
     cmd += ' --dry-run';
@@ -209,16 +137,13 @@ async function publishPackage(
     await exec({ cmd, condense: true });
   } catch (e: unknown) {
     const error = !(e instanceof Error) ? new Error(e as string) : e;
-    if (otp && otp !== RETRY_TRUSTED_PUBLISHING) {
-      if (error.message.includes('E401') || error.message.includes('EOTP')) {
-        otp = await getOTPToken(config, true);
-        return publishPackage(config, distTag, tarball, dryRun, otp);
-      }
-    } else if (error.message.includes('E401') && process.env.CI && otp !== RETRY_TRUSTED_PUBLISHING) {
-      return publishPackage(config, distTag, tarball, dryRun, RETRY_TRUSTED_PUBLISHING);
+    // A GitHub Actions OIDC token can go stale between packages in a long
+    // publish loop; one retry is enough to get a fresh one negotiated.
+    if (!isRetry && error.message.includes('E401')) {
+      return publishPackage(distTag, tarball, dryRun, true);
     }
-    return [process.env.CI ? undefined : otp, error];
+    return error;
   }
 
-  return [process.env.CI ? undefined : otp, null];
+  return null;
 }

--- a/tools/release/guide/canary.md
+++ b/tools/release/guide/canary.md
@@ -2,7 +2,7 @@
 
 ## Automated Workflow
 
-The [Release > Canary](../../.github/workflows/release_publish-canary.yml) workflow should be used to publish all new canaries from the [Action Overview](https://github.com/warp-drive-data/warp-drive/actions/workflows/release_publish-canary.yml).
+The [0. Release](../../.github/workflows/release.yml) workflow's `canary` job should be used to publish all new canaries, triggered via `workflow_dispatch` (channel: `canary`) from the [Actions tab](https://github.com/warp-drive-data/warp-drive/actions/workflows/release.yml).
 
 This workflow trigger is restricted to project maintainers.
 
@@ -11,16 +11,18 @@ For the first release of a new cycle, manually running this flow with the increm
 Subsequent pre-release versions will be auto-released on a chron schedule.
 
 
-## Manually Canarying
+## Local Dry Runs
 
-Ensure you have bun, node and pnpm configured correctly. mise is preferred for managing
-node and pnpm versions. For bun, any `1.x` version should work but minimum version should
-ideally match the installed `bun-types` dependency `package.json`.
+Publishing itself requires npm's Trusted Publishing (OIDC), which is only available from within
+the GitHub Actions release workflow above -- there is no local/manual publish path.
 
-We always release canary from the `main` branch, though forcing from another branch is possible if required in a last resort.
+You can still preview what a release would do with a local dry run. Ensure you have bun, node
+and pnpm configured correctly (mise is preferred for managing node and pnpm versions; for bun,
+any `1.x` version should work but minimum version should ideally match the installed
+`bun-types` dependency in `package.json`), then run:
 
 ```ts
-bun release publish canary -i <patch|major|minor>
+bun release publish canary -i <patch|major|minor> --dry-run
 ```
 
 Run `bun release help` for additional options.

--- a/tools/release/help/sections/about.ts
+++ b/tools/release/help/sections/about.ts
@@ -25,12 +25,11 @@ This script is used to automate the release process for cy<<WarpDrivea>>.
 
 ye<<##>> Who Can Release?
 
-It is intended that this process is run in CI (ENV cy<<CI=true>>);
-however, it is able to be run manually as well.
-
-For both CI and locally it is expected that ENV contains a cy<<NODE_AUTH_TOKEN>>
-with proper permissions to publish the various packages within the ember-data NPM
-organization.
+Publishing requires npm's cy<<Trusted Publishing>> (OIDC) and is therefore
+only possible from the configured GitHub Actions release workflow (ENV
+cy<<CI=true>>) -- there is no local/manual publish path. Other steps (e.g.
+generating a release strategy, or a cy<<--dry-run>>) can still be run
+manually to review a release before triggering it for real in CI.
 
 Users (or CI) will also need special permission to push to main, beta, lts, lts-*-*
 and release-*-* branches. For CI based triggers, the user triggering MUST have been

--- a/tools/release/utils/flags-config.ts
+++ b/tools/release/utils/flags-config.ts
@@ -498,7 +498,7 @@ export const command_config: CommandConfig = {
     cmd: 'publish',
     default: true,
     description:
-      'Publish a new version of WarpDrive to the specified channel.\nRequires a configured ye<<NODE_AUTH_TOKEN>> with npm access to all associated scopes and packages,\nor the ability to generate an OTP token for the same.',
+      'Publish a new version of WarpDrive to the specified channel.\nRequires npm Trusted Publishing (OIDC) -- only runnable from the configured GitHub Actions release workflow.',
     options: publish_flags_config,
     example: ['$ bun release', '$ bun release publish'],
   },


### PR DESCRIPTION
## Summary

Every scheduled canary (and beta/stable/lts/promote) publish job has been failing with `npm error code ENEEDAUTH` since the pnpm 12 migration ([#11014](https://github.com/warp-drive-data/warp-drive/pull/11014) fixed a masking crash in the failure path, but not the underlying auth failure). Root cause:

- pnpm ≤11 shelled out to `npm publish` under the hood, so npm's OIDC **Trusted Publishing** worked transparently as long as the system `npm` CLI was new enough (≥11.5.1).
- pnpm 12 replaced that with its own **native (Rust) publish implementation** and no longer delegates to `npm` at all — so whichever `npm` happens to be on `PATH` after `pnpm/setup`'s Node install is irrelevant now, and isn't a viable fix target either.
- This repo's npmjs.com packages have Trusted Publishing configured (confirmed), scoped to an environment — matching `release.yml`'s `environment: deployment` and `permissions: id-token: write`. The publish path is designed around OIDC, not a static token (see the `RETRY_TRUSTED_PUBLISHING` / "STALE OIDC TOKEN" retry logic already in the code).

## Changes

- `publishPackage()` (`tools/release/core/publish/steps/publish-packages.ts`) and `updateDistTag()` (`tools/release/core/promote/index.ts`) now shell out to `pnpm publish` / `pnpm dist-tag add` instead of `npm publish` / `npm dist-tag add`. pnpm 12's publish implementation carries its own complete, independent Trusted Publishing support.
- Added `--provenance` (parity with npm CLI's default provenance attestation under Trusted Publishing) and `--no-git-checks` to the publish command — pnpm's own publish-branch enforcement defaults to requiring `main`/`master`, which would incorrectly reject every non-canary channel (beta, release, lts-\*) that this pipeline already validates itself via its own per-channel branch checks in `utils/git.ts`.
- `pnpm dist-tag` has no `--dry-run` flag (confirmed locally — passing one is a hard argument-parsing error, not a silent no-op), so `updateDistTag()` now skips invoking it entirely for a dry run instead of trying to pass the flag through.
- Dropped the `NODE_AUTH_TOKEN`/OTP-token local-publish fallback entirely: going forward this tooling only supports OIDC-based publishing from the configured GitHub Actions release workflow, for clarity. Local/manual publishing via this script is no longer possible. Updated the two doc strings (`help/sections/about.ts`, `utils/flags-config.ts`) that described the old flow.
- Along the way, fixed a pre-existing bug in `updateTags()`: it never actually checked `updateDistTag()`'s returned error, always printing a success checkmark regardless of failure.

## Test plan

- [x] `tsc --noEmit` on `tools/release` — no new errors (4 pre-existing, unrelated `Response.text()` errors remain, out of scope)
- [x] `oxfmt --check` clean
- [x] Verified `pnpm publish <tarball> --tag=... --access=public --provenance --no-git-checks --dry-run` end-to-end locally against a scratch package (correct manifest read, correct dry-run skip, no argument errors)
- [x] Verified `pnpm dist-tag add ... --dry-run` errors (confirms the flag isn't supported, justifying the guard added)
- [ ] Real end-to-end verification via the actual release workflow (author will trigger a run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7)_