### PR TITLE
chore: group typescript, eslint, and vite dependencies in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,8 +27,20 @@
       "groupName": "bun"
     },
     {
+      "matchPackageNames": ["typescript", "globals"],
+      "groupName": "typescript"
+    },
+    {
       "matchPackageNames": ["/qunit/"],
       "groupName": "qunit"
+    },
+    {
+      "matchPackageNames": ["/eslint/"],
+      "groupName": "eslint"
+    },
+    {
+      "matchPackageNames": ["/vite/"],
+      "groupName": "vite"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Description

Updates the Renovate configuration to group related dependencies together for more organized and manageable dependency updates:

- **typescript**: Groups `typescript` and `globals` packages
- **eslint**: Groups all eslint-related packages (via regex matching)
- **vite**: Groups all vite-related packages (via regex matching)

This improves the dependency update workflow by keeping related tools and their dependencies in separate, focused pull requests.

## Test Plan

N/A - Configuration change only. Renovate will apply these grouping rules to future dependency updates.

https://claude.ai/code/session_014rbcvZ22hJASgffWAaWQBc