### PR TITLE
fix(release): stop shallow fetches from truncating release-notes history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,9 @@ jobs:
           fetch-depth: 3
           ref: ${{ steps.desired-branch.outputs.DESIRED_BRANCH }}
       - run: git fetch origin main --depth=1
-      - run: git fetch origin --tags --depth=1
+      # scoped to `refs/tags/*` on purpose: `--tags --depth=1` would also match the
+      # remote's default refspec and re-shallow every branch to a single commit
+      - run: git fetch origin --depth=1 "+refs/tags/*:refs/tags/*"
       - name: Make sure git user is setup
         run: |
           git config --local user.email ${{ secrets.GH_DEPLOY_EMAIL }}
@@ -273,11 +275,15 @@ jobs:
           fetch-tags: true
           show-progress: false
           token: ${{ secrets.GH_DEPLOY_TOKEN }}
-          fetch-depth: 1000 # release notes will need more history
+          # release notes are generated from `git log <last-stable-tag>..HEAD`, so we need
+          # the full history *and* the full history behind every tag. `--depth` is not an
+          # option here: it applies to every ref in the fetch, so any shallow fetch after
+          # this point re-truncates the branch we just checked out (see the tag fetches in
+          # the other jobs below).
+          fetch-depth: 0
           ref: ${{ steps.desired-branch.outputs.DESIRED_BRANCH }}
       ## Ensure we have a full copy of the source branch
       - run: git fetch origin ${{ github.event.inputs.stable_source-branch }}
-      - run: git fetch origin --tags --depth=1
       - name: Make sure git user is setup
         run: |
           git config --local user.email ${{ secrets.GH_DEPLOY_EMAIL }}
@@ -323,7 +329,7 @@ jobs:
           TARGET: ${{ steps.desired-branch.outputs.MAIN_BRANCH }}
         run: |
           git checkout -- .
-          git fetch origin $TARGET --depth=1
+          git fetch origin $TARGET
           git checkout -B $TARGET origin/$TARGET
           if git cherry-pick $SHA; then
             git push origin $TARGET
@@ -347,7 +353,7 @@ jobs:
           TARGET: ${{ steps.desired-branch.outputs.BETA_BRANCH }}
         run: |
           git checkout -- .
-          git fetch origin $TARGET --depth=1
+          git fetch origin $TARGET
           git checkout -B $TARGET origin/$TARGET
           if git cherry-pick $SHA; then
             git push origin $TARGET
@@ -382,9 +388,10 @@ jobs:
           fetch-tags: true
           show-progress: false
           token: ${{ secrets.GH_DEPLOY_TOKEN }}
-          fetch-depth: 25
+          # as with the stable job, release notes need full history behind the branch and
+          # behind the tag we diff against
+          fetch-depth: 0
           ref: ${{ github.event.inputs.lts_branch_or_promote_channel }}
-      - run: git fetch origin --tags --depth=1
       - name: Make sure git user is setup
         run: |
           git config --local user.email ${{ secrets.GH_DEPLOY_EMAIL }}
@@ -424,7 +431,9 @@ jobs:
           fetch-tags: true
           show-progress: false
           token: ${{ secrets.GH_DEPLOY_TOKEN }}
-      - run: git fetch origin --tags --depth=1
+      # scoped to `refs/tags/*` on purpose: `--tags --depth=1` would also match the
+      # remote's default refspec and re-shallow every branch to a single commit
+      - run: git fetch origin --depth=1 "+refs/tags/*:refs/tags/*"
       - uses: ./.github/actions/setup
         with:
           install: true

--- a/tools/release/core/release-notes/steps/get-changes.ts
+++ b/tools/release/core/release-notes/steps/get-changes.ts
@@ -263,11 +263,49 @@ function* lines(markdown: string): Generator<string> {
   yield* markdown.split(/\r?\n/);
 }
 
