### PR TITLE
feat: lint rules requiring an error block on `<Request>`/`<Await>`

### DIFF
--- a/guides/linting/index.md
+++ b/guides/linting/index.md
@@ -38,6 +38,14 @@ what exposes template nodes to ESLint as `Glimmer`-prefixed selectors (e.g. `Gli
 [First-Class Component Templates RFC](https://rfcs.emberjs.com/id/0779-first-class-component-templates/#linting-and-formatting)
 for integrating template linting into ESLint.
 
+## React Rules
+
+React rules operate on the JSX AST rather than the JS/TS AST or the Glimmer template AST used by
+the rules above. They don't require any special parser dependency beyond enabling JSX parsing --
+ESLint's default parser (or `@typescript-eslint/parser` for `.tsx` files) already exposes plain
+`JSX*`-prefixed selectors (e.g. `JSXElement`, `JSXOpeningElement`) once
+`parserOptions.ecmaFeatures.jsx` is enabled.
+
 ## Usage
 
 Recommended Rules are available as a flat config for easy consumption:
@@ -45,8 +53,12 @@ Recommended Rules are available as a flat config for easy consumption:
 ```ts
 // eslint.config.js (flat config)
 const WarpDriveRecommended = require('eslint-plugin-warp-drive/recommended');
+const WarpDriveTemplateRecommended = require('eslint-plugin-warp-drive/recommended-templates');
+const WarpDriveReactRecommended = require('eslint-plugin-warp-drive/recommended-react');
 
 module.exports = [
   ...WarpDriveRecommended,
+  ...WarpDriveTemplateRecommended,
+  ...WarpDriveReactRecommended,
 ];
 ```

--- a/packages/eslint-plugin-warp-drive/README.md
+++ b/packages/eslint-plugin-warp-drive/README.md
@@ -71,6 +71,19 @@ for integrating template linting into ESLint.
 | Rule | Description | 🏷️ | ✨ |
 | ---- | ----------- | -- | -- |
 | [template-always-use-request-content](./docs/template-always-use-request-content.md) | Ensures the result of a `<Request>` is actually consumed | 🐞 | |
+| [template-require-request-error-block](./docs/template-require-request-error-block.md) | Ensures `<Request>`/`<Await>` always provide an `:error` block | 🐞 | |
+
+## React Rules
+
+React rules operate on the JSX AST rather than the Glimmer template AST used by the `template-*`
+rules above. They don't require any special parser dependency beyond enabling JSX parsing --
+ESLint's default parser (or `@typescript-eslint/parser` for `.tsx` files) already exposes plain
+`JSX*`-prefixed nodes (e.g. `JSXElement`, `JSXOpeningElement`) once `parserOptions.ecmaFeatures.jsx`
+is enabled.
+
+| Rule | Description | 🏷️ | ✨ |
+| ---- | ----------- | -- | -- |
+| [require-request-error-block](./docs/require-request-error-block.md) | Ensures `<Request>` is always given a `states.error` handler | 🐞 | |
 
 ## Usage
 
@@ -102,3 +115,17 @@ module.exports = [
 To lint classic `.hbs` files instead of (or in addition to) `.gjs`/`.gts`, add your own override
 using [`ember-eslint-parser/hbs`](https://github.com/NullVoxPopuli/ember-eslint-parser#hbs-handlebars-support)
 as the parser for `**/*.hbs`.
+
+React rules are also available as a separate flat config, since they additionally wire up JSX
+parsing for `.jsx`/`.tsx` files:
+
+```ts
+// eslint.config.js (flat config)
+const WarpDriveRecommended = require('eslint-plugin-warp-drive/recommended');
+const WarpDriveReactRecommended = require('eslint-plugin-warp-drive/recommended-react');
+
+module.exports = [
+  ...WarpDriveRecommended,
+  ...WarpDriveReactRecommended,
+];
+```

--- a/packages/eslint-plugin-warp-drive/package.json
+++ b/packages/eslint-plugin-warp-drive/package.json
@@ -18,6 +18,9 @@
     },
     "./recommended-templates": {
       "default": "./src/recommended-templates.js"
+    },
+    "./recommended-react": {
+      "default": "./src/recommended-react.js"
     }
   },
   "dependencies": {

--- a/packages/eslint-plugin-warp-drive/src/recommended-react.js
+++ b/packages/eslint-plugin-warp-drive/src/recommended-react.js
@@ -1,0 +1,27 @@
+const warpdrive = require('./index');
+
+/**
+ * React rules operate on the JSX AST rather than the JS/TS AST used by `./recommended`
+ * or the Glimmer template AST used by `./recommended-templates`. This config enables
+ * JSX parsing for `.jsx`/`.tsx` files and turns on the recommended React rules.
+ *
+ * @type {import('eslint').Linter.Config[]}
+ */
+module.exports = [
+  {
+    plugins: {
+      'warp-drive': warpdrive,
+    },
+  },
+  {
+    files: ['**/*.{jsx,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {
+      'warp-drive/require-request-error-block': 'error',
+    },
+  },
+];

--- a/packages/eslint-plugin-warp-drive/src/recommended-templates.js
+++ b/packages/eslint-plugin-warp-drive/src/recommended-templates.js
@@ -25,6 +25,7 @@ module.exports = [
     },
     rules: {
       'warp-drive/template-always-use-request-content': 'error',
+      'warp-drive/template-require-request-error-block': 'error',
     },
   },
 ];

