### PR TITLE
perf(ci): skip workspace package builds in bootstrap workflow

### DIFF
--- a/.github/workflows/bootstrap-new-packages.yml
+++ b/.github/workflows/bootstrap-new-packages.yml
@@ -36,6 +36,12 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           install: true
+          # This command only reads package.json metadata and talks to the npm
+          # registry -- it never needs any workspace package's build output, so
+          # skip the (slow) turbo build:pkg a normal `pnpm install` triggers.
+          # DISABLE_TURBO_CACHE too: with no build ever running, there's
+          # nothing for a turbo build-cache restore/save to do here either.
+          skip-addon-build: true
           DISABLE_TURBO_CACHE: true
       - name: Bootstrap new packages
         run: bun release exec bootstrap --dry_run=${{ github.event.inputs.dryRun }} --otp=${{ github.event.inputs.otp }}


### PR DESCRIPTION
## Summary

`bootstrap-packages` (added in #11018) only reads `package.json` metadata across the monorepo and talks to the npm registry (`pnpm view`/`pnpm publish` of a throwaway placeholder) — it never needs any workspace package's actual build output. A normal `pnpm install` in this repo runs the full `turbo run build:pkg` across all ~35 buildable packages via the `prepare` lifecycle script, plus a sync step for injected workspace deps afterward. For this workflow that's pure added time for no benefit.

## Change

Set `skip-addon-build: true` on the `./.github/actions/setup` step, which switches to `pnpm install --prefer-offline --ignore-scripts` (skipping the `prepare`/build step entirely) and correspondingly skips the injected-deps sync step that only matters if something was built. Also dropped `DISABLE_TURBO_CACHE: true`'s prior purpose is moot too, so I kept it — with no build ever running in this job, there was nothing for the turbo local build-cache restore/save to do here regardless of this flag, so this just avoids that step's overhead as well.

## Test plan

- [x] Read through `.github/actions/setup/action.yml`'s `skip-addon-build`/`DISABLE_TURBO_CACHE` gating to confirm the install step, sync step, and turbo build-cache step are all correctly skipped together and nothing else in the job depends on built output
- [ ] First real run of the updated workflow (this input isn't exercised by any other workflow yet, so worth watching the first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5tFmb9X2iWnmgDhNtbiH7)_