### PR TITLE
Keep a document's `meta` optional until a request narrows it

### DIFF
--- a/guides/the-manual/requests/typing-requests.md
+++ b/guides/the-manual/requests/typing-requests.md
@@ -189,7 +189,10 @@ Number(content.meta?.total ?? 0); // meta.total is unknown
 ```
 
 Both `ReactiveDataDocument` and `withReactiveResponse` take an optional second type param for the meta.
-Supplying it also makes `meta` non-optional, so you stop writing `?.` for a key you just declared:
+Supplying it also makes `meta` non-optional, so you stop writing `?.` for a key you just declared.
+Leave it off and `meta` stays optional, which is what keeps a document type derivable — an interface
+that re-declares `meta?:`, an intersection with `{ meta?: X }`, or a `class ... implements` all
+continue to work:
 
 ```ts
 import { withReactiveResponse } from '@warp-drive/core/request';

--- a/tests/utilities/tests/unit/document-type-params-test.ts
+++ b/tests/utilities/tests/unit/document-type-params-test.ts
@@ -36,6 +36,15 @@ type ErrorsOf<D extends { next: (...args: never[]) => unknown }> = Extract<
   { errors: unknown[] }
 >['errors'];
 
+/**
+ * `true` when `K` is an OPTIONAL property of `T`.
+ *
+ * The empty object type is load-bearing here — it is the only thing assignable
+ * to a `Pick` whose sole member is optional — so the lint rule does not apply.
+ */
+// oxlint-disable-next-line typescript/no-empty-object-type
+type IsOptional<T, K extends keyof T> = {} extends Pick<T, K> ? true : false;
+
 interface User {
   id: string;
   name: string;
@@ -99,6 +108,34 @@ type DocumentParamsReachTheirMembers = [
   MustBeTrue<Exact<ErrorsOf<ContentOf<typeof restCollection>>, object[]>>,
 ];
 
+/**
+ * Deriving a type from a document has to keep working — it is a first-class
+ * usage pattern, not just something test doubles do. All of it follows from
+ * `meta` staying OPTIONAL until a request narrows it: a required member cannot
+ * be re-declared optional by an extending interface, is not mutually assignable
+ * with a mirrored copy that kept `meta?:`, must be declared by a
+ * `class ... implements`, and survives an intersection as required.
+ */
+type MetaStaysDerivable = [
+  // optional until narrowed...
+  MustBeTrue<IsOptional<ReactiveDataDocument<User[]>, 'meta'>>,
+  MustBeTrue<IsOptional<ReactiveErrorDocument<User[]>, 'meta'>>,
+  // ...required once it is, which is what removes the `?.`
+  MustBeTrue<Exact<IsOptional<ReactiveDataDocument<User[], PageMeta>, 'meta'>, false>>,
+  MustBeTrue<Exact<ReactiveDataDocument<User[], PageMeta>['meta'], PageMeta>>,
+  // an intersection still yields an optional `meta` at the default
+  MustBeTrue<IsOptional<ReactiveDataDocument<User[]> & { meta?: PageMeta }, 'meta'>>,
+];
+
+/**
+ * Declaring this at all is the assertion: an interface cannot re-declare an
+ * inherited REQUIRED property as optional, so this fails to compile if `meta`
+ * stops being optional at the default.
+ */
+interface DerivedDocument extends ReactiveDataDocument<User[]> {
+  meta?: PageMeta;
+}
+
 const EXPECTED = [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true] as const;
 
 module('Unit | Document type params', function () {
@@ -106,8 +143,12 @@ module('Unit | Document type params', function () {
     // The real assertions are the type above: this case exists so a failure has
     // a home in the suite, and so the type is referenced rather than unused.
     const assertions: DocumentParamsReachTheirMembers = [...EXPECTED];
+    const derivable: MetaStaysDerivable = [true, true, true, true, true];
+    const derived = { meta: undefined } as DerivedDocument;
 
     assert.deepEqual(assertions, [...EXPECTED], 'both params reach every document member');
+    assert.deepEqual(derivable, [true, true, true, true, true], '`meta` stays optional until narrowed');
+    assert.equal(derived.meta, undefined, 'an extending interface may re-declare `meta` as optional');
     assert.equal(collection.method, 'GET', 'query built a GET request');
     assert.equal(resource.method, 'GET', 'findRecord built a GET request');
     assert.equal(handWritten.url, '/users', 'withReactiveResponse passed the object through');

--- a/warp-drive-packages/core/src/reactive/-private/document.ts
+++ b/warp-drive-packages/core/src/reactive/-private/document.ts
@@ -9,7 +9,6 @@ import type { RequestKey } from '../../types/identifier.ts';
 import type { ImmutableRequestInfo, RequestInfo } from '../../types/request.ts';
 import type { ResourceDocument } from '../../types/spec/document.ts';
 import type { Link, Meta, PaginationLinks } from '../../types/spec/json-api-raw.ts';
-import type { Mutable } from '../../types/utils.ts';
 import { Destroy } from './symbols.ts';
 
 function urlFromLink(link: Link): string {
@@ -106,55 +105,87 @@ export interface ReactiveDocumentBase<
 }
 
 /**
+ * The `meta` member of a reactive document.
+ *
+ * Optional when the meta type has not been narrowed — the default,
+ * `Meta | undefined`, is "any JSON object, or nothing" — and required once a
+ * request declares what its endpoint returns, so a declared key needs no `?.`.
+ *
+ * Keeping it optional at the default is what lets consumers keep deriving from
+ * these types: an interface that re-declares `meta?:`, a mirrored copy checked
+ * by mutual assignability, a `class ... implements`, an intersection with
+ * `{ meta?: X }`, and `satisfies` all continue to work.
+ *
+ * The check is `undefined extends M` and not `M extends undefined`: a naked
+ * type param on the left of a conditional distributes over the union default
+ * and yields `{ meta: Meta } | { meta?: undefined }` rather than one object
+ * type.
+ */
+type DocumentMeta<M extends Meta | undefined> = undefined extends M
+  ? {
+      /**
+       * The meta object for this document, if any.
+       *
+       * @public
+       */
+      readonly meta?: M;
+    }
+  : {
+      /**
+       * The meta object for this document.
+       *
+       * Required because the request named the shape it returns — read a
+       * documented key directly, no cast, coercion, or `?.`.
+       *
+       * ```ts
+       * type PageMeta = { page: { limit: number; offset: number }; total?: number };
+       *
+       * const { content } = await store.request(query<User, PageMeta>('user'));
+       * content.meta.total; // number | undefined, not unknown
+       * ```
+       *
+       * @public
+       */
+      readonly meta: M;
+    };
+
+/**
  * The variant of {@link ReactiveDocument} returned for a request whose
  * response contained no primary data, e.g. an error response.
  *
  * @public
  */
-export interface ReactiveErrorDocument<
+export type ReactiveErrorDocument<
   T,
   EM extends Meta | undefined = Meta | undefined,
   E extends object = object,
   M extends Meta | undefined = EM,
-> extends ReactiveDocumentBase<T, M, E, EM> {
-  /**
-   * The primary data for this document, if any.
-   *
-   * If this document has no primary data (e.g. because it is an error document)
-   * this property will be `undefined`.
-   *
-   * For collections this will be an array of record instances,
-   * for single resource requests it will be a single record instance or null.
-   *
-   * @public
-   */
-  readonly data?: undefined;
+> = ReactiveDocumentBase<T, M, E, EM> &
+  DocumentMeta<EM> & {
+    /**
+     * The primary data for this document, if any.
+     *
+     * If this document has no primary data (e.g. because it is an error document)
+     * this property will be `undefined`.
+     *
+     * For collections this will be an array of record instances,
+     * for single resource requests it will be a single record instance or null.
+     *
+     * @public
+     */
+    readonly data?: undefined;
 
-  /**
-   * The meta object for this document, if any
-   *
-   * A failed request need not carry the same `meta` a successful one does, so
-   * this document names its own meta as its second type param, just as
-   * {@link ReactiveDataDocument} does. The fourth param is the *other* arm's
-   * meta, needed only to type what `next`/`prev`/`fetch` resolve with, and it
-   * defaults to this one — the right answer for an API that returns one
-   * envelope either way.
-   *
-   * @public
-   */
-  readonly meta: EM;
-
-  /**
-   * The errors returned by the API for this request, if any
-   *
-   * The cache stores whatever the API sent without validating it, so by
-   * default this is `object` — no shape is promised. Requests that know what
-   * their endpoint returns may narrow it by supplying the `E` type param.
-   *
-   * @public
-   */
-  readonly errors: E[];
-}
+    /**
+     * The errors returned by the API for this request, if any
+     *
+     * The cache stores whatever the API sent without validating it, so by
+     * default this is `object` — no shape is promised. Requests that know what
+     * their endpoint returns may narrow it by supplying the `E` type param.
+     *
+     * @public
+     */
+    readonly errors: E[];
+  };
 
 /**
  * The variant of {@link ReactiveDocument} returned for a request whose
@@ -162,51 +193,33 @@ export interface ReactiveErrorDocument<
  *
  * @public
  */
-export interface ReactiveDataDocument<
+export type ReactiveDataDocument<
   T,
   M extends Meta | undefined = Meta | undefined,
   E extends object = object,
   EM extends Meta | undefined = M,
-> extends ReactiveDocumentBase<T, M, E, EM> {
-  /**
-   * The primary data for this document, if any.
-   *
-   * If this document has no primary data (e.g. because it is an error document)
-   * this property will be `undefined`.
-   *
-   * For collections this will be an array of record instances,
-   * for single resource requests it will be a single record instance or null.
-   *
-   * @public
-   */
-  readonly data: T;
+> = ReactiveDocumentBase<T, M, E, EM> &
+  DocumentMeta<M> & {
+    /**
+     * The primary data for this document, if any.
+     *
+     * If this document has no primary data (e.g. because it is an error document)
+     * this property will be `undefined`.
+     *
+     * For collections this will be an array of record instances,
+     * for single resource requests it will be a single record instance or null.
+     *
+     * @public
+     */
+    readonly data: T;
 
-  /**
-   * The meta object for this document, if any
-   *
-   * By default this is {@link Meta}, an arbitrary JSON object. Requests that
-   * know the shape of the `meta` their endpoint returns may narrow it by
-   * supplying the `M` type param, in which case reading a documented key
-   * requires no cast or coercion.
-   *
-   * ```ts
-   * type PageMeta = { page: { limit: number; offset: number }; total?: number };
-   *
-   * const { content } = await store.request(query<User, PageMeta>('user'));
-   * content.meta?.total; // number | undefined, not unknown
-   * ```
-   *
-   * @public
-   */
-  readonly meta: M;
-
-  /**
-   * The errors returned by the API for this request, if any
-   *
-   * @public
-   */
-  readonly errors?: undefined;
-}
+    /**
+     * The errors returned by the API for this request, if any
+     *
+     * @public
+     */
+    readonly errors?: undefined;
+  };
 
 interface PrivateReactiveDocument {
   /** @internal */
@@ -329,7 +342,16 @@ const ReactiveDocumentProto = {
     this: ReactiveDocument<T, M, E, EM>
   ): object {
     upgradeThis(this);
-    const data: Mutable<Partial<ReactiveDocument<T, M, E, EM>>> = {};
+    // Spelled out rather than `Partial<ReactiveDocument<…>>`: the document is a
+    // union of intersections, and `Partial` over that distributes into per-arm
+    // indexed accesses that no single accumulator satisfies.
+    const data: {
+      identifier?: RequestKey | null;
+      data?: T;
+      links?: PaginationLinks;
+      errors?: E[];
+      meta?: M | EM;
+    } = {};
     data.identifier = this.identifier;
     if (this.data !== undefined) {
       data.data = this.data;


### PR DESCRIPTION
Follow-up to #11043, which is merged.

### The problem

#11043 made `meta` a required member (`meta: M`, constraint widened to `Meta | undefined`) so that a request declaring its meta reads `content.meta.total` without a `?.`. That part works and is worth keeping.

But required-vs-optional is not only about reading an instance. It changes every way of **deriving** a type from a document, and deriving from these types is a first-class pattern — apps build their own document types on top of them. All five of these regressed:

| Pattern | After #11043 |
| --- | --- |
| `interface MyDoc extends ReactiveDataDocument<…> { meta?: X }` | ❌ `TS2430` — cannot re-declare an inherited required member as optional |
| A mirrored copy that kept `meta?:`, checked by mutual assignability | ❌ no longer matches, so a drift-detecting conformance assert fires |
| `class X implements ReactiveDataDocument<…>` | ❌ must declare `meta` |
| `ReactiveDataDocument<…> & { meta?: X }` | ❌ intersection no longer yields an optional `meta` |
| `{ … } satisfies ReactiveDataDocument<…>` | ❌ fails without a `meta` key |

None of this showed up in CI because nothing in this repo derives from these types — the only `check:types` failures on that PR were read-type assertions in its own two test files. That made the change look free when it was not.

### The fix

```ts
type DocumentMeta<M extends Meta | undefined> = undefined extends M
  ? { readonly meta?: M }
  : { readonly meta: M };
```

Optional when `M` has not been narrowed, required once it has. Both properties hold at once — the default stays derivable, and a request that names its meta keeps the `?.`-free read that #11043 was after.

```ts
declare const defaulted: ReactiveDataDocument<User[]>;
defaulted.meta?.total; // still narrows, still derivable

declare const declared: ReactiveDataDocument<User[], PageMeta>;
declared.meta.total; // still no `?.`
```

### Two things worth knowing

**`undefined extends M`, not `M extends undefined`.** A naked type param on the left of a conditional distributes over the union default, so `M extends undefined ? … : …` at `Meta | undefined` produces `{ meta: Meta } | { meta?: undefined }` — a union rather than one object type. The non-distributive form gives a single object type.

**An interface cannot extend a conditional type** (`TS2312`), so `ReactiveDataDocument` and `ReactiveErrorDocument` become type aliases intersecting `DocumentMeta`. Nothing in the repo extended them, but this does cost declaration merging on those two names — flagging it as the one real tradeoff here.

`toJSON`'s accumulator is spelled out rather than `Partial<ReactiveDocument<…>>`, which distributes into per-arm indexed accesses that no single accumulator satisfies once the arms are intersections.

### Tests

`tests/utilities/tests/unit/document-type-params-test.ts` gains an `IsOptional` helper and a `MetaStaysDerivable` block asserting the member is optional at the default on both arms, required once narrowed, and still optional through an intersection. `DerivedDocument` — an interface extending a document and re-declaring `meta?:` — is itself the assertion for the `TS2430` case: it fails to compile if `meta` stops being optional.

Verified load-bearing: forcing `DocumentMeta` down the required branch fails `check:types` in six places, including `DerivedDocument` with `TS2430`.

### Verification

- `pnpm check:types` — 83/83
- `pnpm lint:oxlint` and `pnpm lint:oxfmt` clean
- `utilities-tests`, `core-tests`, `@warp-drive/legacy-tests`, `json-api`, `main-test-app` — 38/38 tasks, 5876 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
