### PR TITLE
fix(docs): fence JSX object literals containing `{{ }}` in error-block rule doc

### DIFF
--- a/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.md
+++ b/packages/eslint-plugin-warp-drive/src/rules/require-request-error-block.md
@@ -4,7 +4,12 @@
 
 `<Request>` (from `@warp-drive/react`) is a component for declaratively resolving a request's
 `idle` / `loading` / `cancelled` / `error` / `content` states. The handler for each state is
-supplied as a property on the `states` prop object, e.g. `states={{ error: MyErrorComponent, ... }}`.
+supplied as a property on the `states` prop object, e.g.:
+
+```tsx
+states={{ error: MyErrorComponent, ... }}
+```
+
 If no `states.error` handler is supplied and the request rejects, the error is thrown from within
 the component and can crash the app.
 
@@ -12,16 +17,28 @@ This rule flags any `<Request>` element that cannot be statically shown to provi
 `states.error` handler:
 
 - No `states` prop at all.
-- A `states` prop whose value is an object literal (`states={{ ... }}`) that has no `error` key,
-  and no spread element that might supply one.
+- A `states` prop whose value is an object literal that has no `error` key, and no spread element
+  that might supply one:
+
+  ```tsx
+  states={{ content: MyContent }}
+  ```
 
 To avoid false positives, this rule does **not** report when it cannot statically determine
 whether `error` is supplied:
 
-- `states={{ ...shared, content: MyContent }}` -- a spread is present, so `shared` may supply
-  `error` even though it isn't listed directly.
-- `states={sharedStates}` -- the `states` value isn't an object literal at all, so its shape can't
-  be inspected.
+- A spread element is present, so the spread source may supply `error` even though it isn't
+  listed directly:
+
+  ```tsx
+  states={{ ...shared, content: MyContent }}
+  ```
+
+- The `states` value isn't an object literal at all, so its shape can't be inspected:
+
+  ```tsx
+  states={sharedStates}
+  ```
 
 ### Incorrect Code
 


### PR DESCRIPTION
## Summary

The `canary.warp-drive.io deployment` workflow (`.github/workflows/deploy.yml`) has failed on **every** push to `main` since `require-request-error-block.md` merged in #11078 -- checked the last dozen+ runs on `main` via the Actions API and all are red with the same error.

**Root cause:** VitePress wraps fenced code blocks (` ```lang `) in `<pre v-pre>`, which tells Vue's template compiler to skip parsing their contents entirely. That's why every other rule doc in `packages/eslint-plugin-warp-drive/src/rules/*.md` that needs literal Handlebars/glimmer `{{ }}` syntax (e.g. `no-create-record-rerender.md`, `template-require-request-error-block.md`) always puts it inside a fenced code block.

`require-request-error-block.md` instead put its `states={{ ... }}` React/JSX examples in inline single-backtick code spans. Inline code spans get no `v-pre` treatment, so when this markdown is embedded (via `{@include ...}`) into the generated API docs and compiled as a Vue SFC, Vue tries to parse `{{ error: MyErrorComponent, ... }}` and `{{ ...shared, content: MyContent }}` as JavaScript expressions and fails:

```
RolldownError: Error parsing JavaScript expression: Unexpected token (1:29)
[plugin vite:vue] .../api/eslint-plugin-warp-drive/rules/require-request-error-block/index.md:23:85
```

I reproduced this exactly with `@vue/compiler-sfc` against the offending inline HTML (`Error parsing JavaScript expression: Unexpected token`), confirmed it disappears once the same content is wrapped in a fenced block, and confirmed via `node_modules/vitepress`'s own markdown renderer that fenced blocks (without a `-vue` language suffix) get `v-pre` while inline code does not.

## Fix

Moves the three offending `states={{ ... }}` examples out of inline code spans into fenced ` ```tsx ` blocks, matching the convention used everywhere else in this file and its sibling docs. No behavioral/content change, just where the code sample lives.

## Note

There's no CI check that builds `docs-viewer` on pull requests -- `deploy.yml` only triggers on `push: branches: [main]` -- so this kind of break is invisible until it lands on `main`. Out of scope for this fix, but worth a follow-up if you want PRs to catch this earlier.

## Test plan

- [x] Reproduced the exact `@vue/compiler-sfc` parse error against the original inline-code content.
- [x] Confirmed the fenced-code version parses cleanly with the same compiler.
- [x] Confirmed (via vitepress's own markdown renderer source) that fenced blocks get `<pre v-pre>` while inline code spans do not, which is why the fix works and matches existing conventions.
- [ ] Full `pnpm run build` inside `docs-viewer` (blocked in this sandbox: the repo pins node `26.8.1` via mise and this environment only has node `22.22.2`, so `pnpm install`'s `turbo run build:pkg` fails on an unrelated toolchain mismatch before reaching the docs build). The next push to `main` (or a manual `workflow_dispatch` of `canary.warp-drive.io deployment`) will confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZuVfo7i5eogKn7Vy2Yt81

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZuVfo7i5eogKn7Vy2Yt81)_