--- a/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.js
@@ -71,9 +71,7 @@ module.exports = {
         if (!expression || expression.type !== 'ObjectExpression') return;
 
         const hasSpread = expression.properties.some((property) => property.type === 'SpreadElement');
-        const errorProperty = expression.properties.find(
-          (property) => getPropertyKeyName(property) === 'error'
-        );
+        const errorProperty = expression.properties.find((property) => getPropertyKeyName(property) === 'error');
 
         if (errorProperty) {
           // A property explicitly named `error` was found; only flag it if it's a bare

--- a/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.js
@@ -1,0 +1,95 @@
+/**
+ * {@include ./require-request-error-block.md}
+ * @module
+ */
+'use strict';
+
+const REQUEST_TAG = 'Request';
+
+const messages = {
+  noStatesAttribute:
+    '<Request> requires a `states` prop with an `error` handler. If this is not provided, and ' +
+    "the request's error is thrown and can crash the app. Add a `states` prop with a `states.error` " +
+    'handler to <Request>.',
+  noErrorState:
+    '<Request> requires a `states.error` handler. Without one, if the request rejects, the error ' +
+    'is thrown and can crash the app. Add an `error` key to the `states` object passed to <Request>.',
+};
+
+/**
+ * Returns the key name of an ObjectExpression `Property`, whether declared as an
+ * identifier (`{ error }` / `{ error: ... }`) or a string literal (`{ 'error': ... }`).
+ *
+ * @param {object} property
+ * @returns {string | undefined}
+ */
+function getPropertyKeyName(property) {
+  if (property.type !== 'Property') return undefined;
+  if (property.computed) return undefined;
+  if (property.key.type === 'Identifier') return property.key.name;
+  if (property.key.type === 'Literal' && typeof property.key.value === 'string') return property.key.value;
+  return undefined;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensures <Request> is always given a states.error handler',
+      category: 'Possible Errors',
+      recommended: false,
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/require-request-error-block.md',
+    },
+    schema: [],
+    messages,
+  },
+
+  create(context) {
+    // This rule operates on the plain ESTree JSX AST (`JSXElement`/`JSXOpeningElement`/
+    // `JSXAttribute`/`JSXExpressionContainer`/`ObjectExpression`/`Property`/`SpreadElement`)
+    // rather than the Glimmer template AST used by the sibling `template-*` rules -- React's
+    // `<Request>` doesn't use named template blocks, so the `error` handler is a plain
+    // property on the `states` prop's object literal instead.
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.type !== 'JSXIdentifier' || node.name.name !== REQUEST_TAG) return;
+
+        const statesAttribute = node.attributes.find(
+          (attribute) => attribute.type === 'JSXAttribute' && attribute.name.name === 'states'
+        );
+
+        if (!statesAttribute) {
+          context.report({ node, messageId: 'noStatesAttribute' });
+          return;
+        }
+
+        const value = statesAttribute.value;
+        if (!value || value.type !== 'JSXExpressionContainer') return;
+
+        const expression = value.expression;
+        if (!expression || expression.type !== 'ObjectExpression') return;
+
+        const hasSpread = expression.properties.some((property) => property.type === 'SpreadElement');
+        const errorProperty = expression.properties.find(
+          (property) => getPropertyKeyName(property) === 'error'
+        );
+
+        if (errorProperty) {
+          // A property explicitly named `error` was found; only flag it if it's a bare
+          // `undefined` identifier, since that's statically known to supply no handler.
+          if (errorProperty.value.type === 'Identifier' && errorProperty.value.name === 'undefined') {
+            context.report({ node: statesAttribute, messageId: 'noErrorState' });
+          }
+          return;
+        }
+
+        // No `error` key found directly. If a spread is present, its source object may
+        // supply `error` and that can't be resolved statically -- don't guess, don't report.
+        if (hasSpread) return;
+
+        context.report({ node: statesAttribute, messageId: 'noErrorState' });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.md
@@ -1,0 +1,74 @@
+| Rule | 🏷️ | ✨ |
+| ---- | -- | -- |
+| `require-request-error-block` | 🐞 | |
+
+`<Request>` (from `@warp-drive/react`) is a component for declaratively resolving a request's
+`idle` / `loading` / `cancelled` / `error` / `content` states. The handler for each state is
+supplied as a property on the `states` prop object, e.g. `states={{ error: MyErrorComponent, ... }}`.
+If no `states.error` handler is supplied and the request rejects, the error is thrown from within
+the component and can crash the app.
+
+This rule flags any `<Request>` element that cannot be statically shown to provide a
+`states.error` handler:
+
+- No `states` prop at all.
+- A `states` prop whose value is an object literal (`states={{ ... }}`) that has no `error` key,
+  and no spread element that might supply one.
+
+To avoid false positives, this rule does **not** report when it cannot statically determine
+whether `error` is supplied:
+
+- `states={{ ...shared, content: MyContent }}` -- a spread is present, so `shared` may supply
+  `error` even though it isn't listed directly.
+- `states={sharedStates}` -- the `states` value isn't an object literal at all, so its shape can't
+  be inspected.
+
+### Incorrect Code
+
+```tsx
+import { Request } from '@warp-drive/react';
+
+function UserPreview({ id }: { id: string | null }) {
+  // no `states` prop at all: if the request rejects, the error is thrown and can crash the app
+  return <Request query={findRecord('user', id)} />;
+}
+```
+
+```tsx
+import { Request } from '@warp-drive/react';
+
+function UserPreview({ id }: { id: string | null }) {
+  return (
+    <Request
+      query={findRecord('user', id)}
+      states={{
+        // no `error` handler: if the request rejects, the error is thrown and can crash the app
+        content: ({ result }) => <h2>{result.name}</h2>,
+      }}
+    />
+  );
+}
+```
+
+### Correct Code
+
+```tsx
+import { Request } from '@warp-drive/react';
+
+function UserPreview({ id }: { id: string | null }) {
+  return (
+    <Request
+      query={findRecord('user', id)}
+      states={{
+        error: ({ error, features }) => (
+          <div>
+            <p>Error: {error.message}</p>
+            <button onClick={features.retry}>Try Again?</button>
+          </div>
+        ),
+        content: ({ result }) => <h2>{result.name}</h2>,
+      }}
+    />
+  );
+}
+```

--- a/packages/eslint-plugin-warp-drive/src/rules/template-require-request-error-block.js
+++ b/packages/eslint-plugin-warp-drive/src/rules/template-require-request-error-block.js
@@ -1,0 +1,51 @@
+/**
+ * {@include ./template-require-request-error-block.md}
+ * @module
+ */
+'use strict';
+
+const ERROR_BLOCK_TAG = ':error';
+const TRACKED_TAGS = new Set(['Request', 'Await']);
+
+const messages = {
+  noErrorBlock:
+    'Using <{{tag}}> without an :error block means that if the request/promise rejects, the ' +
+    'error is thrown and can crash the app. Add an :error block to <{{tag}}> to handle the ' +
+    'failure case explicitly.',
+};
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensures <Request>/<Await> always provide an :error block',
+      category: 'Possible Errors',
+      recommended: false,
+      url: 'https://github.com/warp-drive-data/warp-drive/tree/main/packages/eslint-plugin-warp-drive/docs/template-require-request-error-block.md',
+    },
+    schema: [],
+    messages,
+  },
+
+  create(context) {
+    // This rule visits the Glimmer template AST that `ember-eslint-parser` exposes to
+    // ESLint for `.gjs`/`.gts` files, using `Glimmer`-prefixed node types that otherwise
+    // match `@glimmer/syntax`'s AST shape 1:1 (e.g. `GlimmerElementNode.tag`). Unlike
+    // `template-always-use-request-content`, this rule only needs to check for the
+    // presence of an `:error` named block, so no usage/shadow tracking is needed.
+    return {
+      GlimmerElementNode(node) {
+        if (!TRACKED_TAGS.has(node.tag)) return;
+
+        const hasErrorBlock = node.children.some(
+          (child) => child.type === 'GlimmerElementNode' && child.tag === ERROR_BLOCK_TAG
+        );
+
+        if (!hasErrorBlock) {
+          context.report({ node, messageId: 'noErrorBlock', data: { tag: node.tag } });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-warp-drive/src/rules/template-require-request-error-block.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/template-require-request-error-block.md
@@ -1,0 +1,89 @@
+| Rule | 🏷️ | ✨ |
+| ---- | -- | -- |
+| `template-require-request-error-block` | 🐞 | |
+
+> [!TIP]
+> This rule requires a template-aware parser. See [Template Rules](/guides/linting/#template-rules) for setup.
+
+`<Request>` and `<Await>` are components for declaratively resolving a request or promise's states
+in a template. Both only render an `:error` block if you provide one -- if the request or promise
+rejects and no `:error` block was supplied, the error is thrown from within the component and can
+crash the app.
+
+This rule flags any `<Request>` or `<Await>` element that does not have an `:error` named block
+among its children, including a completely empty or self-closing element.
+
+### Incorrect Code
+
+```gjs
+import { Request } from '@warp-drive/ember';
+
+<template>
+  {{! no :error block: if the request rejects, the error is thrown and can crash the app }}
+  <Request @request={{@request}}>
+    <:content as |result|>
+      <h1>{{result.title}}</h1>
+    </:content>
+  </Request>
+</template>
+```
+
+```gjs
+import { Await } from '@warp-drive/ember';
+
+<template>
+  {{! no :error block: if the promise rejects, the error is thrown and can crash the app }}
+  <Await @promise={{@promise}}>
+    <:success as |result|>
+      <h1>{{result.title}}</h1>
+    </:success>
+  </Await>
+</template>
+```
+
+```gjs
+import { Request } from '@warp-drive/ember';
+
+<template>
+  {{! completely empty, self-closing <Request> has no :error block either }}
+  <Request @request={{@request}} />
+</template>
+```
+
+### Correct Code
+
+```gjs
+import { Request } from '@warp-drive/ember';
+
+<template>
+  <Request @request={{@request}}>
+    <:error as |error|>
+      <ErrorForm @error={{error}} />
+    </:error>
+
+    <:content as |result|>
+      <h1>{{result.title}}</h1>
+    </:content>
+  </Request>
+</template>
+```
+
+```gjs
+import { Await } from '@warp-drive/ember';
+
+<template>
+  <Await @promise={{@promise}}>
+    <:pending>
+      <Spinner />
+    </:pending>
+
+    <:error as |error|>
+      <ErrorForm @error={{error}} />
+    </:error>
+
+    <:success as |result|>
+      <h1>{{result.title}}</h1>
+    </:success>
+  </Await>
+</template>
+```

--- a/packages/eslint-plugin-warp-drive/tests/require-request-error-block.js
+++ b/packages/eslint-plugin-warp-drive/tests/require-request-error-block.js
@@ -1,0 +1,95 @@
+// @ts-nocheck
+const rule = require('../src/rules/require-request-error-block');
+const RuleTester = require('eslint').RuleTester;
+
+// This rule operates on the plain ESTree JSX AST rather than the Glimmer template AST used
+// by the `template-*` rules, so no custom parser is needed -- ESLint's default parser
+// (espree) parses JSX fine given `parserOptions.ecmaFeatures.jsx = true`.
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+const noStatesAttribute = 'noStatesAttribute';
+const noErrorState = 'noErrorState';
+
+ruleTester.run('require-request-error-block', rule, {
+  valid: [
+    {
+      name: 'all state keys present',
+      code: `
+        <Request
+          query={query}
+          states={{ idle, loading, error, content }}
+        />
+      `,
+    },
+    {
+      name: 'minimal states with error and content',
+      code: `
+        <Request
+          query={query}
+          states={{ error, content }}
+        />
+      `,
+    },
+    {
+      name: 'spread present but error is also explicit',
+      code: `
+        <Request
+          query={query}
+          states={{ ...shared, error, content }}
+        />
+      `,
+    },
+    {
+      name: 'spread present, error not statically visible: must not report',
+      code: `
+        <Request
+          query={query}
+          states={{ ...shared, content }}
+        />
+      `,
+    },
+    {
+      name: 'states value is not an object literal: must not report',
+      code: `
+        <Request
+          query={query}
+          states={sharedStatesVariable}
+        />
+      `,
+    },
+    {
+      name: 'a differently named JSX element with no states is not linted',
+      code: `<MyRequest query={query} />`,
+    },
+    {
+      name: 'a differently named JSX element containing "Request" is not linted',
+      code: `<RequestThing query={query} />`,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'no states attribute at all',
+      code: `<Request query={query} />`,
+      errors: [{ messageId: noStatesAttribute }],
+    },
+    {
+      name: 'object literal present but error key genuinely missing, no spread',
+      code: `
+        <Request
+          query={query}
+          states={{ content }}
+        />
+      `,
+      errors: [{ messageId: noErrorState }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-warp-drive/tests/template-require-request-error-block.js
+++ b/packages/eslint-plugin-warp-drive/tests/template-require-request-error-block.js
@@ -1,0 +1,170 @@
+// @ts-nocheck
+const rule = require('../src/rules/template-require-request-error-block');
+const RuleTester = require('eslint').RuleTester;
+const emberEslintParser = require('ember-eslint-parser');
+
+// This rule operates on the Glimmer template AST that `ember-eslint-parser` exposes to
+// ESLint for `.gjs`/`.gts` files. Test cases use `.gjs` (rather than `.gts`) so that the
+// parser's babel-based mode is used and no TypeScript-specific setup is required.
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: emberEslintParser,
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+});
+
+const noErrorBlock = 'noErrorBlock';
+
+/**
+ * Wraps a `<template>` body in a minimal `.gjs` component module, matching how
+ * `<Request>`/`<Await>` are actually authored throughout this monorepo (exclusively in
+ * `.gjs`/`.gts` First-Class Component Templates, never in standalone `.hbs`).
+ *
+ * @param {string} templateBody
+ */
+function wrap(templateBody) {
+  return `
+import { Request, Await } from '@warp-drive/ember';
+import Component from '@glimmer/component';
+
+export default class Foo extends Component {
+  <template>
+${templateBody}
+  </template>
+}
+`;
+}
+
+ruleTester.run('template-require-request-error-block', rule, {
+  valid: [
+    {
+      name: '<Request> with an :error block alongside other blocks',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Request @request={{@request}}>
+          <:loading as |state|>
+            <Spinner @percentDone={{state.completedRatio}} />
+          </:loading>
+
+          <:error as |error|>
+            <ErrorForm @error={{error}} />
+          </:error>
+
+          <:content as |result|>
+            <h1>{{result.title}}</h1>
+          </:content>
+        </Request>
+      `),
+    },
+    {
+      name: '<Await> with an :error block alongside :pending/:success',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Await @promise={{@promise}}>
+          <:pending>
+            <Spinner />
+          </:pending>
+
+          <:error as |error|>
+            <ErrorForm @error={{error}} />
+          </:error>
+
+          <:success as |result|>
+            <h1>{{result.title}}</h1>
+          </:success>
+        </Await>
+      `),
+    },
+    {
+      name: '<Request> where :error is the only block present',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Request @request={{@request}}>
+          <:error as |error|>
+            <ErrorForm @error={{error}} />
+          </:error>
+        </Request>
+      `),
+    },
+    {
+      name: '<Await> where :error is the only block present',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Await @promise={{@promise}}>
+          <:error as |error|>
+            <ErrorForm @error={{error}} />
+          </:error>
+        </Await>
+      `),
+    },
+    {
+      name: 'a component whose tag merely contains "Request" is not linted',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <MyRequest @request={{@request}}>
+          <:content>
+            no :error block, but this isn't a real Request
+          </:content>
+        </MyRequest>
+      `),
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'a completely empty, self-closing <Request>',
+      filename: 'foo.gjs',
+      code: wrap(`<Request @request={{@request}} />`),
+      errors: [{ messageId: noErrorBlock, data: { tag: 'Request' } }],
+    },
+    {
+      name: 'a completely empty, self-closing <Await>',
+      filename: 'foo.gjs',
+      code: wrap(`<Await @promise={{@promise}} />`),
+      errors: [{ messageId: noErrorBlock, data: { tag: 'Await' } }],
+    },
+    {
+      name: '<Request> with other named blocks but no :error block',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Request @request={{@request}}>
+          <:loading as |state|>
+            <Spinner @percentDone={{state.completedRatio}} />
+          </:loading>
+
+          <:content as |result|>
+            <h1>{{result.title}}</h1>
+          </:content>
+        </Request>
+      `),
+      errors: [{ messageId: noErrorBlock, data: { tag: 'Request' } }],
+    },
+    {
+      name: '<Await> with other named blocks but no :error block',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Await @promise={{@promise}}>
+          <:pending>
+            <Spinner />
+          </:pending>
+
+          <:success as |result|>
+            <h1>{{result.title}}</h1>
+          </:success>
+        </Await>
+      `),
+      errors: [{ messageId: noErrorBlock, data: { tag: 'Await' } }],
+    },
+    {
+      name: '<Request> with only a plain/default (non-named) block and no :error',
+      filename: 'foo.gjs',
+      code: wrap(`
+        <Request @request={{@request}}>
+          <SomeUnrelatedMarkup />
+        </Request>
+      `),
+      errors: [{ messageId: noErrorBlock, data: { tag: 'Request' } }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

This implements the "a lint rule around ensuring an error block is present" direction proposed in
#10049 (review: Request Component Error Handling Improvements), as the preferred static-analysis
alternative to the runtime-throw approach that stale draft PR #9963 ("chore: ensure error blocks
are added") attempted but never merged.

`<Request>` (Ember/React) and `<Await>` (Ember) only throw a rejection/error at runtime, and only
if the request/promise actually fails *and* no error handler was supplied. Instead of making that
a hard runtime requirement (throwing immediately, even before any failure, as #9963 tried), this PR
adds two ESLint rules that catch the missing handler statically, at lint time:

- **`template-require-request-error-block`** (Ember, `.gjs`/`.gts`): flags any `<Request>` or
  `<Await>` element in a Glimmer template that has no `:error` named block among its children
  (including empty/self-closing elements). Wired into the existing
  `eslint-plugin-warp-drive/recommended-templates` config. Closely mirrors the structure of the
  existing `template-always-use-request-content` rule (same `GlimmerElementNode` AST, same
  `meta.messages`/doc-comment conventions).
- **`require-request-error-block`** (React, `.jsx`/`.tsx`): flags any `<Request>` JSX element that
  cannot be statically shown to supply a `states.error` handler -- no `states` prop at all, or a
  `states={{ ... }}` object literal with no `error` key and no spread that might supply one.
  Conservatively does *not* report when a spread is present (`states={{ ...shared, content }}`) or
  when `states` isn't an object literal at all (`states={sharedStates}`), since those cases can't
  be resolved statically. Wired into a new `eslint-plugin-warp-drive/recommended-react` config
  (new sibling to `recommended`/`recommended-templates`), which enables JSX parsing for
  `.jsx`/`.tsx` files.
- `package.json` exports a new `"./recommended-react"` entry; `README.md` and
  `guides/linting/index.md` document both rules and the new config.

## Test plan

Run from a fresh worktree (`packages/eslint-plugin-warp-drive`):

- [x] `pnpm --filter eslint-plugin-warp-drive exec mocha tests/template-require-request-error-block.js tests/require-request-error-block.js` -- 19 passing
- [x] `pnpm --filter eslint-plugin-warp-drive run lint` -- clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BES2FKBdibZ2snWm62soq4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BES2FKBdibZ2snWm62soq4)_