### PR TITLE
chore: lower minimumReleaseAge from 7 days to 3 days (renovate + pnpm)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,9 +60,7 @@
       "groupName": "github-actions"
     }
   ],
-  "npm": {
-    "minimumReleaseAge": "7 days"
-  },
+  "minimumReleaseAge": "3 days",
   "rangeStrategy": "bump",
   "prHourlyLimit": 10,
   "branchConcurrentLimit": 12,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -121,9 +121,9 @@ dedupeInjectedDeps: false
 ## maintainer account or leaked publish token) before we can pull them in,
 ## including as transitive dependencies.
 ##
-## 10080 minutes = 7 days.
+## 4320 minutes = 3 days.
 ##
-minimumReleaseAge: 10080
+minimumReleaseAge: 4320
 
 ## Our own packages are published by our own release automation and are
 ## never installed from a public attacker's account, so there's no reason


### PR DESCRIPTION
## Description

Lowers `minimumReleaseAge` from 7 days to 3 days in both places it's configured:

- **Renovate** (`.github/renovate.json`): moved from the `npm`-only scope to the top level, so it applies globally (pnpm, github-actions, etc.) rather than just npm-datasource dependencies. This controls how long Renovate waits before opening a PR for a new release.
- **pnpm** (`pnpm-workspace.yaml`): pnpm's own supply-chain hardening `minimumReleaseAge` (10080 → 4320 minutes), which controls how long a newly-published version must exist before pnpm will actually install it, independent of Renovate.

The Dependency Dashboard currently shows 14 updates sitting in "Pending Status Checks" — including `pnpm`, `oxlint`, `vitest`, and several of the newly-grouped rules (`build-tools`, `dev-engines`, `docs`, `eslint`) — solely because their releases haven't cleared the previous 7-day cooldown yet. Shortening both cooldowns to 3 days gets these moving faster while still keeping a buffer against day-one regressions in freshly published releases.

## Test Plan

N/A - Configuration change only. Renovate and pnpm will apply the shorter cooldown to future dependency updates and installs respectively.

<!-- Thank you for opening up this PR! -->

If this PR updates API docs, preview them by:

- install [bun](https://bun.sh/docs/installation) (if needed)
- install [mise](https://mise.jdx.dev/getting-started.html) and run `mise install` in the root (if needed)
- run `pnpm install` in the root (if needed)
- run `pnpm preview` in the root

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rbcvZ22hJASgffWAaWQBc