### PR TITLE
fix(release): move @warp-drive/experiments onto the primary version train

### DIFF
--- a/tools/release/strategy.json
+++ b/tools/release/strategy.json
@@ -105,7 +105,7 @@
       "unpkgPublish": true
     },
     "@warp-drive/experiments": {
-      "stage": "beta",
+      "stage": "stable",
       "types": "stable",
       "typesPublish": false,
       "mirrorPublish": true,

--- a/warp-drive-packages/experiments/package.json
+++ b/warp-drive-packages/experiments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-drive/experiments",
   "description": "Experimental features for WarpDrive",
-  "version": "0.2.7-alpha.32",
+  "version": "5.9.0-alpha.32",
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "repository": {


### PR DESCRIPTION
Fixes the npm failure in the v5.9.0 stable release, [run 183](https://github.com/warp-drive-data/warp-drive/actions/runs/33947688441/job/101256644687):

```
× Failed to publish package @warp-drive/experiments@0.2.7 (status 403 Forbidden):
  {"success":false,"error":"You cannot publish over the previously published versions: 0.2.7."}

✅ published 67 📦 packages to npm
🚫 1 errors occurred while publishing packages to npm
```

## Root cause

`@warp-drive/experiments` was the only package still on `"stage": "beta"`, which puts it on its own `0.x` line. That line had drifted into an unpublishable state — its **stable** versions had moved past where its **pre-release** versions still sat:

| version | published | with |
| --- | --- | --- |
| `0.2.7` | 2026-01-12 | v5.8.1 |
| `0.2.8` | 2026-04-17 | v5.8.2 |
| `0.2.7-alpha.32` / `0.2.7-beta.3` | 2026-09-05 | current canary / beta |

A stable release derives its version by dropping the prerelease suffix, so v5.9.0 targeted `0.2.7` — taken eight months earlier. `publishPackages` collects errors across all tarballs and throws at the end, so the collision failed the job *after* the other 67 packages had already gone out, which in turn skipped the changelog cherry-picks to `main` and `beta`.

## Changes

Rather than nudging the `0.x` base past `0.2.8` and leaving the same drift to recur, this puts the package on the primary train:

- `warp-drive-packages/experiments/package.json` — `0.2.7-alpha.32` → `5.9.0-alpha.32`, matching root and the rest of `warp-drive-packages/*`.
- `tools/release/strategy.json` — `"stage": "beta"` → `"stable"`, so it increments with everything else.

Mirror publishing stays on and types publishing stays off, unchanged:

```json
"@warp-drive/experiments": {
  "stage": "stable",
  "types": "stable",
  "typesPublish": false,
  "mirrorPublish": true,
  "unpkgPublish": true
}
```

## Verification

Ran the real `applyStrategy()` against the changed files. `@warp-drive/experiments` now resolves identically to `@warp-drive/core` on every channel:

| channel | from | to | mirror | types |
| --- | --- | --- | --- | --- |
| canary | `5.9.0-alpha.32` | `5.9.0-alpha.33` | `@warp-drive-mirror/experiments` | `N/A` |
| beta | `5.9.0-alpha.32` | `5.9.0-beta.0` | `@warp-drive-mirror/experiments` | `N/A` |
| release | `5.9.0-alpha.32` | `5.9.0` | `@warp-drive-mirror/experiments` | `N/A` |

Other checks:

- Neither `@warp-drive/experiments` nor `@warp-drive-mirror/experiments` has any `5.x` version on npm (224 versions each, max `0.2.8`), so the jump is clean and strictly increasing — `latest` goes `0.2.8` → `5.9.0`.
- Every consumer (`specs`, `tests/experiments`, `tests/framework-ember`) depends on it via `workspace:*`, and `pnpm-lock.yaml` resolves it as `file:` with no version recorded — hence no lockfile or dependent-manifest churn.
- `oxfmt --check` clean on both changed files.

## Note on the already-shipped release

This does not retroactively ship `@warp-drive/experiments` at 5.9.0 — that stable release is out with 67 of 68 packages and `experiments` still at `latest: 0.2.8`. The next canary from `main` publishes `5.9.0-alpha.33`, and the next stable picks it up from there. The `release` branch still carries the old `0.2.7-*`/`beta` config and will need this change too before another release is cut from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz)_