### PR TITLE
fix(release): include the synthesized types directory in *-types tarballs

### DIFF
--- a/tools/release/core/publish/steps/generate-types-tarballs.ts
+++ b/tools/release/core/publish/steps/generate-types-tarballs.ts
@@ -5,6 +5,12 @@ import { exec } from '../../../utils/cmd.ts';
 import { APPLIED_STRATEGY, Package } from '../../../utils/package.ts';
 import { PROJECT_ROOT, TARBALL_DIR, toTarballName } from './generate-tarballs.ts';
 
+const TYPES_SUBDIR = 'unstable-preview-types';
+
+function hasDeclaration(entry: string | Buffer) {
+  return String(entry).endsWith('.d.ts');
+}
+
 const INVALID_FILES = new Set([
   'src',
   'dist',
@@ -47,10 +53,32 @@ export async function generateTypesTarballs(
       // create a new package.json
       const pkg = packages.get(strat.name)!;
       const pkgData = pkg.pkgData;
+
+      // `makeTypesAlpha` synthesizes this directory and pushes it onto `pkgData.files`,
+      // but that push is in-memory only and `restoreTypesStrategyChanges` has since run
+      // `git checkout HEAD -- <package.json>` + `pkg.refresh()` for every package, so by
+      // the time we get here `pkgData.files` is back to its on-disk state. Before
+      // declarations moved into `dist/` the directory was declared in `files` on disk and
+      // survived that restore; now it does not, and relying on `files` alone ships a
+      // types package containing nothing but a README.
+      const sourceFiles = [...(pkgData.files ?? [])];
+      if (!sourceFiles.includes(TYPES_SUBDIR)) {
+        sourceFiles.push(TYPES_SUBDIR);
+      }
+
+      const typesDir = path.join(path.dirname(pkg.filePath), TYPES_SUBDIR);
+      if (!fs.existsSync(typesDir) || !fs.readdirSync(typesDir, { recursive: true }).some(hasDeclaration)) {
+        throw new Error(
+          `Expected ${pkgData.name} to have a populated ${TYPES_SUBDIR} directory to publish as ` +
+            `${strat.typesPublishTo}, but it is missing or contains no .d.ts files. It is synthesized by ` +
+            `makeTypesAlpha during tarball generation — check that step ran for this package.`
+        );
+      }
+
       const newPkgData = {
         name: strat.typesPublishTo,
         version: pkgData.version,
-        files: pkgData.files?.filter((f) => !INVALID_FILES.has(f)) ?? [],
+        files: sourceFiles.filter((f) => !INVALID_FILES.has(f)),
         private: false,
         description: `Type Declarations for ${pkgData.name}`,
         author: pkgData.author,
@@ -63,18 +91,8 @@ export async function generateTypesTarballs(
       const newPkgJson = path.join(tmpTypesDir, 'package.json');
       fs.writeFileSync(newPkgJson, JSON.stringify(newPkgData, null, 2));
 
-      // // copy the types directory
-      // const typesDir = path.join(path.dirname(pkg.filePath), 'unstable-preview-types');
-      // if (!fs.existsSync(typesDir)) {
-      //   throw new Error(`Types directory does not exist: ${typesDir}`);
-      // }
-      // const typesDest = path.join(tmpTypesDir, 'unstable-preview-types');
-      // fs.mkdirSync(typesDest, { recursive: true });
-      // await exec(`cp -r ${typesDir}/* ${typesDest}`);
-
       // copy files that are needed
-      const files = pkgData.files ?? [];
-      for (const file of files) {
+      for (const file of sourceFiles) {
         const src = path.join(path.dirname(pkg.filePath), file);
         const dest = path.join(tmpTypesDir, file);
         fs.mkdirSync(path.dirname(dest), { recursive: true });


### PR DESCRIPTION
Every `@ember-data-types/*` and `@warp-drive-types/core-types` package published since `5.9.0-alpha.22` ships **no declarations** — just a README, LICENSE and logos. [`@ember-data-types/store` on npm](https://www.npmjs.com/package/@ember-data-types/store?activeTab=code) shows it.

## What happens

`makeTypesAlpha` synthesizes the directory from `dist/` and adds it to the file list, because after #10715 it is no longer developer-declared:

```ts
// generate-tarballs.ts:560-567
await synthesizeTypesDirectoryFromDist(pkg, 'unstable-preview-types');
const present = new Set(pkg.pkgData.files);
if (!present.has('unstable-preview-types')) {
  pkg.pkgData.files!.push('unstable-preview-types');   // in-memory only
}
```

`generatePackageTarballs` then runs this in a `finally`, for every package:

```ts
// generate-tarballs.ts:667-673
await exec({ cmd: `git checkout HEAD -- ${pkg.filePath}`, silent: true });
await pkg.refresh();     // reloads pkgData from disk — the push is gone
```

`generateTypesTarballs` runs after all of that (`index.ts:103-105`) and derives both the published `files` and the copy loop from `pkgData.files`, which is now back to its on-disk state:

```ts
// generate-types-tarballs.ts:53, 76-82
files: pkgData.files?.filter((f) => !INVALID_FILES.has(f)) ?? [],
...
const files = pkgData.files ?? [];
for (const file of files) { /* copy */ }
```

No `unstable-preview-types` in that list, so it is neither copied into the staging directory nor listed in the published `files`. The tarball packs without it.

Before declarations moved into `dist/`, the directory was a real entry in each package's `files` on disk and survived the restore. Making it synthesized-and-pushed-at-runtime put it on the wrong side of that `git checkout`.

The synthesized directory itself is fine — `git checkout` only touches `package.json`, so it is still on disk when `generateTypesTarballs` runs. Only the bookkeeping is lost.

## The fix

Add the subdirectory explicitly instead of depending on `files` surviving a restore, and use that list for both the manifest and the copy loop.

Also throws when the directory is missing or has no `.d.ts`. This shipped silently for three weeks across ~30 releases; `synthesizeTypesDirectoryFromDist` already fails loudly on an empty `dist/` (line 490) and this deserves the same.

## Verification

Traced against the published artifacts:

| version | published | `@ember-data-types/store` |
|---|---|---|
| 5.9.0-alpha.21 | 2026-08-14 | `files: ['unstable-preview-types', …]`, 4 `.d.ts` |
| 5.9.0-beta.1 | 2026-08-20 | same |
| **5.9.0-alpha.22** | **2026-08-21** | **`files: ['README.md','LICENSE.md','logos']`, 0 `.d.ts`** |
| every release since | | 0 `.d.ts` |

The cutover lands on #10715 (merged 2026-08-21T03:04Z). All 11 packages we consume are affected identically.

I have **not** run the release pipeline — no publish credentials, and it only runs on release — so this is verified by reading the code path against the published tarballs rather than by producing one. Worth a maintainer confirming against a dry-run pack.

Two things I deliberately did not touch:

- The `beta` path (`makeTypesBeta` → `preview-types`) has the same shape and presumably the same bug, but `generateTypesTarballs` throws on any non-`alpha` strategy today, so it is unreachable and untested. Left alone rather than speculatively fixed.
- I removed the commented-out block that this change supersedes; it described the copy this now does properly. Say the word if you would rather keep it.

## Why we noticed

Optro runs the 4.13 runtime typed by the 5.x unified types via these packages — the separate-type-package strategy. With them empty, `@ember-data/store` falls back to the legacy 4.13 declarations, `store.request` stops threading its result type, and call sites degrade to `content: unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
