### PR TITLE
ci: reset turbo remote-cache proxy server log between runs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -109,6 +109,18 @@ runs:
         restore-keys: |
           turbo-remote-cache-
 
+    # felixmosh's server process appends its stdout/stderr to this file
+    # (open(..., 'a'), never truncated) for the whole job, and its post step
+    # unconditionally cats the file as "Server logs:" during cleanup. Since
+    # the restore above carries turbo-cache/ forward from whichever prior run
+    # last saved it, a crash logged by one run would otherwise keep
+    # reappearing in every later run's cleanup output forever. Clearing it
+    # here means each run only ever sees its own server's logs.
+    - name: 'Reset Turbo Remote-Cache Proxy Server Log'
+      if: ${{ inputs.repo-token && inputs.DISABLE_TURBO_CACHE != 'true' }}
+      shell: bash
+      run: rm -f "${{ runner.temp }}/turbo-cache/out.log"
+
     # Turborepo always checks its local on-disk cache (`.turbo/cache`) before
     # the remote (felixmosh) cache, and every turbo task's hash is purely a
     # function of file contents, so sharing that directory here -- keyed by


### PR DESCRIPTION
## Summary

- `felixmosh/turborepo-gh-artifacts`'s local proxy server appends its stdout/stderr to `turbo-cache/out.log` in append mode, and that whole directory is restored from a shared `actions/cache` entry on every run via a repo-wide `turbo-remote-cache-` prefix match.
- Its post/cleanup step unconditionally dumps that file's full contents under "Server logs:" in the `Post Setup local TurboRepo server` step, on every run.
- Because `out.log` is never truncated, a crash logged by any single past run (e.g. a job that once failed to get `repo-token` through to the spawned server process) keeps resurfacing in every subsequent run's cleanup output forever — this is what was showing up as `Error: Input required and not supplied: repo-token` in Test Chrome job cleanup logs, even though the current run's server started fine.
- Adds a step in `.github/actions/setup/action.yml` that deletes `turbo-cache/out.log` right after the remote-cache-proxy disk cache is restored and before the server starts, so each run only ever shows its own server's logs. The actual cached build artifacts (`.gz` files) are untouched and continue to be shared across runs/PRs as before.

## Test plan

- [ ] Confirm CI passes on this PR
- [ ] Confirm the `Post Setup local TurboRepo server` step no longer prints stale `Server logs:` content from prior runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kY3q4TyvspTvsiFPwEtd6

---
_Generated by [Claude Code](https://claude.ai/code/session_016kY3q4TyvspTvsiFPwEtd6)_