### PR TITLE
chore: add dev-engines and build-tools groups to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,8 +23,8 @@
       "groupName": "legacy-ember-types"
     },
     {
-      "matchPackageNames": ["bun-types", "@types/bun"],
-      "groupName": "bun"
+      "matchPackageNames": ["bun", "bun-types", "@types/bun", "node", "@types/node"],
+      "groupName": "dev-engines"
     },
     {
       "matchPackageNames": ["typescript", "globals"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,8 +39,8 @@
       "groupName": "eslint"
     },
     {
-      "matchPackageNames": ["/vite/"],
-      "groupName": "vite"
+      "matchPackageNames": ["/vite/", "/rollup/", "/rolldown/", "/tsdown/", "/unplugin/"],
+      "groupName": "build-tools"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Description

Follow-up to warp-drive-data/warp-drive#11044, adding two more Renovate grouping rules:

- **dev-engines**: groups `bun`, `bun-types`, `@types/bun`, `node`, and `@types/node` — these toolchain/type-definition versions are pinned together (`mise.toml`, `package.json` engines) and should update together.
- **build-tools**: broadens the `vite` group to also match `/rollup/`, `/rolldown/`, `/tsdown/`, and `/unplugin/` — these bundler/build-plugin ecosystems are used interchangeably across packages and tend to release in step.

## Test Plan

N/A - Configuration change only. Renovate will apply these grouping rules to future dependency updates.

<!-- Thank you for opening up this PR! -->

If this PR updates API docs, preview them by:

- install [bun](https://bun.sh/docs/installation) (if needed)
- install [mise](https://mise.jdx.dev/getting-started.html) and run `mise install` in the root (if needed)
- run `pnpm install` in the root (if needed)
- run `pnpm preview` in the root

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rbcvZ22hJASgffWAaWQBc

---
_Generated by [Claude Code](https://claude.ai/code/session_014rbcvZ22hJASgffWAaWQBc)_