### PR TITLE
fix(json-api): don't announce relationship fields as attribute changes

### DIFF
--- a/tests/json-api/tests/integration/cache/changed-keys-field-kinds-test.ts
+++ b/tests/json-api/tests/integration/cache/changed-keys-field-kinds-test.ts
@@ -1,0 +1,190 @@
+import type { NotificationType } from '@warp-drive/core';
+import { Store } from '@warp-drive/core';
+import { registerDerivations, SchemaService, withDefaults } from '@warp-drive/core/reactive';
+import type { CacheCapabilitiesManager } from '@warp-drive/core/types';
+import type { ResourceKey } from '@warp-drive/core/types/identifier';
+import { module, test } from '@warp-drive/diagnostic';
+import { JSONAPICache as Cache } from '@warp-drive/json-api';
+
+/**
+ * Uses the real `SchemaService` rather than the test app's `TestSchema`
+ * because only the real one implements `cacheFields`. `calculateChangedKeys`
+ * receives whatever `getCacheFields` returns, and `getCacheFields` falls back
+ * to the much broader `fields()` map for any schema service that does not
+ * implement `cacheFields` — so a `TestSchema`-based store would exercise a
+ * field set that no application actually sees.
+ */
+class TestStore extends Store {
+  createSchemaService() {
+    const schema = new SchemaService();
+    registerDerivations(schema);
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          {
+            name: 'bestFriend',
+            kind: 'belongsTo',
+            type: 'user',
+            options: { inverse: 'bestFriend', async: false, linksMode: true },
+          },
+          {
+            name: 'friends',
+            kind: 'hasMany',
+            type: 'user',
+            options: { inverse: 'friends', async: false, linksMode: true },
+          },
+        ],
+      })
+    );
+    return schema;
+  }
+
+  override createCache(wrapper: CacheCapabilitiesManager) {
+    return new Cache(wrapper);
+  }
+}
+
+// subscriber callbacks are typed as `key?: string`, but a keyless/wildcard
+// dispatch passes `null` through at runtime (see `_flushNotification`), so
+// the tuple type here must allow for it.
+type Call = [type: NotificationType, key: string | null | undefined];
+
+module('Integration | JSONAPICache | changed keys are filtered by field kind', function () {
+  test('a relationship carrying data in both `attributes` and `relationships` is not announced as an attributes change', function (assert) {
+    const store = new TestStore();
+    const cache = store.cache;
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    // seed the cache so the second upsert is an update (`existed === true`),
+    // which is the only case in which changed keys are calculated at all.
+    cache.upsert(
+      identifier,
+      {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Chris' },
+        relationships: {
+          bestFriend: { data: { type: 'user', id: '2' } },
+          friends: { data: [{ type: 'user', id: '2' }] },
+        },
+      },
+      false
+    );
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    // {json:api} requires a resource's fields to share one namespace, so a
+    // name cannot appear as both an attribute and a relationship:
+    // https://jsonapi.org/format/#document-resource-object-fields
+    //
+    // This payload violates that — `bestFriend` and `friends` carry data in
+    // `attributes` *and* in `relationships`. It is the realistic shape of the
+    // mistake (a serializer emitting linkage into the wrong bucket), and it is
+    // the only way to reach the branch under test.
+    cache.upsert(
+      identifier,
+      {
+        type: 'user',
+        id: '1',
+        attributes: {
+          // positive control: a genuine attribute change, so that a silent
+          // no-op cannot masquerade as this test passing.
+          name: 'Chris Thoburn',
+          // duplicated out of `relationships` below. Both names are fields on
+          // `user`, so they pass the cache-field membership check — but they
+          // are relationships, their data lives in the graph rather than in
+          // `remoteAttrs`, and nothing reads them through the attribute path.
+          bestFriend: { type: 'user', id: '3' },
+          friends: [{ type: 'user', id: '3' }],
+        },
+        relationships: {
+          bestFriend: { data: { type: 'user', id: '3' } },
+          friends: { data: [{ type: 'user', id: '3' }] },
+        },
+      },
+      true
+    );
+
+    store.notifications.unsubscribe(token);
+
+    // Assert on the notifications rather than on a property read: outside a
+    // tracking frame a getter re-reads the cache every time, and `bestFriend`
+    // resolves through the graph regardless, so a value assertion passes with
+    // or without the defect.
+    //
+    // `deepEqual` on the whole delivered sequence rather than a `notOk` on the
+    // bad keys, so that an over-broad fix silencing the genuine `name` change
+    // fails here too.
+    assert.deepEqual(
+      calls,
+      [['attributes', 'name']],
+      'only the genuine attribute change was announced under `attributes`; the relationship names duplicated into `attributes` were not'
+    );
+  });
+
+  test('a relationship carrying data ONLY in `attributes` is not announced, and its data is discarded', function (assert) {
+    const store = new TestStore();
+    const cache = store.cache;
+    const identifier = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    cache.upsert(
+      identifier,
+      {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Chris' },
+        relationships: { bestFriend: { data: { type: 'user', id: '2' } } },
+      },
+      false
+    );
+
+    const calls: Call[] = [];
+    const token = store.notifications.subscribe(
+      identifier,
+      (_key: ResourceKey, type: NotificationType, key?: string | null) => {
+        calls.push([type, key]);
+      }
+    );
+
+    // the same namespace violation, but with no `relationships` member at all,
+    // so `setupRelationships` never runs and the graph never sees this data.
+    cache.upsert(
+      identifier,
+      {
+        type: 'user',
+        id: '1',
+        attributes: {
+          name: 'Chris Thoburn',
+          bestFriend: { type: 'user', id: '3' },
+        },
+      },
+      true
+    );
+
+    store.notifications.unsubscribe(token);
+
+    assert.deepEqual(
+      calls,
+      [['attributes', 'name']],
+      'only the genuine attribute change was announced; `bestFriend` in `attributes` was not'
+    );
+
+    // The relationship is unmoved: the payload's `bestFriend` never reached the
+    // graph, because only `data.relationships` feeds it. Pre-fix, the announced
+    // `attributes`/`bestFriend` change invalidated this field's signal anyway,
+    // so a reader re-read it and got back the value it already had.
+    assert.deepEqual(
+      cache.getRelationship(identifier, 'bestFriend').data,
+      store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '2' }),
+      'the relationship still points at the originally-linked resource, unaffected by the data in `attributes`'
+    );
+  });
+});

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -1844,7 +1844,14 @@ function calculateChangedKeys(
 
   for (let i = 0; i < length; i++) {
     const key = keys[i];
-    if (!fields.has(key)) {
+    // `updates` is always `data.attributes` and the keys we return are always
+    // dispatched under the `attributes` notification bucket, so membership in
+    // the cache-field set is not enough: relationship fields are cache fields
+    // too, and a payload that puts a relationship name inside `attributes`
+    // would otherwise be announced as an attribute change for a key whose data
+    // lives in the graph and is never read back out of `remoteAttrs`.
+    const field = fields.get(key);
+    if (!field || isRelationship(field)) {
       continue;
     }
 

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -1826,11 +1826,6 @@ function getDefaultValue(
   }
 }
 
-/*
-      TODO @deprecate IGOR DAVID
-      There seems to be a potential bug here, where we will return keys that are not
-      in the schema
-  */
 function calculateChangedKeys(
   cached: CachedResource,
   updates: Exclude<ExistingResourceObject['attributes'], undefined>,


### PR DESCRIPTION
## The bug

**A relationship name that appears inside `data.attributes` is announced as an `'attributes'` change.**

Unlike most cache-notification bugs, this one has no user-visible symptom for a well-formed payload — see [What it takes to trigger](#what-it-takes-to-trigger) below, which is the honest caveat on the whole PR. What it fixes is a guard that answers the wrong question, in a function whose only job is to answer that question.

```ts
// `bestFriend` is a `belongsTo` field on `user`
cache.upsert(
  identifier,
  {
    type: 'user',
    id: '1',
    attributes: {
      name: 'Chris Thoburn',
      bestFriend: { type: 'user', id: '3' }, // linkage in the wrong bucket
    },
    relationships: {
      bestFriend: { data: { type: 'user', id: '3' } }, // ...and in the right one
    },
  },
  true
);
```

Measured, subscribing to the resource and recording every notification delivered:

| payload | before | after |
| --- | --- | --- |
| `bestFriend` in `relationships` only (valid) | `[["attributes","name"]]` | `[["attributes","name"]]` |
| `bestFriend` in **both** `attributes` and `relationships` | `[["attributes","name"],["attributes","bestFriend"]]` | `[["attributes","name"]]` |

The first row is the point: **a well-formed payload is unaffected.** No behavior changes for anyone whose API obeys the spec.

## What it takes to trigger

JSON:API is explicit that this payload is invalid — [Resource Objects → Fields](https://jsonapi.org/format/#document-resource-object-fields):

> Fields for a resource object **MUST** share a common namespace with each other and with `type` and `id`. In other words, a resource can not have an attribute and relationship with the same name, nor can it have an attribute or relationship named `type` or `id`.

So no *server* obeying the spec produces this payload.

**But WarpDrive produces it itself.** `preloadData` — in both `core/src/store/deprecated/-private.ts:50` and `legacy/src/store/-private.ts:50` — routes a preload value into `relationships` only for the two LegacyMode kinds:

```js
if (field && (field.kind === 'hasMany' || field.kind === 'belongsTo')) {
  jsonPayload.relationships[key] = preloadRelationship(field, preloadValue);
} else {
  jsonPayload.attributes[key] = preloadValue;   // ← Polaris `resource`/`collection` land here
}
```

A PolarisMode `resource` or `collection` field falls through to the `else` and is written into `attributes`, then handed straight to `cache.upsert`. So `store.findRecord('comment', '2', { preload: { post: … } })` against a `kind: 'resource'` field generates exactly this payload from first-party code, in dev and production alike, with no misbehaving API involved.

That mis-routing is a separate defect and this PR does not fix it — see [Follow-ups](#follow-ups-deliberately-not-in-this-pr). It does mean the guard here is covering a reachable case rather than a hypothetical one.

**The validator agrees this payload is invalid, but it is not switched on.** `validator/1.1/7.2_resource-objects.ts:297` has the rule:

```js
// validateResourceAttributes
} else if (field && RELATIONSHIP_FIELD_KINDS.includes(field.kind)) {
  reporter.error(
    [...path, key],
    `Expected the "${key}" field to be in "relationships" as it has kind "${field.kind}", but received data for it in "attributes".`
  );
}
```

That rule never runs in a default build. `validateDocument` is reached only from `Cache#put` under `DEBUG`, and it then returns early unless `JSON_API_CACHE_VALIDATION_ERRORS` is enabled or `LOG_CACHE` is on — and that flag is an unreleased canary feature, declared `false` in `build-config/src/canary-features.ts:138` and documented as "this **upcoming** feature".

| | default dev build | default production build | canary flag on / `LOG_CACHE` |
| --- | --- | --- | --- |
| `cache.put()` | no validation | no validation | validator errors |
| `cache.upsert()` direct | no validation | no validation | no validation (validator hangs off `put`) |

So nothing catches this payload today on any path, and the phantom notification fires everywhere. The validator rule is useful corroboration that the payload is malformed by this repo's own standard — it is not a live guard that makes the cache-side fix redundant.

No validator change is needed, and this PR makes none.

Field kinds probed, all placed in `data.attributes` on a resource that declares them:

| key in `attributes` | field kind | mode | announced before? | correct? |
| --- | --- | --- | --- | --- |
| `name` | `field` | — | yes | ✅ genuine attribute |
| `bestFriend` | `belongsTo` | Legacy | **yes** | ❌ |
| `friends` | `hasMany` | Legacy | **yes** | ❌ |
| `bestFriend` | `resource` | Polaris | **yes** | ❌ |
| `friends` | `collection` | Polaris | **yes** | ❌ |
| `localOnly` | `@local` | — | no | ✅ |
| `id` | `@id` | — | no | ✅ |
| `notAField` | not in schema | — | no | ✅ |

All four relationship kinds leak, and all four are covered by the fix — the Polaris `resource`/`collection` rows were probed directly rather than inferred from the type union. `@local`, `@id`, `@hash`, `derived`, and `alias` never reach the guard at all; `isNonIdentityCacheableField` excludes them from `cacheFields` upstream.

## Why it happens

Glossary, for anyone following along:

- **`fields(identifier)`** — every field on the resource, including `derived`, `alias`, `@local`, `@id`.
- **`cacheFields(identifier)`** — the subset whose data lives in the cache. Excludes the above, **includes relationships**, because relationship data is cached too (in the graph).
- **`remoteAttrs`** — the last-known-persisted attribute values. Relationship data is not here.

`calculateChangedKeys` receives `cacheFields`, via `getCacheFields`:

```js
function getCacheFields(cache, identifier) {
  if (cache._capabilities.schema.cacheFields) {
    const result = cache._capabilities.schema.cacheFields(identifier);
    if (result) return result;
  }
  // the model schema service cannot process fields that are not cache fields
  return cache._capabilities.schema.fields(identifier);
}
```

And guarded on bare membership in that set:

```js
function calculateChangedKeys(cached, updates, fields) {
  //                                  ^^^^^^^ always `data.attributes`
  const keys = Object.keys(updates);
  for (let i = 0; i < length; i++) {
    const key = keys[i];
    if (!fields.has(key)) continue;   // "is this key cached at all?"
    …
    if (original[key] !== value) changedKeys.add(key);
  }
}
```

Both call sites then dispatch the result to one channel and one bucket:

```js
if (changedKeys?.size) notifyChange(identifier, 'attributes', changedKeys);
```

So the guard asks **"is this key backed by the cache?"** when the only question its caller can act on is **"is this key an attribute?"** Those diverge on exactly one set of field kinds:

| question | `belongsTo` / `hasMany` / `resource` / `collection` |
| --- | --- |
| is this key backed by the cache? | yes — in the graph |
| is this key an attribute? | **no** |

`cacheFields` is a shared lookup serving both the attribute and relationship paths, so relationships are in it deliberately. The gap is that this one consumer needs a narrower set than the one it was handed.

## What goes wrong downstream

Two things, both in `ReactiveResource`'s notification handler, and both confirmed by reading it rather than assumed:

**The relationship's signal is dirtied twice.** `'attributes'` and `'relationships'` both resolve to the same per-field signal — `record.ts:188` and `record.ts:226` each do `signals.get(key)` → `notifyInternalSignal(signal)`. On the malformed payload the relationship got invalidated once for the real relationship change and once for the phantom attribute change.

**For `hasMany`, the phantom notification is the wrong shape.** The `'attributes'` branch special-cases `array`, `schema-array`, and `object` to also notify the collection's own inner signal; it has no `hasMany` case. The `'relationships'` branch does — for a linksMode `hasMany` it notifies `peeked[Context].signal`, the `ManyArray`'s signal. So a `hasMany` announced through `'attributes'` dirties the outer field signal and never the array's, which is neither the correct relationship notification nor a harmless no-op.

## The fix

```diff
-    if (!fields.has(key)) {
+    const field = fields.get(key);
+    if (!field || isRelationship(field)) {
       continue;
     }
```

One lookup replacing one membership test, at the single place that has the fact it needs. `isRelationship` is the predicate already defined in this file (`cache.ts:1953`) and already used by `setupRelationships` and `patchCache`, so the definition of "is a relationship" stays in one place rather than being restated.

Unknown keys still fall out, now via `!field` instead of `!fields.has(key)` — that's the [#9698](https://github.com/warp-drive-data/warp-drive/pull/9698) behavior, preserved.

Nothing was needed for the other non-attribute kinds. `@local`, `@id`, `@hash`, `derived`, and `alias` are already excluded from `cacheFields` upstream by `isNonIdentityCacheableField`, so the narrow check is the whole fix.

This lives in `calculateChangedKeys` rather than at either call site because both `upsert` and `didCommit` dispatch its result identically, to the `'attributes'` bucket. Filtering in the shared function covers both; filtering at the call sites would be the same check written twice.

## Behavior change

`belongsTo`, `hasMany`, `resource`, and `collection` stop being announced under the `'attributes'` bucket when their names appear inside `data.attributes`. Someone could in principle be relying on that, which is why it's called out here rather than buried.

One thing this deliberately does **not** change: the key still lands in `remoteAttrs`, because `Object.assign(cached.remoteAttrs, data.attributes)` is unguarded and this PR doesn't touch it. That matches [#9698](https://github.com/warp-drive-data/warp-drive/pull/9698), which also filtered the notification and left the write alone.

That write is observable, and worth being explicit about rather than leaving implied. `Cache#peek` composes its `attributes` from the raw buckets:

```js
const attributes = structuredClone(Object.assign({}, peeked.remoteAttrs, peeked.inflightAttrs, peeked.localAttrs));
```

Measured after the malformed upsert, **with this fix applied**:

| | keys |
| --- | --- |
| `peek().attributes` | `["name","bestFriend","friends"]` |
| `peek().relationships` | `["bestFriend"]` |

`bestFriend` appears in both, so `peek()` — a `@public` API — emits a resource object violating the same shared-namespace rule the input violated. This PR silences the notification and leaves that intact; filtering the write is deliberately [a separate PR](#follow-ups-deliberately-not-in-this-pr), because it changes what the cache *stores* rather than what it announces, and that reaches `peek`, cache dumps, and forking.

## Tests

**`tests/json-api/.../changed-keys-field-kinds-test.ts`** — 2 tests, both failing without the source change.

They're committed failing, ahead of the fix, so the defect is recorded in history independently of it.

| test | payload | what it pins down |
| --- | --- | --- |
| both buckets | `bestFriend`/`friends` in `attributes` **and** `relationships` | the realistic shape — a serializer emitting linkage into the wrong bucket alongside the right one. The relationship genuinely changes, so the phantom notification lands next to a real update. |
| attributes only | `bestFriend` in `attributes`, no `relationships` member | `setupRelationships` never runs, so the graph never sees the data. Asserts the relationship still points at the originally-linked resource — the payload's relationship data is simply discarded, and pre-fix the phantom notification invalidated that field's signal anyway, making a reader re-read an unchanged value. |

Both assert on the **notifications**, not on a property read. That distinction is load-bearing: outside a tracking frame a getter re-reads the cache on every access, and reading `record.bestFriend` goes through the graph regardless, so a value assertion passes with and without the bug. Only the notification shows it.

Both include a positive control — `name`, a genuine attribute change, asserted as still announced — so a silent no-op can't masquerade as a pass. Both assert `deepEqual` on the full delivered sequence rather than `notOk` on the bad keys, so an over-broad fix that silenced everything would fail too.

Both use the real `SchemaService` rather than the test app's `TestSchema`, which matters more than it looks: `TestSchema` doesn't implement `cacheFields`, so `getCacheFields` falls back to the full `fields()` map and the tests would exercise a field set — including `$key`, `$type`, `constructor`, and `@local` fields — that no application ever sees. Asserting on that would encode a test-harness gap as product behavior.

Coverage is on the `upsert` path. `didCommit` reaches the same function and is fixed by the same change, but [#11088](https://github.com/warp-drive-data/warp-drive/pull/11088) is in flight in that function's immediate neighborhood and I'd rather not collide with it. Happy to add the `didCommit` case here or after that lands, whichever you prefer.

<details>
<summary><b>Verification</b></summary>

- `tests/json-api` — 95 pass / 0 fail / 6 todo, against 93 pass / 2 fail / 6 todo without the source change
- `tests/core` 206, `tests/legacy` 134, `tests/ember-data__graph` 143, `tests/utilities` 105, `tests/dont-write-new-tests-here` 5344 — all green
- `check:types` clean on `warp-drive-packages/json-api`; `lint:oxfmt` and `lint:oxlint` clean from the repo root
- all of the above run on the pinned toolchain (node 26.8.1, bun 1.4.2) after `pnpm run sync`

On CI: `framework-ember` and `framework-react` are red here and on unrelated PRs including dependency bumps ([#11086](https://github.com/warp-drive-data/warp-drive/pull/11086), [#11085](https://github.com/warp-drive-data/warp-drive/pull/11085)). That is a holodeck bug, not this diff, and a fix is in flight in `packages/holodeck/server/`.

Mechanism, for anyone else who hits it: the mock server hands a Node `fs.ReadStream` to `new Response()`, and undici adapts an async-iterable body into a byte stream whose pull closes the controller in a queued microtask. A client aborting mid-response closes the controller first, so the queued `close()` throws — synchronously, inside a microtask, so it surfaces as an `uncaughtException` that nothing can `.catch()`. Under `bun ./diagnostic.js` the server is a standalone node child process, so it dies outright and every later request in the run fails as `network error`. Measured per-run crash rate on `origin/main` is high enough (10 of 14 runs for `framework-ember`) that a single red run there carries no signal in either direction. These are false failures only, never false passes — the reporter prints the denominator, and the error-state specs assert exact error text that a `network error` cannot satisfy. This branch needs no change for it.

</details>

## Follow-ups, deliberately not in this PR

Three things this investigation turned up. Each is separable from the guard above, and each changes something this one doesn't.

**1. `preloadData` mis-routes PolarisMode relationship kinds.** Detailed under [What it takes to trigger](#what-it-takes-to-trigger). It only recognizes `hasMany`/`belongsTo`, so `resource` and `collection` preloads are written into `attributes`. This is a plain bug with a user-facing entry point (`findRecord(..., { preload })`) and it wants its own PR — the fix is a kind check in two files, but it needs test coverage for the Polaris preload path, which doesn't exist today.

**2. `Cache#upsert` performs no validation.** `validateDocument` is reached only from `put`, so every route through `upsert` — including `preloadData` above — bypasses it entirely. Worth noting that this is lower-value than it first looks: the validator is itself gated behind the unreleased `JSON_API_CACHE_VALIDATION_ERRORS` canary flag, so extending it to `upsert` would extend a feature that is not yet on for `put` either. Sequencing it behind that flag's rollout is probably right.

**3. Filtering the `remoteAttrs` write.** Measured and documented under [Behavior change](#behavior-change): the phantom key reaches `peek()`, which re-emits it in `attributes` alongside the legitimate `relationships` entry. Separate PR rather than folded in here, for three reasons — it changes what the cache stores rather than what it announces, so its blast radius covers `peek`, cache dumps, and forking; it departs from the #9698 precedent this PR follows, which is a new decision rather than a continuation of an existing one; and the right shape for it may not be "filter the write" at all but "reject the payload," which is really (2). Deciding it alongside (2) will produce a better answer than deciding it here.

Resolved while investigating, so no longer open: `resource` and `collection` are covered by this PR's fix — probed directly against a PolarisMode schema rather than inferred, results in the [field-kinds table](#what-it-takes-to-trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
