### PR TITLE
fix(release): publish releases that have no changelog-worthy changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,11 @@ jobs:
         with:
           install: true
           DISABLE_TURBO_CACHE: true
+      # Recorded before the release script commits anything, so the changelog lookup below
+      # can be limited to the commits this run actually created.
+      - name: Record pre-release HEAD
+        id: pre-release
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Publish New Release
         # If we are not reversioning
         # Then we do the default patch increment from the current branch state.
@@ -319,7 +324,11 @@ jobs:
         id: changelog-commit
         if: github.event.inputs.dryRun != 'true'
         run: |
-          SHA=$(git log --format='%H' -n 1 --grep="chore: update changelogs")
+          # Scoped to the commits this run created. A release with no changelog-worthy
+          # changes makes no changelog commit, and an unscoped search would then find the
+          # *previous* release's commit and cherry-pick it a second time. No match leaves
+          # SHA empty, which already skips the cherry-pick steps below.
+          SHA=$(git log --format='%H' -n 1 --grep="chore: update changelogs" ${{ steps.pre-release.outputs.sha }}..HEAD)
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
       - name: Cherry-pick changelog to main
         if: github.event.inputs.dryRun != 'true' && steps.changelog-commit.outputs.sha != ''

--- a/tools/release/core/publish/index.ts
+++ b/tools/release/core/publish/index.ts
@@ -7,7 +7,7 @@ import { GIT_TAG, getAllPackagesForGitTag, getGitState } from '../../utils/git.t
 import { gatherPackages, loadStrategy } from '../../utils/package.ts';
 import { parseRawFlags, printConfig } from '../../utils/parse-args.ts';
 import { confirmCommitChangelogs } from '../release-notes/steps/confirm-changelogs.ts';
-import { getChanges } from '../release-notes/steps/get-changes.ts';
+import { getChanges, reportNoChangelogEntries } from '../release-notes/steps/get-changes.ts';
 import { updateChangelogs } from '../release-notes/steps/update-changelogs.ts';
 import { bumpAllPackages, restorePackagesForDryRun } from './steps/bump-versions.ts';
 import { confirmStrategy } from './steps/confirm-strategy.ts';
@@ -63,29 +63,31 @@ export async function executePublish(args: string[]) {
     // generate the list of changes (first entry is the unreleased block)
     const changesets = await getChanges(strategy.config, packages, fromTag);
     const newChanges = changesets[0];
+
+    // a release with nothing changelog-worthy in it is a real release, not a failure:
+    // publish it, just without a changelog commit. getChanges() throws if lerna-changelog
+    // actually broke, so reaching here means it ran and had nothing to report.
     if (!newChanges) {
-      throw new Error(
-        `lerna-changelog produced no parseable output from ${fromTag}. Check the log above for the raw output.`
+      await reportNoChangelogEntries(fromTag);
+    } else {
+      const toTag = `v${versions.get('root')!}` as GIT_TAG;
+      const date = new Date().toISOString().split('T')[0];
+
+      // update all changelogs, including the primary changelog
+      // and the changelogs for each package in changelogRoots
+      // this will not commit the changes
+      const changedFiles = await updateChangelogs(
+        fromTag,
+        toTag,
+        date,
+        newChanges,
+        config.full,
+        strategy.config,
+        packages
       );
+
+      await confirmCommitChangelogs(changedFiles, config.full, versions);
     }
-
-    const toTag = `v${versions.get('root')!}` as GIT_TAG;
-    const date = new Date().toISOString().split('T')[0];
-
-    // update all changelogs, including the primary changelog
-    // and the changelogs for each package in changelogRoots
-    // this will not commit the changes
-    const changedFiles = await updateChangelogs(
-      fromTag,
-      toTag,
-      date,
-      newChanges,
-      config.full,
-      strategy.config,
-      packages
-    );
-
-    await confirmCommitChangelogs(changedFiles, config.full, versions);
   }
 
   // Bump package.json versions & commit/tag

--- a/tools/release/core/release-notes/steps/get-changes.ts
+++ b/tools/release/core/release-notes/steps/get-changes.ts
@@ -310,5 +310,52 @@ export async function getChanges(
   // lerna-changelog emits ANSI color codes; strip them before parsing
   const changelogMarkdown = raw.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, '');
   const results = parseLernaOutput(changelogMarkdown, strategy, packages);
+
+  // An empty result has two very different causes, and they need opposite handling.
+  //
+  // lerna-changelog prints *nothing at all* when no commit in the range carries one of the
+  // labels configured in package.json#changelog.labels: renderRelease() returns "" for a
+  // release whose categories are all empty, and renderMarkdown() returns "" when every
+  // release renders empty. That is a legitimate release — one made up entirely of
+  // unlabelled or infra commits — and it should publish with no changelog entry rather
+  // than halt. Report it as an empty result and let the caller decide.
+  //
+  // Output we did get but could not parse into a version block is the genuinely broken
+  // case, and still throws — with the raw output attached, since exec() captures stdout
+  // and nothing else would ever print it.
+  if (results.length === 0 && changelogMarkdown.trim().length > 0) {
+    throw new Error(
+      `lerna-changelog produced output from ${fromTag} that could not be parsed into a release block.` +
+        ` Raw output:\n${changelogMarkdown}`
+    );
+  }
+
   return results;
+}
+
+/**
+ * Explain a release that carries no changelog entries, so an empty changelog reads as a
+ * deliberate outcome in the job log rather than as something that silently didn't happen.
+ * Lists the commits in the range: if any of them *should* have appeared, the fix is a
+ * changelog label on its PR, and seeing the commit is what makes that obvious.
+ *
+ * @internal
+ */
+export async function reportNoChangelogEntries(fromTag: string): Promise<void> {
+  const log = (await exec({ cmd: ['git', 'log', '--oneline', `${fromTag}..HEAD`], silent: true })).trim();
+
+  console.log(
+    `\n\t${styleText('yellow', `➠ No changelog entries since ${fromTag}.`)}\n\t${styleText(
+      'gray',
+      'No commit in the range carries a label from package.json#changelog.labels, so there is nothing to write. Skipping the changelog update.'
+    )}`
+  );
+
+  if (log) {
+    console.log(`\t${styleText('gray', 'Commits in range:')}`);
+    for (const line of log.split('\n')) {
+      console.log(`\t  ${styleText('gray', line)}`);
+    }
+  }
+  console.log('');
 }


