### PR TITLE
fix(legacy): release legacy support when a schema-backed legacy record is torn down

### DIFF
--- a/tests/legacy/tests/legacy-mode/unload-releases-legacy-support-test.ts
+++ b/tests/legacy/tests/legacy-mode/unload-releases-legacy-support-test.ts
@@ -1,0 +1,87 @@
+import { setOwner } from '@ember/owner';
+
+import { recordIdentifierFor } from '@warp-drive/core';
+import type { Type } from '@warp-drive/core/types/symbols';
+import { module, setupTest, test } from '@warp-drive/diagnostic/ember';
+import { JSONAPICache } from '@warp-drive/json-api';
+import { useLegacyStore } from '@warp-drive/legacy';
+import Model, { hasMany } from '@warp-drive/legacy/model';
+import { LEGACY_SUPPORT } from '@warp-drive/legacy/model/-private';
+import { withRestoredDeprecatedModelRequestBehaviors as withLegacy } from '@warp-drive/legacy/model/migration-support';
+
+const Store = useLegacyStore({
+  linksMode: false,
+  cache: JSONAPICache,
+});
+
+module('Legacy | Unload | legacy support', function (hooks) {
+  setupTest(hooks);
+
+  test('unloading a schema-backed legacy record releases its legacy support', function (assert) {
+    type User = {
+      id: string | null;
+      name: string;
+      friends: User[];
+      [Type]: 'user';
+    };
+    const store = new Store();
+    setOwner(store, this.owner);
+    this.owner.register('service:store', store, { instantiate: false });
+
+    store.schema.registerResource(
+      withLegacy({
+        type: 'user',
+        fields: [
+          { name: 'name', type: null, kind: 'attribute' },
+          { name: 'friends', type: 'user', kind: 'hasMany', options: { async: false, inverse: 'friends' } },
+        ],
+      })
+    );
+
+    const user = store.push<User>({
+      data: {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Chris' },
+        relationships: { friends: { data: [] } },
+      },
+    });
+    const identifier = recordIdentifierFor(user);
+
+    assert.equal(user.friends.length, 0, 'the relationship is readable');
+    assert.true(LEGACY_SUPPORT.has(identifier), 'accessing a relationship creates legacy support');
+
+    store.unloadRecord(user);
+
+    assert.false(LEGACY_SUPPORT.has(identifier), 'unloading the record releases its legacy support');
+  });
+
+  test('unloading a class-based legacy record releases its legacy support', function (assert) {
+    class Tag extends Model {
+      @hasMany('tag', { async: false, inverse: null })
+      related;
+
+      declare [Type]: 'tag';
+    }
+    this.owner.register('model:tag', Tag);
+    const store = new Store();
+    setOwner(store, this.owner);
+    this.owner.register('service:store', store, { instantiate: false });
+
+    const tag = store.push<Tag>({
+      data: {
+        type: 'tag',
+        id: '1',
+        relationships: { related: { data: [] } },
+      },
+    });
+    const identifier = recordIdentifierFor(tag);
+
+    assert.equal(tag.related.length, 0, 'the relationship is readable');
+    assert.true(LEGACY_SUPPORT.has(identifier), 'accessing a relationship creates legacy support');
+
+    store.unloadRecord(tag);
+
+    assert.false(LEGACY_SUPPORT.has(identifier), 'unloading the record releases its legacy support');
+  });
+});

--- a/warp-drive-packages/legacy/src/index.ts
+++ b/warp-drive-packages/legacy/src/index.ts
@@ -37,6 +37,7 @@ import type Model from './model';
 import { instantiateRecord as instantiateModel, modelFor, teardownRecord as teardownModel } from './model';
 import { FragmentArrayExtension, FragmentExtension } from './model-fragments';
 import { fragmentsModelFor } from './model-fragments/hooks/model-for';
+import { releaseLegacySupport } from './model/-private/legacy-relationships-support';
 import { DelegatingSchemaService, registerDerivations as registerLegacyDerivations } from './model/migration-support';
 import { restoreDeprecatedStoreBehaviors } from './store';
 
@@ -412,6 +413,7 @@ export function useLegacyStore<T extends Cache>(
       if (this.schema.isDelegated(key)) {
         return teardownModel.call(this, record as Model);
       }
+      releaseLegacySupport(key);
       return teardownRecord(record);
     }
 

--- a/warp-drive-packages/legacy/src/model/-private/legacy-relationships-support.ts
+++ b/warp-drive-packages/legacy/src/model/-private/legacy-relationships-support.ts
@@ -45,6 +45,14 @@ export const LEGACY_SUPPORT: Map<ResourceKey | MinimalLegacyRecord, LegacySuppor
   new Map<ResourceKey | MinimalLegacyRecord, LegacySupport>()
 );
 
+export function releaseLegacySupport(identifier: ResourceKey): void {
+  const support = LEGACY_SUPPORT.get(identifier);
+  if (support) {
+    support.destroy();
+    LEGACY_SUPPORT.delete(identifier);
+  }
+}
+
 export function lookupLegacySupport(record: MinimalLegacyRecord): LegacySupport {
   const identifier = recordIdentifierFor(record);
   assert(`Expected a record`, identifier);

--- a/warp-drive-packages/legacy/src/model/-private/model.ts
+++ b/warp-drive-packages/legacy/src/model/-private/model.ts
@@ -14,7 +14,7 @@ import { RecordStore } from '@warp-drive/core/types/symbols';
 
 import type { Snapshot } from '../../compat/-private.ts';
 import { Errors } from './errors.ts';
-import { LEGACY_SUPPORT } from './legacy-relationships-support.ts';
+import { releaseLegacySupport } from './legacy-relationships-support.ts';
 import type { MinimalLegacyRecord } from './model-methods.ts';
 import {
   _destroyRecord,
@@ -545,11 +545,7 @@ class Model extends EmberObject implements MinimalLegacyRecord {
     const store = storeFor(this, false)!;
     store.notifications.unsubscribe(this.___private_notifications);
 
-    const support = LEGACY_SUPPORT.get(identifier);
-    if (support) {
-      support.destroy();
-      LEGACY_SUPPORT.delete(identifier);
-    }
+    releaseLegacySupport(identifier);
 
     super.destroy();
   }


### PR DESCRIPTION
`useLegacyStore` sends records that are not delegated to a `Model` class through the core `teardownRecord`, which does not know about `LEGACY_SUPPORT`. Only `Model.destroy()` deletes from that map, so for schema-backed legacy records the `LegacySupport` created on first relationship access stayed in the module-level map after unload. Each entry retains the store and, through it, the owner (i.e. the Application in Ember). This could lead to significant memory leaks in test suites.

The non-delegated branch now destroys the support object and deletes the entry before the core teardown, matching what `Model.destroy()` does.