### PR TITLE
fix(docs): authenticate GitHub API calls in the canary docs build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,11 @@ jobs:
         env:
           BASE: ''
           HOSTNAME: 'https://canary.warp-drive.io'
+          # authenticates the docs build's calls to api.github.com (contributor list +
+          # profile lookups) so they get the 5,000/hour per-token limit instead of the
+          # 60/hour per-IP anonymous limit, which is shared with unrelated jobs across
+          # the whole GitHub Actions runner pool and fails intermittently under load
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/docs-viewer/docs.warp-drive.io/.vitepress/data/all-time.data.ts
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/data/all-time.data.ts
@@ -1,4 +1,4 @@
-import { Contributor, getFromCache, default as loadAll, saveToCache } from './contributors.data.ts';
+import { Contributor, getFromCache, githubHeaders, default as loadAll, saveToCache } from './contributors.data.ts';
 import { CoreTeamMember, default as loadCore } from './core.data.ts';
 
 // https://api.github.com/users/
@@ -73,7 +73,7 @@ async function fetchPerson(username: string) {
   const cached = await getFromCache(cacheKey);
   if (cached) return cached;
 
-  const res = await fetch(`https://api.github.com/users/${username}`);
+  const res = await fetch(`https://api.github.com/users/${username}`, { headers: githubHeaders() });
   if (res.ok) {
     const profile = await res.json();
     await saveToCache(cacheKey, profile);

--- a/docs-viewer/docs.warp-drive.io/.vitepress/data/contributors.data.ts
+++ b/docs-viewer/docs.warp-drive.io/.vitepress/data/contributors.data.ts
@@ -8,6 +8,15 @@ export interface Contributor {
   githubLink: string;
 }
 
+// Unauthenticated requests to api.github.com are capped at 60/hour *per
+// source IP*, and that IP is shared with unrelated jobs across every
+// GitHub Actions runner in the pool -- an authenticated token raises this
+// to 5,000/hour and is scoped to this token alone.
+export function githubHeaders(): HeadersInit | undefined {
+  const token = process.env.GITHUB_TOKEN;
+  return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
 export async function getFromCache(key: string): Promise<any | null> {
   const CacheDir = './docs.warp-drive.io/.vitepress/cache/github-api';
   const filePath = `${CacheDir}/${key}.json`;
@@ -47,7 +56,8 @@ async function load() {
       contributors = cached;
     } else {
       const res = await fetch(
-        `https://api.github.com/repos/warp-drive-data/warp-drive/contributors?per_page=${PAGE_SIZE}&page=${pages + 1}`
+        `https://api.github.com/repos/warp-drive-data/warp-drive/contributors?per_page=${PAGE_SIZE}&page=${pages + 1}`,
+        { headers: githubHeaders() }
       );
       contributors = await res.json();
       // store the result in cache if successful


### PR DESCRIPTION
## Summary

The `canary.warp-drive.io deployment` workflow's `build` job (`docs-viewer`'s VitePress build) fetches the repo's contributor list and each top-contributor/core-team member's GitHub profile from `api.github.com` **unauthenticated**. That's capped at 60 requests/hour *per source IP*, and that IP is shared with unrelated jobs across the whole GitHub Actions runner pool. No on-disk cache is persisted across CI runs, so every canary deploy does this cold (~15-20 calls), and it has already failed the workflow with `API rate limit exceeded` / a 403 from `vitepress:data` twice in one day (runs [33943303679](https://github.com/warp-drive-data/warp-drive/actions/runs/33943303679) and [33952657008](https://github.com/warp-drive-data/warp-drive/actions/runs/33952657008)).

- Adds `githubHeaders()` in `contributors.data.ts`, which builds an `Authorization: Bearer <token>` header from `process.env.GITHUB_TOKEN` when present (falls back to unauthenticated for local dev where the env var isn't set).
- Uses it in both `fetch` call sites: the contributors-list pagination in `contributors.data.ts` and the per-user profile lookup in `all-time.data.ts`.
- Passes `secrets.GITHUB_TOKEN` into the `Generate Artifact` step's `env` in `deploy.yml` so it's available during `pnpm run build`.

An authenticated `GITHUB_TOKEN` raises the limit to 5,000/hour, scoped to that token alone, eliminating this class of intermittent failure rather than just reducing its frequency.

## Test plan

- [x] Scoped `tsc --noEmit` check against the two edited `.data.ts` files with the project's compiler options — no new type errors introduced.
- [ ] Next `canary.warp-drive.io deployment` run on `main` completes the `Generate Artifact` step without a GitHub API rate-limit error.

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v28PpNpJEFtAJhdVgjDQw

---
_Generated by [Claude Code](https://claude.ai/code/session_011v28PpNpJEFtAJhdVgjDQw)_