### PR DESCRIPTION
Fixes the v5.9.1 stable failure, [run 184](https://github.com/warp-drive-data/warp-drive/actions/runs/33951230713):

```
error: lerna-changelog produced no parseable output from v5.9.0.
```

Same message as #11020, but a completely different cause — and this time nothing was actually broken.

## Root cause

The `assertHistoryIsComplete` guard from #11020 passed, so history was intact. The chain is:

1. **#11023 was the only commit in `v5.9.0..HEAD`**, and it merged **without a changelog label**. Its `enforce-changelog-label` check did fail on the PR, but it isn't a blocking check.
2. lerna-changelog filters commits by the labels in `package.json#changelog.labels`. Nothing qualified, so `renderRelease()` returned `""` (every category empty) and `renderMarkdown()` returned `""` (every release empty).
3. `parseLernaOutput` found no `##` version block → `changesets[0]` was `undefined` → the tooling threw.

So an empty changelog was being treated as a failure. It isn't one. A release made up entirely of unlabelled or infra commits is a real release that should publish, just with no changelog entry — and that matters most in exactly this case, where the whole point of 5.9.1 is to ship the package the previous run failed to publish.

## Changes

**`getChanges()` now separates the two causes of an empty result**, which need opposite handling:

| lerna-changelog output | meaning | behaviour |
| --- | --- | --- |
| empty | no commit carried a configured label — nothing to report | return no changesets, caller carries on |
| non-empty, unparseable | genuinely broken | throw, **with the raw output attached** |

The old error told you to "check the log above for the raw output", but `exec()` captures stdout, so nothing ever printed it. Now the output is in the message.

**`executePublish()` skips the changelog update** on an empty result and calls `reportNoChangelogEntries()`, which explains why and lists the commits in the range:

```
➠ No changelog entries since v5.9.0.
  No commit in the range carries a label from package.json#changelog.labels, so there
  is nothing to write. Skipping the changelog update.
  Commits in range:
    5ebca5d2e fix(release): put @warp-drive/experiments on the 5.x train on release (#11023)
```

If one of those commits *should* have appeared, the fix is a label on its PR — and seeing the commit is what makes that obvious.

**Workflow: the changelog-commit lookup is now scoped to this run.** Skipping the changelog commit exposed a latent bug — `Get changelog commit SHA` greps all of history, so with no new commit to find it would locate the *previous* release's changelog commit and cherry-pick it to `main` and `beta` a second time. Verified against the real release branch:

```
OLD (unscoped)  -> e403d9474  chore: update changelogs for v5.9.0   ← already on main and beta
NEW (scoped)    -> (empty)                                          ← cherry-picks skipped
```

A `Record pre-release HEAD` step captures the branch tip before the release script commits anything, and the lookup runs over `<pre-release>..HEAD`. No match leaves the SHA empty, which already skips the cherry-pick steps.

## Verification

Drove `getChanges()` with stubbed lerna-changelog output, through the real `exec` path:

| case | result |
| --- | --- |
| empty output (the actual v5.9.0 failure) | 0 changesets, no throw |
| whitespace-only output | 0 changesets, no throw |
| non-empty but unparseable | throws, raw output included |
| normal output | parses as before |

Also ran `reportNoChangelogEntries('v5.9.0')` against the real release branch (output above), and confirmed the scoped-vs-unscoped grep behaviour shown in the table. `oxfmt --check` clean; workflow YAML parses.

## Note on the immediate unblock

Because lerna-changelog reads labels live from the API, adding a changelog label to #11023 would *also* let a re-run succeed, and would put that PR in the 5.9.1 notes. With this change the release simply proceeds with no changelog entry instead. Either is fine — worth a moment's thought about which you want for #11023 specifically.

Separately: `enforce-changelog-label` correctly failed on #11023 and did not block the merge. Making it a required check would stop this class of surprise at the source, but that's a repo-settings change rather than something this PR can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DWiEYcFBHz8awyasf3Jgqz)_