### PR TITLE
feat(experiments): expose reactive storage as `@warp-drive/experiments/storage`

### DIFF
--- a/guides/the-manual/experiments/storage-resources.md
+++ b/guides/the-manual/experiments/storage-resources.md
@@ -22,7 +22,7 @@ class SiteTheme {
 ```
 
 ```ts [Decorated]
-import { LocalResource, field } from '@warp-drive/experiments/storage/resource';
+import { LocalResource, field } from '@warp-drive/experiments/storage';
 
 @LocalResource('site-theme')
 export class SiteTheme {
@@ -58,7 +58,7 @@ Storage Resources are either a `LocalResource` (backed by localStorage) or a Ses
 ::: code-group
 
 ```ts [LocalResource]
-import { LocalResource, field } from '@warp-drive/experiments/storage/resource';
+import { LocalResource, field } from '@warp-drive/experiments/storage';
 
 @LocalResource('home-page')
 export class HomePage {
@@ -67,7 +67,7 @@ export class HomePage {
 ```
 
 ```ts [SessionResource]
-import { SessionResource, field } from '@warp-drive/experiments/storage/resource';
+import { SessionResource, field } from '@warp-drive/experiments/storage';
 
 @SessionResource('home-page')
 export class HomePage {
@@ -85,7 +85,7 @@ field configuration achieved using both a LocalResource and a SessionResource.
 ::: code-group
 
 ```ts [LocalResource]
-import { LocalResource, field } from '@warp-drive/experiments/storage/resource';
+import { LocalResource, field } from '@warp-drive/experiments/storage';
 
 @LocalResource('home-page')
 export class HomePage {
@@ -95,7 +95,7 @@ export class HomePage {
 ```
 
 ```ts [SessionResource]
-import { SessionResource, field } from '@warp-drive/experiments/storage/resource';
+import { SessionResource, field } from '@warp-drive/experiments/storage';
 
 @SessionResource('home-page')
 export class HomePage {
@@ -164,7 +164,7 @@ Ideally, field values should be primitives (`string` `number` `boolean` `null`),
 Default values are provided via the field initializer.
 
 ```ts
-import { LocalResource, field } from '@warp-drive/experiments/storage/resource';
+import { LocalResource, field } from '@warp-drive/experiments/storage';
 
 @LocalResource('home-page')
 export class HomePage {
@@ -201,7 +201,7 @@ But this involves manually wiring up the effect in a different file, which may n
 Instead, we can change our field into an `effect`.
 
 ```ts
-import { LocalResource, field } from '@warp-drive/experiments/storage/resource';
+import { LocalResource, field } from '@warp-drive/experiments/storage';
 
 @LocalResource('settings')
 export class HomePage {
@@ -230,7 +230,7 @@ resource key and setting our default values.
 
 ```gts
 import Component from '@glimmer/component';
-import { SessionResource, field } from '@warp-drive/experiments/storage/resource';
+import { SessionResource, field } from '@warp-drive/experiments/storage';
 
 interface LocationSignature {
   Args: {
@@ -254,7 +254,7 @@ regular classes.
 
 ```ts
 import Service from '@ember/service';
-import { LocalResource, field } from '@warp-drive/experiments/storage/resource';
+import { LocalResource, field } from '@warp-drive/experiments/storage';
 
 @LocalResource('route-history')
 export class HistoryService extends Service {
@@ -375,7 +375,7 @@ Configure storage behavior before first use:
 import {
   configureLocalStorage,
   configureSessionStorage
-} from '@warp-drive/experiments/storage/storage';
+} from '@warp-drive/experiments/storage';
 
 configureLocalStorage({
   // Fallback to in-memory storage in private browsing mode

--- a/warp-drive-packages/experiments/package.json
+++ b/warp-drive-packages/experiments/package.json
@@ -12,6 +12,10 @@
   "homepage": "https://github.com/warp-drive-data/warp-drive",
   "bugs": "https://github.com/warp-drive-data/warp-drive/issues",
   "exports": {
+    "./storage": {
+      "types": "./dist/storage.d.ts",
+      "default": "./dist/storage.js"
+    },
     "./document-storage": {
       "types": "./dist/document-storage.d.ts",
       "default": "./dist/document-storage.js"

--- a/warp-drive-packages/experiments/src/storage.ts
+++ b/warp-drive-packages/experiments/src/storage.ts
@@ -4,4 +4,5 @@ export * from './storage/storage-resource.ts';
 export type * from './storage/storage-resource.ts';
 export * from './storage/cache.ts';
 export type * from './storage/cache.ts';
+export type { KeyFn, ValueTransition } from './storage/-private/storage-infra.ts';
 export { initMeta as _initMeta, getParamCompanion as _getParamCompanion } from './storage/-private/storage-infra.ts';


### PR DESCRIPTION
The reactive storage primitives are built and shipped, but not reachable.

`./src/storage.ts` has been an entry point in `tsdown.config.mjs` since they landed, so `dist/storage.js` and `dist/storage.d.ts` are produced and included in `files` — but `package.json`'s `exports` never gained a matching key. Unlike `@warp-drive/core`, that map has no `./*` wildcard, so `import { LocalResource } from '@warp-drive/experiments/storage'` fails to resolve.

## Changes

**Add the `./storage` export entry**, pointing at the `dist` output the existing tsdown entry point already produces.

**Re-export `KeyFn` and `ValueTransition` from the barrel.** Both appear in public signatures — `LocalResource(id: string | KeyFn)`, `SessionResource`, `CacheResource`, and `effect(fn: <K>(update: ValueTransition<K>) => void, ...)` — but are declared only in `-private/storage-infra.ts`, so a consumer writing a typed wrapper or an `effect` callback had no way to name them.

**Point the Storage Resources guide at the real specifier.** It imports from `@warp-drive/experiments/storage/resource` (9 places) and `@warp-drive/experiments/storage/storage` (1 place). Neither subpath exists — everything is one barrel.

## Verification

Local `pnpm install` can't complete in this environment (`turbo` fails to spawn child processes, so the `prepare` build never runs and `@warp-drive/core` has no `dist`), which blocks the package's own `check:types` and the type-aware `oxlint` pass. To get real signal on the change I ran `tsc` over `src/storage.ts` + `src/storage/**` with `@warp-drive/core/build-config/macros` and `@warp-drive/core/signals/-leaked` mapped to hand-written declarations matching their real signatures, keeping the package's own `tsconfig.json` (`isolatedDeclarations`, `erasableSyntaxOnly`, `strict`):

- `tsc`: clean — and confirmed the harness was live by introducing a deliberate error and seeing it reported
- `oxfmt --check`: clean
- `oxlint` (non-type-aware): clean
- `package.json` parses as valid JSON

CI will be the first full build/typecheck of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHtYF43AbjT1jb7bsZQuoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHtYF43AbjT1jb7bsZQuoC)_