### PR TITLE
fix(utilities): stop mutating caller-supplied params when sorting query params

### DIFF
--- a/guides/the-manual/requests/builders.md
+++ b/guides/the-manual/requests/builders.md
@@ -219,4 +219,10 @@ enough, and when it is not the following utilities will come in handy:
 - [buildQueryParams](/api/@warp-drive/utilities/functions/buildQueryParams)
 - [filterEmpty](/api/@warp-drive/utilities/functions/filterEmpty)
 
+:::tip 💡 TIP
+All three sort and filter *copies*. The params you hand them are never mutated, so it is safe to
+pass state you also render — a tracked array of filter values, say — without the act of building a
+request reordering what the user sees.
+:::
+
 

--- a/tests/utilities/tests/unit/build-query-params-test.ts
+++ b/tests/utilities/tests/unit/build-query-params-test.ts
@@ -1,4 +1,4 @@
-import { buildQueryParams } from '@ember-data/request-utils';
+import { buildQueryParams, sortQueryParams } from '@ember-data/request-utils';
 import { module, test } from '@warp-drive/diagnostic';
 
 module('buildQueryParams', function (hooks) {
@@ -134,5 +134,64 @@ module('buildQueryParams', function (hooks) {
       'baz=d%2Ce%2Cf&foo=a%2Cb%2Cc',
       `buildQueryParams works`
     );
+  });
+
+  test('It does not reorder the arrays it was given', function (assert) {
+    const foo = ['c', 'b', 'a'];
+    const baz = ['f', 'd', 'e'];
+
+    assert.equal(buildQueryParams({ foo, baz }), 'baz=d%2Ce%2Cf&foo=a%2Cb%2Cc', `buildQueryParams works`);
+
+    assert.deepEqual(foo, ['c', 'b', 'a'], `foo was not sorted in place`);
+    assert.deepEqual(baz, ['f', 'd', 'e'], `baz was not sorted in place`);
+  });
+
+  test('It does not reorder the arrays it was given for non-comma arrayFormats', function (assert) {
+    for (const arrayFormat of ['bracket', 'indices', 'repeat', 'comma'] as const) {
+      const foo = ['c', 'b', 'a'];
+
+      buildQueryParams({ foo }, { arrayFormat });
+
+      assert.deepEqual(foo, ['c', 'b', 'a'], `foo was not sorted in place for arrayFormat '${arrayFormat}'`);
+    }
+  });
+
+  test('It does not mutate the object it was given', function (assert) {
+    const params = { include: 'foo,bar', foo: ['c', 'b', 'a'] };
+
+    assert.equal(buildQueryParams(params), 'foo=a%2Cb%2Cc&include=bar%2Cfoo', `buildQueryParams works`);
+
+    assert.deepEqual(
+      params,
+      { include: 'foo,bar', foo: ['c', 'b', 'a'] },
+      `the source object was not mutated, include is still a string`
+    );
+  });
+
+  test('It does not reorder an include array it was given', function (assert) {
+    const include = ['foo', 'bar'];
+
+    assert.equal(buildQueryParams({ include }), 'include=bar%2Cfoo', `buildQueryParams works`);
+
+    assert.deepEqual(include, ['foo', 'bar'], `include was not sorted in place`);
+  });
+
+  test('sortQueryParams does not mutate the object it was given', function (assert) {
+    const foo = ['c', 'b', 'a'];
+    const params = { include: 'foo,bar', foo };
+
+    assert.equal(sortQueryParams(params).toString(), 'foo=a%2Cb%2Cc&include=bar%2Cfoo', `sortQueryParams works`);
+
+    assert.deepEqual(foo, ['c', 'b', 'a'], `foo was not sorted in place`);
+    assert.equal(params.include, 'foo,bar', `include is still the string it was`);
+  });
+
+  test('It produces the same output when called repeatedly with the same source', function (assert) {
+    const params = { include: 'foo,bar', foo: ['c', 'b', 'a'] };
+
+    const first = buildQueryParams(params);
+    const second = buildQueryParams(params);
+
+    assert.equal(first, second, `buildQueryParams is stable across calls`);
   });
 });

