### PR TITLE
Add `unknownProperty` and `size` to `IgnoredGlobalFields` list

### DIFF
--- a/warp-drive-packages/core/src/reactive/-private/record.ts
+++ b/warp-drive-packages/core/src/reactive/-private/record.ts
@@ -27,7 +27,17 @@ import { peekManagedObject } from './fields/managed-object.ts';
 import type { SchemaService } from './schema.ts';
 import { Checkout, Commit, Context, Destroy } from './symbols.ts';
 
-const IgnoredGlobalFields = new Set<string>(['length', 'nodeType', 'then', 'setInterval', 'document', STRUCTURED]);
+const IgnoredGlobalFields = new Set<string>([
+  'length',
+  'nodeType',
+  'then',
+  'setInterval',
+  'document',
+  'unknownProperty',
+  'size',
+  STRUCTURED,
+]);
+
 const symbolList = [Context, Destroy, RecordStore, Checkout, Commit];
 const RecordSymbols = new Set(symbolList);
 


### PR DESCRIPTION
## Summary
- Add `'unknownProperty'` and `'size'` to `IgnoredGlobalFields` in `warp-drive-packages/core/src/reactive/-private/record.ts`, so these globals don't trigger `No field named ... on <type>` errors (e.g. when using `isEmpty`/`@ember/utils` with schema-record).
- Rebase of #10108 onto latest `main`, with the updated `Set` literal reformatted to the repo's canonical `oxfmt` style (no longer fits on one line with the two new entries) and verified with `oxlint`.

fix #10096

---

- Read the full [contributing documentation](https://github.com/warp-drive-data/warp-drive/blob/main/contributing/become-a-contributor.md)
- If you do not have permission to add labels or run the test-suite in CI, a team member will do this for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBaiKYKh2xU9CqYCoy7jgQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBaiKYKh2xU9CqYCoy7jgQ)_