### PR TITLE
feat(experiments): export `initializeFields` from the storage barrel

### DIFF
--- a/warp-drive-packages/experiments/src/storage.ts
+++ b/warp-drive-packages/experiments/src/storage.ts
@@ -7,4 +7,8 @@ export type * from './storage/cache.ts';
 export * from './storage/query-params.ts';
 export type * from './storage/query-params.ts';
 export type { KeyFn, ValueTransition } from './storage/-private/storage-infra.ts';
-export { initMeta as _initMeta, getParamCompanion as _getParamCompanion } from './storage/-private/storage-infra.ts';
+export {
+  initMeta as _initMeta,
+  getParamCompanion as _getParamCompanion,
+  initializeFields as _initializeFields,
+} from './storage/-private/storage-infra.ts';


### PR DESCRIPTION
`initializeFields` came across with the rest of the reactive storage primitives and lives in `-private/storage-infra.ts`, but was never re-exported from `src/storage.ts`. Nothing outside the private module referenced it, so the bundler tree-shook it right back out:

```
$ grep -c initializeFields node_modules/@warp-drive/experiments/dist/storage.js   # 5.10.0-alpha.2
0
```

It's absent from the emitted types too, so there is no path for a consumer to reach it.

## Change

One line — export it as `_initializeFields`, matching the convention the barrel already uses for the other `-private` internals it surfaces (`_initMeta`, `_getParamCompanion`).

`initializeFields` seeds a resource's fields from an external source during multi-directional instantiation, where storage, the URL, and a constructor argument can all race to supply the same value. Its structure is deliberate — it writes through to storage before deciding whether the field itself should be updated, so the persisted side is synchronized even when the field keeps its existing value. No behavior change here; this only makes it reachable.

## Verification

- `dist/storage.js` now contains the function, and `dist/storage.d.ts` exports `_initializeFields`
- `tests/experiments` 25/25 passing
- `check:types` clean across the package and the test app
- `oxlint` (type-aware) and `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHtYF43AbjT1jb7bsZQuoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHtYF43AbjT1jb7bsZQuoC)_