--- a/warp-drive-packages/legacy/src/compat/legacy-network-handler/fetch-manager.ts
+++ b/warp-drive-packages/legacy/src/compat/legacy-network-handler/fetch-manager.ts
@@ -340,8 +340,10 @@ function includesSatisfies(current: undefined | string | string[], existing: und
     return false;
   }
 
-  const arrCurrent = (Array.isArray(current) ? current : current.split(',')).sort();
-  const arrExisting = (Array.isArray(existing) ? existing : existing.split(',')).sort();
+  // toSorted for the array branch: these arrays belong to the request options
+  // the caller passed us, sorting them in place would reorder their state.
+  const arrCurrent = Array.isArray(current) ? current.toSorted() : current.split(',').sort();
+  const arrExisting = Array.isArray(existing) ? existing.toSorted() : existing.split(',').sort();
 
   // includes are identical
   if (arrCurrent.join(',') === arrExisting.join(',')) {

--- a/warp-drive-packages/utilities/src/-private/json-api/-utils.ts
+++ b/warp-drive-packages/utilities/src/-private/json-api/-utils.ts
@@ -212,7 +212,9 @@ export function buildQueryParams(query: JsonApiQuery | QueryParamsSource): strin
 
       // fields: { 'company': ['field1', 'field2'] }
       if (Array.isArray(value)) {
-        finalQuery[`fields[${resourceType}]`] = value.sort().join(',');
+        // toSorted: `value` belongs to the caller, sorting it in place would
+        // reorder whatever else they are doing with it
+        finalQuery[`fields[${resourceType}]`] = value.toSorted().join(',');
 
         // fields: { 'company': 'field1' }
         // fields: { 'company': 'field1,field2' }

--- a/warp-drive-packages/utilities/src/index.ts
+++ b/warp-drive-packages/utilities/src/index.ts
@@ -645,6 +645,10 @@ export function filterEmpty(source: Record<string, Serializable>): Record<string
  *
  * Treats `included` specially, splicing it into an array if it is a string and sorting the array.
  *
+ * The `params` given are never mutated: neither the object itself nor any array
+ * value it holds is reordered or replaced, so passing state that is also
+ * rendered (a tracked array of filter values, for instance) is safe.
+ *
  * Options:
  * - arrayFormat: 'bracket' | 'indices' | 'repeat' | 'comma'
  *
@@ -660,7 +664,10 @@ export function sortQueryParams(params: QueryParamsSource, options?: QueryParams
   const opts = Object.assign({}, DEFAULT_QUERY_PARAMS_SERIALIZATION_OPTIONS, options);
   const paramsIsObject = !(params instanceof URLSearchParams);
   const urlParams = new URLSearchParams();
-  const dictionaryParams: Record<string, Serializable> = paramsIsObject ? params : {};
+  // shallow copy so that normalizing `include` below does not write back onto
+  // the caller's object. Array values are still shared with the caller, so
+  // everything downstream must sort copies rather than sorting in place.
+  const dictionaryParams: Record<string, Serializable> = paramsIsObject ? Object.assign({}, params) : {};
 
   if (!paramsIsObject) {
     params.forEach((value, key) => {
@@ -686,26 +693,26 @@ export function sortQueryParams(params: QueryParamsSource, options?: QueryParams
   sortedKeys.forEach((key) => {
     const value = dictionaryParams[key];
     if (Array.isArray(value)) {
-      value.sort();
+      const sortedValue = value.toSorted();
       switch (opts.arrayFormat) {
         case 'indices':
-          value.forEach((v, i) => {
+          sortedValue.forEach((v, i) => {
             urlParams.append(`${key}[${i}]`, String(v));
           });
           return;
         case 'bracket':
-          value.forEach((v) => {
+          sortedValue.forEach((v) => {
             urlParams.append(`${key}[]`, String(v));
           });
           return;
         case 'repeat':
-          value.forEach((v) => {
+          sortedValue.forEach((v) => {
             urlParams.append(key, String(v));
           });
           return;
         case 'comma':
         default:
-          urlParams.append(key, value.join(','));
+          urlParams.append(key, sortedValue.join(','));
           return;
       }
     } else {
@@ -720,6 +727,10 @@ export function sortQueryParams(params: QueryParamsSource, options?: QueryParams
  * Sorts query params by both key and value, returning a query params string
  *
  * Treats `included` specially, splicing it into an array if it is a string and sorting the array.
+ *
+ * The `params` given are never mutated: neither the object itself nor any array
+ * value it holds is reordered or replaced, so passing state that is also
+ * rendered (a tracked array of filter values, for instance) is safe.
  *
  * Options:
  * - arrayFormat: 'bracket' | 'indices' | 'repeat' | 'comma'


### PR DESCRIPTION
## The problem

`sortQueryParams` mutates the object it is given, in two ways:

1. **Array values are sorted in place.** `value.sort()` reorders the caller's array.
2. **`include` is coerced on the source object.** `dictionaryParams.include = handleInclude(...)` replaces a caller's `include: 'a,b'` string with `['a', 'b']`, because `dictionaryParams` *is* `params` when `params` isn't a `URLSearchParams`.

Both are observable from an app. Building a request is supposed to be a read of state, but today it writes to it:

```ts
@tracked filters = ['foo', 'bar', 'baz'];

makeQuery = () => {
  return this.store.request(query('boop', { 'filter[name][in]': this.filters }));
};

<template>
  <List @list={{this.filters}} />
  <Button {{on 'click' this.makeQuery}}>Click to fetch based on the list!</Button>
</template>
```

Clicking the button re-orders the rendered list.

## The fix

`sortQueryParams` shallow-copies the source object before normalizing `include`, and sorts array values with `toSorted()` instead of `sort()`.

Two more instances of the same pattern come along:

| Location | Was | Now |
| --- | --- | --- |
| `utilities/src/index.ts` — `sortQueryParams` | mutated `params` and each array value | copies the object, `toSorted()` per value |
| `utilities/src/-private/json-api/-utils.ts` — `buildQueryParams` | `value.sort()` on each `fields[type]` array | `value.toSorted()` |
| `legacy/…/fetch-manager.ts` — `includesSatisfies` | `(Array.isArray(x) ? x : x.split(',')).sort()` sorted caller arrays in place | `Array.isArray(x) ? x.toSorted() : x.split(',').sort()` |

The `fetch-manager` form is deliberately split rather than blanket-`toSorted`: the string branch is sorting the array `split(',')` just allocated, so there is nothing to protect and no reason to allocate twice.

`toSorted` is safe for the build targets here — the ESM builds target `esnext, firefox121` (`toSorted` landed in Firefox 115) and the only CJS bundle in `@warp-drive/utilities`, which targets `node18`, has `./src/string.ts` as its sole entry point and does not include any of this code.

## Tests

New cases in `tests/utilities/tests/unit/build-query-params-test.ts`:

- array values are not reordered (default `comma` format, and each of `bracket` / `indices` / `repeat` / `comma`)
- a string `include` is still a string on the source object afterwards
- an array `include` is not reordered
- `sortQueryParams` directly, not just through `buildQueryParams`
- repeated calls against the same source produce identical output

`pnpm --filter @warp-drive/utilities-tests test` → 105 pass / 0 fail. `check:types` clean for `utilities`, `legacy`, and `tests/utilities`; `lint:oxfmt` and `lint:oxlint` clean.

## Docs

The non-mutation guarantee is now stated in the `sortQueryParams` and `buildQueryParams` docblocks and in the "stable RequestKey" section of the builders guide, since "is it safe to pass my tracked array to this?" is exactly the question the guarantee answers.

## Context

From discussion in Slack: this was originally raised as "should this be `toSorted`?", with the counter-argument being array allocation. Chris landed on `toSorted` on reflection — none of these are hot paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
