### PR TITLE
fix(release): put @warp-drive/experiments on the 5.x train on release

### DIFF
--- a/tools/release/strategy.json
+++ b/tools/release/strategy.json
@@ -105,7 +105,7 @@
       "unpkgPublish": true
     },
     "@warp-drive/experiments": {
-      "stage": "beta",
+      "stage": "stable",
       "types": "stable",
       "typesPublish": false,
       "mirrorPublish": true,

--- a/warp-drive-packages/experiments/package.json
+++ b/warp-drive-packages/experiments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@warp-drive/experiments",
   "description": "Experimental features for WarpDrive",
-  "version": "0.2.7",
+  "version": "5.9.0",
   "license": "MIT",
   "author": "Chris Thoburn <runspired@users.noreply.github.com>",
   "repository": {


### PR DESCRIPTION
Unblocks a patch release cut from `release`. Companion to #11021, which makes the same change on `main`; this one applies it to the state this branch is actually in.

## Problem

The v5.9.0 publish bumped every package on this branch to `5.9.0` except `@warp-drive/experiments`, which is on `"stage": "beta"` and so tracks its own `0.x` line:

| package.json | version on `release` |
| --- | --- |
| root | `5.9.0` |
| `warp-drive-packages/core` | `5.9.0` |
| `warp-drive-packages/json-api` | `5.9.0` |
| **`warp-drive-packages/experiments`** | **`0.2.7`** |

`experiments` is also the package whose publish failed that release — 403, `0.2.7` was already taken in January — so it never shipped.

A patch release cut from here picks up where the branch leaves off and targets `0.2.8`, published 2026-04-17 with v5.8.2. It would fail the same way, and again only *after* the other 67 packages had already gone out.

## Changes

- `warp-drive-packages/experiments/package.json` — `0.2.7` → `5.9.0`, matching root and the rest of the branch.
- `tools/release/strategy.json` — `"stage": "beta"` → `"stable"`, so it keeps incrementing with everything else.

Mirror publishing stays on, types publishing stays off.

The `stage` flip is not strictly required for a *patch* (every stage does the same `semver.inc(patch)` on the release channel), so the version line alone unblocks you. It is required for a minor or major re-release from this branch, where `stage: "beta"` would send `experiments` down a `0.x` bump while everything else went to `5.10.0` / `6.0.0` — the same drift that caused this. Happy to drop it to a version-only change if you'd rather keep this branch minimal.

## Verification

Ran the release tooling's own `getNextVersion()` and `applyStrategy()` against this branch:

```
before  stage=beta    0.2.7 -> 0.2.8   ← already on npm (v5.8.2, 2026-04-17)
after   stage=stable  5.9.0 -> 5.9.1   ← unpublished
```

After the change, a patch release resolves `@warp-drive/experiments` identically to root and `@warp-drive/core`:

| package | from | to | mirror | types |
| --- | --- | --- | --- | --- |
| root | `5.9.0` | `5.9.1` | `N/A` | `N/A` |
| `@warp-drive/core` | `5.9.0` | `5.9.1` | `@warp-drive-mirror/core` | `N/A` |
| `@warp-drive/experiments` | `5.9.0` | `5.9.1` | `@warp-drive-mirror/experiments` | `N/A` |

Neither `@warp-drive/experiments` nor `@warp-drive-mirror/experiments` has any `5.x` version on npm, so `5.9.1` is clean and strictly increasing past `0.2.8`. All consumers depend on it via `workspace:*` and the lockfile resolves it as `file:` with no version recorded, so nothing else changes. `oxfmt --check` clean on both files.

## Note

`@warp-drive/experiments@5.9.0` itself is skipped — the next release from this branch is `5.9.1`, and `latest` moves `0.2.8` → `5.9.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz)_