### PR TITLE
revert(dx): drop pnpm's global virtual store, breaks check:types

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,6 @@ strictPeerDependencies: false
 ## peer-groups easier to distinguish.
 ## This forces a shorter sha for all groups (vs the default of 1000)
 peersSuffixMaxLength: 40
-virtualStoreType: global
 virtualStoreDirMaxLength: 40
 
 ## If a dependency is not declared, we do not want to accidentally


### PR DESCRIPTION
## Summary

Confirmed: `main`'s `check:types` lint failure (surfaced on [PR #11016](https://github.com/warp-drive-data/warp-drive/pull/11016), unrelated to that PR's changes) started with [`b2153be06`](https://github.com/warp-drive-data/warp-drive/commit/b2153be06fc012623687db4780221c6ebe481917) ("dx: use global cache"), a single-line change setting `virtualStoreType: global` in `pnpm-workspace.yaml`. The immediately prior commit ([`5adb814e4`](https://github.com/warp-drive-data/warp-drive/commit/5adb814e432c8f08b7cb497109e98cda9ffdb5a6)) has a fully green `Main` CI run; `b2153be06`'s very next run fails `check:types` on `@warp-drive/ember` with:

```
src/-private/await.gts(42,3): error TS2345: Argument of type 'typeof Throw' is not assignable to parameter of type 'abstract new (owner: Owner, args: { error: T; }) => HasContext<AnyContext>'.
  Property '[Context]' is missing in type 'Throw<T>' but required in type 'HasContext<AnyContext>'.
```
(same pattern repeats for `each-link.gts` and a few more spots in `await.gts`)

Neither file was touched by that commit or anything since. This is exactly the failure signature this repo's own contributor docs warn about for a shared/non-isolated store (see `warp-drive-packages/memory-alpha/skills/contributors/start-in-a-fresh-worktree.md`): `pnpm-workspace.yaml` sets `hoist: false` and uses injected workspace packages specifically to keep each consumer's dependency tree isolated, and injected packages are hardlinked per-project rather than symlinked to one shared copy. A global virtual store defeats that isolation — it can serve one project's build output (or its branded types) to another, producing spurious brand-mismatch errors like this one that "point nowhere near the cause."

## Change

Reverts the one-line `virtualStoreType: global` addition, restoring pnpm's default (local, per-checkout) virtual store, until this can be revisited with the isolation guarantees intact.

## Test plan

- [x] Confirmed via GitHub Actions run history: the commit immediately before this setting was added has a green `Main` run; the commit that added it is the first to fail, at the same `check:types` step, with the same errors, on every run since
- [x] Confirmed no other file references `virtualStoreType`/`virtual-store` config
- [x] YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7)_