+/**
+ * lerna-changelog builds its commit list from `git log <fromTag>..HEAD`, so it is only
+ * correct when both `fromTag` and `HEAD` have their full ancestry present locally.
+ *
+ * A shallow checkout breaks this silently rather than loudly: git happily resolves the
+ * range, it just walks a truncated graph. Depending on where the boundary lands we either
+ * get nothing at all (HEAD truncated to the release commit, which carries no PR number)
+ * or every commit we happen to have (`fromTag` truncated to a parentless root, so it
+ * excludes nothing). Both yield a wrong changelog, and the second one is wrong in a way
+ * that is easy to miss in review.
+ *
+ * The two commits having a common ancestor is exactly the condition the range needs, so
+ * check for it up front and explain the fix.
+ *
+ * @internal
+ */
+async function assertHistoryIsComplete(fromTag: string): Promise<void> {
+  try {
+    await exec({ cmd: ['git', 'merge-base', fromTag, 'HEAD'], silent: true });
+    return;
+  } catch {
+    // no common ancestor (or `fromTag` is unknown) — fall through to diagnose
+  }
+
+  const isShallow = (await exec({ cmd: ['git', 'rev-parse', '--is-shallow-repository'], silent: true })).trim();
+
+  throw new Error(
+    `Cannot generate release notes: ${fromTag} and HEAD have no common ancestor in this checkout.` +
+      (isShallow === 'true'
+        ? ` This checkout is a shallow clone, so the history behind ${fromTag} is truncated. Release notes need the` +
+          ` complete history of both refs: fetch it with \`git fetch --unshallow\`, and in CI check out with` +
+          ` \`fetch-depth: 0\`. Note that a later \`git fetch --depth=<n>\` re-truncates every ref it matches, not` +
+          ` just the one named on the command line.`
+        : ` Make sure ${fromTag} exists and is a tag of this repository.`)
+  );
+}
+
 export async function getChanges(
   strategy: RawStrategyConfig,
   packages: Map<string, Package>,
   fromTag: string
 ): Promise<VersionedLernaChangeset[]> {
+  await assertHistoryIsComplete(fromTag);
   const raw = await exec(['sh', '-c', `pnpm exec lerna-changelog --from=${fromTag}`]);
   // lerna-changelog emits ANSI color codes; strip them before parsing
   const changelogMarkdown = raw.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, '');


### PR DESCRIPTION
Fixes the stable release failure in [run 33945270762](https://github.com/warp-drive-data/warp-drive/actions/runs/33945270762/job/101250099431#step:10:1):

```
error: lerna-changelog produced no parseable output from v5.8.2.
  at executePublish (tools/release/core/publish/index.ts:67:17)
```

## Root cause

`lerna-changelog` builds its commit list from `git log <fromTag>..HEAD` (`lib/git.js`, `listCommits`), so it is only correct when both `fromTag` and `HEAD` have their full ancestry present locally.

The `stable` job checked out at `fetch-depth: 1000` and then ran:

```sh
git fetch origin --tags --depth=1
```

Two things about that command combine badly:

1. `--tags` is *additive* to the remote's configured refspec, not a replacement for it — so the fetch also re-fetched `refs/heads/*`.
2. `--depth=1` applies to **every** ref a fetch matches, not just the one named on the command line.

So the release branch went from 1000 commits to 2. The only commit left in `v5.8.2..HEAD` was `Release v5.9.0-beta.2`, which carries no PR number, so `lerna-changelog` emitted nothing, `parseLernaOutput` found no `##` version block, and `changesets[0]` was `undefined`.

Replaying the exact CI sequence against the real repository:

| | `v5.8.2..HEAD` commits | of those, PR commits |
| --- | --- | --- |
| before (`fetch-depth: 1000` + `--tags --depth=1`) | 2 | 0 |
| after (`fetch-depth: 0`) | 543 | 475 |

Note this is not only about the branch. A tag fetched at `--depth=1` is a parentless root, so it excludes nothing from `<tag>..HEAD` — with the branch depth restored but the tag still shallow, the range silently widens to *every* commit in the checkout (1000, going back to July 2025) rather than the 543 that belong in a 5.8.2 → 5.9.0 changelog. Both refs need real history.

## Changes

`.github/workflows/release.yml`

- `stable` and `lts` now check out at `fetch-depth: 0`. Both generate release notes, and both need whole history behind the branch *and* the tag they diff against. Their `git fetch origin --tags --depth=1` steps are dropped — `fetch-tags: true` already brings the tags along, now with their ancestry.
- The `stable` job's two changelog cherry-pick steps drop `--depth=1` from `git fetch origin $TARGET`. On a now-complete clone that fetch re-shallows every ref and can leave the commit being cherry-picked without a parent to diff against.
- `beta` and `promote` keep their shallow tag fetch (neither generates release notes) but scope it to `+refs/tags/*:refs/tags/*` so it stops clobbering branch history as a side effect.

`tools/release/core/release-notes/steps/get-changes.ts`

- `getChanges()` now checks up front that `fromTag` and `HEAD` have a common ancestor — exactly the condition the range needs. If they don't, it fails naming the shallow clone and the fix, instead of producing an empty changelog (as here) or an over-wide one (the quieter failure described above).

## Verification

- Replayed both fetch sequences against the real repository; the numbers in the table above are measured, not estimated. The fixed sequence completes in ~22s.
- Exercised the new guard against a checkout reproducing the CI state — it throws with the actionable message — and against a full-history checkout, where it passes through to `lerna-changelog`.
- `oxfmt --check` clean on the changed TypeScript. (`tools/` is out of oxlint's scoped dirs, and `*.yml` is in oxfmt's ignore list.)
- An end-to-end `lerna-changelog` run was not possible from this session: its GitHub user-data lookups are blocked by the session's repository-scoped token. The verification above covers the layer that actually failed — the git range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz)_