### PR TITLE
fix(internal-config): support @rollup/plugin-babel@7's object-hook transform

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2906,8 +2906,8 @@ importers:
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.7)
       '@rollup/plugin-babel':
-        specifier: ^6.1.0
-        version: 6.1.0(@babel/core@7.29.7)
+        specifier: ^7.1.0
+        version: 7.1.0(@babel/core@7.29.7)
       '@types/debug':
         specifier: 4.1.13
         version: 4.1.13
@@ -14172,24 +14172,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-babel@6.1.0(6ad958b0fac2ae7830d3cd04df3c1700)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4
-    optionalDependencies:
-      '@types/babel__core': 7.20.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.1.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.7)(rollup@4.63.1)':
     dependencies:
       '@babel/core': 7.29.7
@@ -15394,7 +15376,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(9ec8e8dc0efa15f8799162fd67b13f37)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15447,7 +15429,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(898ee546b130d0840a48cdd2a651e062)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15500,7 +15482,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(a17da383a2ad9251dbc32f008959784b)
       '@rolldown/plugin-babel': 0.2.3(59f2fa0795344b619d0db7caea9d8326)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15553,7 +15535,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(9ec8e8dc0efa15f8799162fd67b13f37)
       '@rolldown/plugin-babel': 0.2.3(59f2fa0795344b619d0db7caea9d8326)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15606,7 +15588,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(9ec8e8dc0efa15f8799162fd67b13f37)
       '@rolldown/plugin-babel': 0.2.3(abd7fc075a76404ea361dd5f25237cb6)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15659,7 +15641,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(a17da383a2ad9251dbc32f008959784b)
       '@rolldown/plugin-babel': 0.2.3(e36f4c5c78a179bed16b520e05120361)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15712,7 +15694,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(9ec8e8dc0efa15f8799162fd67b13f37)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15765,7 +15747,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(9ec8e8dc0efa15f8799162fd67b13f37)
       '@rolldown/plugin-babel': 0.2.3(22db23e7c975b0c1a7930213700e17ae)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15818,7 +15800,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(cb99b9e1817872a97ded65f2fa6b2728)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)
-      '@rollup/plugin-babel': 6.1.0(6ad958b0fac2ae7830d3cd04df3c1700)
+      '@rollup/plugin-babel': 7.1.0(6ad958b0fac2ae7830d3cd04df3c1700)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15871,7 +15853,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(a17da383a2ad9251dbc32f008959784b)
       '@rolldown/plugin-babel': 0.2.3(02d9a2513d9ed1d532b075ffd9c2b5e7)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15924,7 +15906,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(898ee546b130d0840a48cdd2a651e062)
       '@rolldown/plugin-babel': 0.2.3(22db23e7c975b0c1a7930213700e17ae)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)
@@ -15977,7 +15959,7 @@ snapshots:
       '@eslint/js': 10.0.1(eslint@10.9.1)
       '@nullvoxpopuli/ember-rolldown': 2.7.0(9ec8e8dc0efa15f8799162fd67b13f37)
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(vite@8.2.2)
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.29.7)
+      '@rollup/plugin-babel': 7.1.0(@babel/core@7.29.7)
       '@types/debug': 4.1.13
       '@typescript-eslint/eslint-plugin': 8.69.0(7cba72682efd86a4bdde7a146a8606b7)
       '@typescript-eslint/parser': 8.69.0(eslint@10.9.1)(typescript@6.0.3)

--- a/tools/internal-config/package.json
+++ b/tools/internal-config/package.json
@@ -8,7 +8,7 @@
     "@babel/eslint-parser": "7.29.7",
     "@nullvoxpopuli/ember-rolldown": "^2.7.0",
     "@rolldown/plugin-babel": "^0.2.3",
-    "@rollup/plugin-babel": "^6.1.0",
+    "@rollup/plugin-babel": "^7.1.0",
     "@typescript-eslint/eslint-plugin": "^8.69.0",
     "@typescript-eslint/parser": "^8.69.0",
     "@types/debug": "4.1.13",

--- a/tools/internal-config/vite/babel.js
+++ b/tools/internal-config/vite/babel.js
@@ -97,10 +97,14 @@ export function maybeBabel(userOptions) {
     return extraCodePatterns.some((pattern) => pattern.test(sourceCode));
   }
 
+  // `@rollup/plugin-babel`@7 switched `transform` from a plain function to an
+  // object-hook shape (`{ filter, handler }`, per rollup/plugins#1954) --
+  // unwrap it so wrapping the hook keeps working across both v6 and v7.
   const originalTransform = plugin.transform;
+  const originalHandler = typeof originalTransform === 'function' ? originalTransform : originalTransform.handler;
   plugin.transform = function wrappedTransform(sourceCode, id) {
     if (!shouldTransform(sourceCode, id)) return null;
-    return originalTransform.call(this, sourceCode, id);
+    return originalHandler.call(this, sourceCode, id);
   };
 
   return { ...plugin, enforce: 'pre', name: 'warp-drive:maybe-babel' };


### PR DESCRIPTION
## Summary

- Unblocks [#11049](https://github.com/warp-drive-data/warp-drive/pull/11049) (Renovate's `@rollup/plugin-babel` v6→v7 bump), which fails CI on every `*:build:tests` task with `TypeError: originalTransform.call is not a function`.
- `@rollup/plugin-babel`@7.0.0 ([rollup/plugins#1954](https://redirect.github.com/rollup/plugins/issues/1954)) changed its `transform` hook from a plain function to the object-hook shape `{ filter, handler }`. `maybeBabel` in `tools/internal-config/vite/babel.js` wraps that hook and assumed it was always directly callable, so it broke under v7.
- Fix: unwrap `originalTransform.handler` when it's the v7 object shape, falling back to the plain function for v6, so the wrapper works with either.
- Bumps `@rollup/plugin-babel` to `^7.1.0` and regenerates the lockfile accordingly.

## Test plan

- [x] `pnpm turbo run build:tests` across the whole workspace — all 51 tasks pass (Ember, React, Vue, Svelte test apps), including the previously-failing `json-api` build.
- [x] `npx oxlint` / `npx prettier --check` on the changed files.

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rbcvZ22hJASgffWAaWQBc

---
_Generated by [Claude Code](https://claude.ai/code/session_014rbcvZ22hJASgffWAaWQBc)_