### PR TITLE
fix(docs): repair dead links breaking the docs production build

### DIFF
--- a/guides/the-manual/requests/typing-requests.md
+++ b/guides/the-manual/requests/typing-requests.md
@@ -52,7 +52,7 @@ export default <template>
 
 ## Typing Reactive Responses
 
-Requests that return reactive responses wrap the primary resource data in a [ReactiveDocument](/api/@warp-drive/core/reactive/type-aliases/ReactiveDocument). In the case of an error, this will be a [ReactiveErrorDocument](/api/@warp-drive/core/reactive/interfaces/ReactiveErrorDocument) and in the case of success it will be a [ReactiveDataDocument](/api/@warp-drive/core/reactive/interfaces/ReactiveDataDocument)
+Requests that return reactive responses wrap the primary resource data in a [ReactiveDocument](/api/@warp-drive/core/reactive/type-aliases/ReactiveDocument). In the case of an error, this will be a [ReactiveErrorDocument](/api/@warp-drive/core/reactive/type-aliases/ReactiveErrorDocument) and in the case of success it will be a [ReactiveDataDocument](/api/@warp-drive/core/reactive/type-aliases/ReactiveDataDocument)
 
 A conventient utility is available for [typing these reactive responses](/api/@warp-drive/core/request/functions/withReactiveResponse).
 
@@ -248,7 +248,7 @@ content.meta.total; // number
 
 ## Typing Errors
 
-The error variant of a document, [ReactiveErrorDocument](/api/@warp-drive/core/reactive/interfaces/ReactiveErrorDocument),
+The error variant of a document, [ReactiveErrorDocument](/api/@warp-drive/core/reactive/type-aliases/ReactiveErrorDocument),
 exposes `errors`. The cache stores whatever the API sent without validating it, so by default the
 type promises no shape — `errors` is `object[]`.
 


### PR DESCRIPTION
## Summary

- The docs production build (`docs-viewer` → `vitepress build`) has been failing on every push to `main` with `Error: 3 dead link(s) found.`
- `#11063` changed `ReactiveErrorDocument` and `ReactiveDataDocument` from `export interface` to `export type` in `warp-drive-packages/core/src/reactive/-private/document.ts`. TypeDoc categorizes generated API pages by declaration kind, so their generated pages moved from `/api/@warp-drive/core/reactive/interfaces/...` to `/api/@warp-drive/core/reactive/type-aliases/...`.
- `guides/the-manual/requests/typing-requests.md` still linked to the stale `interfaces/` paths (3 occurrences), which VitePress's `ignoreDeadLinks` check fails the build on.
- Updated the 3 stale links to point at `type-aliases/` instead, matching the neighboring `ReactiveDocument` link that was already correct.

## Test plan

- [x] Reproduced the exact CI failure locally using the pinned Node 26.8.1 / pnpm 12.3.4 toolchain, matching `deploy.yml`'s `pnpm run sync` + `docs-viewer` `pnpm run build` invocation.
- [x] Confirmed the `3 dead link(s) found` error disappears and `vitepress build` completes successfully after the fix (verified with GitHub API calls in the theme's data loaders stubbed out locally, since this sandbox has no working GitHub API credentials — that stubbing was not part of the committed change).
- [x] Verified no other stale `interfaces/ReactiveErrorDocument` or `interfaces/ReactiveDataDocument` references remain anywhere under `docs-viewer/` or `guides/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxPuoqhZKG6HzMbKRxgr5R

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxPuoqhZKG6HzMbKRxgr5R)_