### PR TITLE
fix(release): mirror the WarpDrive global-config key regardless of quote style

### DIFF
--- a/tools/release/core/publish/steps/generate-mirror-tarballs.ts
+++ b/tools/release/core/publish/steps/generate-mirror-tarballs.ts
@@ -78,10 +78,12 @@ export async function generateMirrorTarballs(
           newContents = newContents.replace(new RegExp(`"${from}`, 'g'), `"${to}`);
         }
 
-        // macros.globalConfig['WarpDrive']
-        // macros.setGlobalConfig(import.meta.filename, 'WarpDrive', finalizedConfig);
+        // Both quote styles, because the emitted quote style is not ours to control:
+        //   macros.setGlobalConfig(import.meta.filename, "WarpDrive", finalizedConfig)
+        //   macros.globalConfig["WarpDrive"]
+        //   types.identifier("WarpDrive")  <- emitted by the babel-plugin-transform-* files
         if (strat.name === '@warp-drive/build-config') {
-          newContents = newContents.replace(new RegExp(`'WarpDrive'`, 'g'), `'WarpDriveMirror'`);
+          newContents = newContents.replace(/(['"])WarpDrive\1/g, '$1WarpDriveMirror$1');
         }
 
         newContents = newContents.replace(/getGlobalConfig\(\)\.WarpDrive\./g, 'getGlobalConfig().WarpDriveMirror.');


### PR DESCRIPTION
Every published `@warp-drive-mirror/*` since `5.9.0-alpha.20` is unbuildable by consumers. One line in the mirror tarball generator stopped matching.

## What's wrong

`generate-mirror-tarballs.ts` rewrites the embroider global-config key inside `@warp-drive/build-config` so the mirror gets its own namespace:

```js
// before
newContents = newContents.replace(new RegExp(`'WarpDrive'`, 'g'), `'WarpDriveMirror'`);
```

That matches **single quotes only**. Since the tsdown/rolldown build migration the emitted literals are double-quoted, so it silently matches nothing. Measured against the real published tarballs:

| `@warp-drive/build-config` | sites the old regex rewrites |
|---|---|
| `5.9.0-alpha.8` | 9 |
| `5.10.0-alpha.3` | **0** |

The reader rewrite on the very next line uses `/getGlobalConfig\(\)\.WarpDrive\./` — unquoted member access, so it is quote-agnostic and kept working. That asymmetry is the bug: the published mirror ends up with a `build-config` that **writes** the config under `WarpDrive`, while its prebuilt runtime packages **read** `WarpDriveMirror`.

```
@warp-drive-mirror/build-config@5.10.0-alpha.3/dist/index.js:292
  macros.setGlobalConfig(import.meta.filename, "WarpDrive", finalizedConfig);

@warp-drive-mirror/utilities@5.10.0-alpha.3/dist/index.js:55
  macroCondition(getGlobalConfig().WarpDriveMirror.env.DEBUG) && ...
```

`WarpDriveMirror` is never defined, so any app bundling the mirror dies at build time:

```
TypeError: Cannot read properties of undefined (reading 'env')
  at get value (@embroider/macros/src/babel/evaluate-json.js:135:57)
  at macroCondition (@embroider/macros/src/babel/macro-condition.js:50:44)
  [plugin embroider:maybe-babel] @warp-drive-mirror/utilities/dist/index.js
```

The string `WarpDriveMirror` appears nowhere in `@warp-drive-mirror/build-config@5.10.0-alpha.3`'s `dist/`. At `5.9.0-alpha.8` it appears 9 times.

## The fix

```js
newContents = newContents.replace(/(['"])WarpDrive\1/g, '$1WarpDriveMirror$1');
```

Backreferenced quote, so it handles either style and preserves it. Same nine sites as `5.9.0-alpha.8`: the two `setGlobalConfig` calls, the two `globalConfig["WarpDrive"]` guards, and five `types.identifier("WarpDrive")` calls in the `babel-plugin-transform-{asserts,logging,features,deprecations}` files — those last five emit the reader expressions, so they need mirroring too, not just the writer.

I also expanded the comment above it, since the stale single-quoted example is what made this invisible.

## Verification

Applied both regexes to the actual `5.10.0-alpha.3` tarball: old = 0 matches, new = 11 (9 in code, plus 2 I should flag below).

Then, end to end in a real consumer (a private Ember monorepo pinned to the mirror via an aggregator package). Patched **only** the config key in `node_modules`, changed nothing else:

| | before | after |
|---|---|---|
| `libraries/data` test-app build | 11 macro errors, exit 1 | ✓ 976 modules, 1.72s |
| `libraries/data` QUnit | never ran | **504 / 504 pass** |
| `libraries/client-core` test-app build | same failure | ✓ exit 0 |
| `libraries/client-core` QUnit | never ran | **339 / 339 pass** |

So this key is the only thing standing between that app and `5.10.0-alpha.3` — 843 tests green behind it, no other canary breakage.

## One thing to decide

The new regex also rewrites 2 non-code hits: `alt="WarpDrive"` and `title="WarpDrive"` in the mirror package's own `README.md` logo block. The old single-quote regex never touched them. It's cosmetic and arguably more accurate for the mirror, but it is collateral — happy to scope the replace to non-markdown files if you'd rather keep the diff inert there.

Also worth saying: if #10537 lands and `getGlobalConfig().WarpDrive` goes away for a WarpDrive-owned `getConfig()`, this whole replace becomes moot — but the mirror generator's replace list will need the equivalent treatment for whatever replaces it.

I have not run the release pipeline itself (no publish credentials, and it only runs on release), so this is verified by regex-against-real-tarballs plus the consumer-side proof above rather than by generating a mirror tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
