### PR TITLE
fix(holodeck): stop aborted requests from killing the mock server

### DIFF
--- a/packages/holodeck/server/bun.js
+++ b/packages/holodeck/server/bun.js
@@ -4,6 +4,7 @@ import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 import fs from 'node:fs';
 import { createSecureServer } from 'node:http2';
+import { Readable } from 'node:stream';
 import { styleText } from 'node:util';
 import { Worker, threadId, parentPort } from 'node:worker_threads';
 import path from 'path';
@@ -42,14 +43,15 @@ async function replayRequest(context, cacheKey) {
 
   try {
     const bodyPath = `${cacheKey}.body.br`;
-    // Read the recorded body into memory rather than streaming it -- see the
-    // longer note on the same line in ./node.js. A Node `fs.ReadStream` handed
-    // to `new Response()` is adapted as an async iterable whose controller is
-    // closed from a queued microtask, so a client aborting mid-response can
-    // make that `close()` throw `ERR_INVALID_STATE` somewhere no handler can
-    // catch it, killing the mock-server process. Recorded bodies are tiny
-    // brotli-compressed fixtures with a `Content-Length` fixed at record time.
-    const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.readFileSync(bodyPath) : '';
+    // Convert to a web stream explicitly rather than handing `new Response()` a
+    // Node `Readable` -- see the longer note on the same line in ./node.js. A
+    // Node stream is adapted by undici as an async iterable whose controller is
+    // closed from a queued microtask, so a client aborting mid-response can make
+    // that `close()` throw `ERR_INVALID_STATE` somewhere no handler can catch
+    // it, killing the mock-server process. `Readable.toWeb` keeps the streaming
+    // behaviour while avoiding that adapter.
+    const bodyInit =
+      metaJson.status !== 204 && metaJson.status < 500 ? Readable.toWeb(fs.createReadStream(bodyPath)) : '';
 
     const headers = new Headers(metaJson.headers || {});
     const response = new Response(bodyInit, {

--- a/packages/holodeck/server/bun.js
+++ b/packages/holodeck/server/bun.js
@@ -43,13 +43,10 @@ async function replayRequest(context, cacheKey) {
 
   try {
     const bodyPath = `${cacheKey}.body.br`;
-    // Convert to a web stream explicitly rather than handing `new Response()` a
-    // Node `Readable` -- see the longer note on the same line in ./node.js. A
-    // Node stream is adapted by undici as an async iterable whose controller is
-    // closed from a queued microtask, so a client aborting mid-response can make
-    // that `close()` throw `ERR_INVALID_STATE` somewhere no handler can catch
-    // it, killing the mock-server process. `Readable.toWeb` keeps the streaming
-    // behaviour while avoiding that adapter.
+    // Hand `new Response()` a web stream explicitly, never a Node `Readable` --
+    // see the longer note on the same line in ./node.js. A Node stream reaches
+    // undici through an adapter whose queued-microtask `close()` races a client
+    // abort and can kill this process.
     const bodyInit =
       metaJson.status !== 204 && metaJson.status < 500 ? Readable.toWeb(fs.createReadStream(bodyPath)) : '';
 

--- a/packages/holodeck/server/bun.js
+++ b/packages/holodeck/server/bun.js
@@ -42,10 +42,16 @@ async function replayRequest(context, cacheKey) {
 
   try {
     const bodyPath = `${cacheKey}.body.br`;
-    const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.createReadStream(bodyPath) : '';
+    // Read the recorded body into memory rather than streaming it -- see the
+    // longer note on the same line in ./node.js. A Node `fs.ReadStream` handed
+    // to `new Response()` is adapted as an async iterable whose controller is
+    // closed from a queued microtask, so a client aborting mid-response can
+    // make that `close()` throw `ERR_INVALID_STATE` somewhere no handler can
+    // catch it, killing the mock-server process. Recorded bodies are tiny
+    // brotli-compressed fixtures with a `Content-Length` fixed at record time.
+    const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.readFileSync(bodyPath) : '';
 
     const headers = new Headers(metaJson.headers || {});
-    // @ts-expect-error - createReadStream is supported in node
     const response = new Response(bodyInit, {
       status: metaJson.status,
       statusText: metaJson.statusText,

--- a/packages/holodeck/server/node.js
+++ b/packages/holodeck/server/node.js
@@ -44,21 +44,14 @@ async function replayRequest(context, cacheKey) {
 
   try {
     const bodyPath = `${cacheKey}.body.br`;
-    // Convert to a web stream explicitly rather than handing `new Response()` a
-    // Node `Readable`. Undici treats a Node stream as an async iterable and
-    // adapts it into a byte stream whose controller it closes from inside a
-    // queued microtask. A client that aborts mid-response -- which the
-    // cancelled-request specs do deliberately, and which any real client does by
-    // navigating away -- closes that controller first, so the already-queued
-    // `close()` then throws `ERR_INVALID_STATE: ReadableStream is already
-    // closed`. Being a synchronous throw inside a microtask, it lands as an
-    // `uncaughtException` that no `.catch()` or `unhandledRejection` handler can
-    // intercept, and it terminates the whole mock-server process -- every later
-    // request in the run then fails as a network error.
-    //
-    // `Readable.toWeb` hands undici a real `ReadableStream`, which it uses
-    // directly instead of going through that adapter, so chunked reads,
-    // backpressure, and not buffering the whole body are all preserved.
+    // Hand `new Response()` a web stream explicitly. Undici treats a Node
+    // `Readable` as an async iterable and adapts it into a byte stream whose
+    // controller it closes from a queued microtask, so a client that aborts
+    // mid-response closes that controller first and the queued `close()` then
+    // throws `ERR_INVALID_STATE`. It throws synchronously inside a microtask,
+    // so it is an `uncaughtException` -- unreachable by `.catch()` or an
+    // `unhandledRejection` handler, and fatal to this process. Do not "fix" a
+    // recurrence by installing one; keep the body a real `ReadableStream`.
     const bodyInit =
       metaJson.status !== 204 && metaJson.status < 500 ? Readable.toWeb(fs.createReadStream(bodyPath)) : '';
 

--- a/packages/holodeck/server/node.js
+++ b/packages/holodeck/server/node.js
@@ -5,6 +5,7 @@ import { HTTPException } from 'hono/http-exception';
 import { logger } from 'hono/logger';
 import fs from 'node:fs';
 import { createSecureServer } from 'node:http2';
+import { Readable } from 'node:stream';
 import { styleText } from 'node:util';
 import { Worker, threadId, parentPort } from 'node:worker_threads';
 import path from 'path';
@@ -43,21 +44,23 @@ async function replayRequest(context, cacheKey) {
 
   try {
     const bodyPath = `${cacheKey}.body.br`;
-    // Read the recorded body into memory rather than streaming it. Handing a
-    // Node `fs.ReadStream` to `new Response()` leaves undici to adapt it as an
-    // async iterable, and that adapter closes the byte stream's controller from
-    // inside a queued microtask. A client that aborts mid-response (which the
-    // cancelled-request specs do deliberately) closes the controller first, so
-    // the already-queued `close()` then throws `ERR_INVALID_STATE: ReadableStream
-    // is already closed`. That throw happens synchronously inside a microtask,
-    // where no `.catch()` or `unhandledRejection` handler can reach it, so it
-    // terminates the whole mock-server process and every later request in the
-    // run fails as a network error.
+    // Convert to a web stream explicitly rather than handing `new Response()` a
+    // Node `Readable`. Undici treats a Node stream as an async iterable and
+    // adapts it into a byte stream whose controller it closes from inside a
+    // queued microtask. A client that aborts mid-response -- which the
+    // cancelled-request specs do deliberately, and which any real client does by
+    // navigating away -- closes that controller first, so the already-queued
+    // `close()` then throws `ERR_INVALID_STATE: ReadableStream is already
+    // closed`. Being a synchronous throw inside a microtask, it lands as an
+    // `uncaughtException` that no `.catch()` or `unhandledRejection` handler can
+    // intercept, and it terminates the whole mock-server process -- every later
+    // request in the run then fails as a network error.
     //
-    // Recorded bodies are brotli-compressed test fixtures -- the largest in this
-    // repo is under 200 bytes -- so streaming them buys nothing, and their
-    // `Content-Length` is already fixed at record time.
-    const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.readFileSync(bodyPath) : '';
+    // `Readable.toWeb` hands undici a real `ReadableStream`, which it uses
+    // directly instead of going through that adapter, so chunked reads,
+    // backpressure, and not buffering the whole body are all preserved.
+    const bodyInit =
+      metaJson.status !== 204 && metaJson.status < 500 ? Readable.toWeb(fs.createReadStream(bodyPath)) : '';
 
     const headers = new Headers(metaJson.headers || {});
     const response = new Response(bodyInit, {

--- a/packages/holodeck/server/node.js
+++ b/packages/holodeck/server/node.js
@@ -43,10 +43,23 @@ async function replayRequest(context, cacheKey) {
 
   try {
     const bodyPath = `${cacheKey}.body.br`;
-    const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.createReadStream(bodyPath) : '';
+    // Read the recorded body into memory rather than streaming it. Handing a
+    // Node `fs.ReadStream` to `new Response()` leaves undici to adapt it as an
+    // async iterable, and that adapter closes the byte stream's controller from
+    // inside a queued microtask. A client that aborts mid-response (which the
+    // cancelled-request specs do deliberately) closes the controller first, so
+    // the already-queued `close()` then throws `ERR_INVALID_STATE: ReadableStream
+    // is already closed`. That throw happens synchronously inside a microtask,
+    // where no `.catch()` or `unhandledRejection` handler can reach it, so it
+    // terminates the whole mock-server process and every later request in the
+    // run fails as a network error.
+    //
+    // Recorded bodies are brotli-compressed test fixtures -- the largest in this
+    // repo is under 200 bytes -- so streaming them buys nothing, and their
+    // `Content-Length` is already fixed at record time.
+    const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.readFileSync(bodyPath) : '';
 
     const headers = new Headers(metaJson.headers || {});
-    // @ts-expect-error - createReadStream is supported in node
     const response = new Response(bodyInit, {
       status: metaJson.status,
       statusText: metaJson.statusText,


### PR DESCRIPTION
## The bug

**A test that aborts an in-flight request can kill the holodeck mock server, and every test after it fails as a network error.**

The server process dies with an uncaught exception. Nothing in the run recovers, because nothing restarts it:

```
TypeError [ERR_INVALID_STATE]: Invalid state: ReadableStream is already closed
    at ReadableByteStreamController.close (node:internal/webstreams/readablestream:1275:13)
    at node:internal/deps/undici/undici:1994:30
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

This is pre-existing and independent of any branch's diff — it reproduces on `origin/main`, and the same job set has been failing on dependency-bump-only PRs.

The failures it produces are always false, never false passes. The reporter still prints the true denominator, so `Total 70 / # pass 70` means all 70 really ran; and the error-state specs assert exact error text, which a `network error` cannot satisfy.

## How it presents

Cascade size is just how far the run got before the server died, which is why the same defect looks like three different problems:

1. **A partial suite.** The server dies mid-run and the remaining tests fail as `network error` — e.g. 20 of 70 passing, or 61 of 70.

2. **A whole package at 0ms.** The server died during an earlier app's run, so the next app's tests fail before any of them can issue a request. Every test at 0ms in one package looks like a harness or boot crash rather than an abort race.

3. **A different package each run.** `framework-ember` one run, `framework-react` the next. That scatter reads as a race because it is one — which package loses depends on where the abort lands.

## What aborts, and why that is correct

Every abort involved is deliberate. The shared specs call `request.abort()` at 8 sites — 4 in `specs/src/request-component.spec.ts`, 4 in `specs/src/paginate-component.spec.ts` — and each asserts on the abort behaviour itself (`'Cancelled:The user aborted a request.Count:2Retry'`, `'the abort reason falls through to the error block'`). `Future#abort` is public API and cancel-then-retry is a supported capability, so these specs are testing a real feature and should not change.

Nothing aborts incidentally. No component tears down an in-flight request on unmount, and the only client-side stream aborts (`fetch.ts:209`, `fetch.ts:244`) sit inside `context.request.signal?.addEventListener('abort', …)` handlers, so they fire only when a consumer aborted — normal completion takes the `done → writer.close()` path with no cancel.

As a cross-check that nothing else contributes: 8 abort sites at roughly a 13% race-hit each predicts `1 - 0.87^8 ≈ 67%` of runs crashing, against the 71% measured below. Deliberate aborts alone account for the observed rate.

A client disappearing mid-response is also not a test-only condition — a browser navigating away does the same thing to a local holodeck server. The server needing to survive it is the actual defect.

## Why it happens

Glossary, for anyone following along:

- **`replayRequest`** — serves a previously-recorded fixture back to the test that asks for it.
- **`bodyInit`** — whatever gets handed to `new Response()` as the body.
- **the async-iterable adapter** — undici's conversion of a Node `Readable` into a web `ReadableStream` of `type: 'bytes'`.
- **`compat-shim.js`** — spawns the mock server as a `node` child process when the test runner itself is bun, which is the path every suite here takes.

`replayRequest` handed `new Response()` a Node stream directly:

```js
const bodyInit = metaJson.status !== 204 && metaJson.status < 500 ? fs.createReadStream(bodyPath) : '';
//                                                                  ^^^^^^^^^^^^^^^^^^^ a Node Readable
```

A Node `Readable` is an async iterable, so undici adapts it into a byte stream whose `pull` closes the controller **from inside a queued microtask** rather than synchronously. That queued `close()` and a client abort then race for the same controller:

| event | effect on the controller |
| --- | --- |
| the abort arrives first | closes the controller |
| the queued microtask then runs | calls `close()` on an already-closed controller → **throws** |

Two properties turn that throw from noise into a process kill:

- **It is not a rejection.** It is a synchronous throw inside a microtask, so it surfaces as an `uncaughtException`. No `.catch()`, and no `unhandledRejection` handler, can intercept it — which is also why adding one would not have helped.
- **The server is its own process.** Under `bun ./diagnostic.js`, `compat-shim.js` spawns `node node-compat-start.js`, and `useWorker` is never set on that path, so the replay handler runs on that child's main thread. The throw takes the whole mock server with it, and `compat-shim`'s `reprintErrors` is why a Node banner shows up in the middle of a browser test run.

**It does not happen when nothing aborts.** A response read to completion closes the controller exactly once, which is why the great majority of requests are fine and this reads as flake rather than breakage.

## The fix

Convert to a web stream explicitly instead of letting undici adapt a Node one:

```js
const bodyInit =
  metaJson.status !== 204 && metaJson.status < 500 ? Readable.toWeb(fs.createReadStream(bodyPath)) : '';
```

`Readable.toWeb` hands undici a real `ReadableStream`, which it consumes directly rather than through the async-iterable adapter, so the microtask `close()` that races the abort never enters the picture. Streaming behaviour is unchanged: chunked reads, backpressure, and no whole-body buffering are all preserved.

Applied to both `node.js` and `bun.js`, which held identical copies of this block. The `@ts-expect-error` that annotated the old Node-stream body is no longer needed — `check:types` passes without it.

Rejected alternatives:

- **`fs.readFileSync` into a Buffer** — also measured clean, and simpler. But it gives up chunked reads, backpressure, and non-blocking reads, and while none of those are engaged at present fixture sizes (default `highWaterMark` is 65536 bytes; the largest recorded body in the repo is 173, so every fixture already arrives in one chunk), a future large recording would silently reintroduce a blocking whole-file read. `toWeb` costs nothing to keep them.
- **A `process.on('uncaughtException')` handler** — would hide the next real server fault, and the cause is reachable at its source, so there is no reason to swallow it.
- **Guarding the `close()` call** — not ours to guard; it is inside undici.
- **Changing the specs** — they are testing a supported feature, and the server has to survive a client disconnect regardless.

## Verification

A/B by toggling only these two files between their `origin/main` and fixed contents. holodeck's `server/*.js` are hardlinked into each test app's `node_modules` (same inode), so a swap takes effect with no rebuild.

| suite | variant | runs | crash runs | clean |
| --- | --- | --- | --- | --- |
| `framework-ember` | `origin/main` | 14 | **10** (71%) | 3 |
| `framework-ember` | fixed | 20 | **0** | 20 × 70/70 |
| `framework-react` | `origin/main` | 8 | **2** (25%) | 6 |
| `framework-react` | fixed | 20 | **0** | 20 × 39/39 |

Baseline crash runs lost between 9 and 50 of 70 tests, matching the cascade shapes above.

<details>
<summary><b>Reproducing the mechanism in isolation</b></summary>

The race reproduces in a bare script with no holodeck, hono, or WarpDrive code on the stack — `new Response(<body>)` plus a consumer that cancels mid-body, at varying microtask and timer offsets. The stack it produces matches the CI banner frame for frame.

| Node | Response body | faults / 2000 cancel attempts |
| --- | --- | --- |
| 26.8.1 | `fs.createReadStream` | 10 |
| 26.8.1 | `Readable.toWeb(...)` | 0 |
| 26.8.1 | `fs.readFileSync` → Buffer | 0 |
| 24.11.1 | `fs.createReadStream` | 3 (per 200) |

Not specific to a Node version — Node 24 faults at a comparable rate to the pinned 26.8.1, so the pin is not implicated.

The same script shows the fault arriving as `uncaughtException` with zero `unhandledRejection` events, which is the evidence for the "not a rejection" claim above.

Separately, since the fix keeps a stream open per request: 300 cancelled `toWeb` bodies leave 0 open descriptors to the fixture and raise 0 uncaught exceptions, so the cancel path destroys the underlying `ReadStream` rather than leaking it.

</details>

<details>
<summary><b>Full verification</b></summary>

- Neighbour suites, one run each with the fix in place, all with no crash and zero failures: `json-api` 93/99, `core` 206/208, `legacy` 134/137, `ember-data__graph` 143/143, `utilities` 105/105, `dont-write-new-tests-here` 5344/5349
- All four lint steps clean: `lint:oxfmt`, `lint:prettier`, `lint:oxlint`, `lint`
- `check:types` clean on `packages/holodeck`

</details>

## No new test, and why

`packages/holodeck` has no test suite — no `test` script and no test files — so there is nowhere for a regression test to live without standing up new infrastructure for the package. I did not widen the PR to do that.

What stands in for it is the isolation script above, which pins the mechanism precisely and fails against the old body type. Happy to land it as the seed of a holodeck test suite, here or separately, if you want the coverage.

## Open questions

- **`bun.js`'s replay path is exercised by no suite.** `useBun` is only ever `false` in this repo (`tests/ember-data__request` sets it explicitly; nothing sets it true), so that file's copy of the fix is applied by symmetry with `node.js` and is not covered by the runs above. Left symmetric on the grounds that divergent copies of the same handler are worse than an untested one.
- **A separate `framework-ember` flake remains.** `Spec | <Paginate /> | ember:multiple paginate components have individual rendering states while sharing cached pages` fails intermittently on a render-count assertion (`Count: 3` vs `Count: 4`) with no network error involved. It appeared once across the 14 baseline runs and never across the fixed runs. Different mechanism, untouched here, worth its own issue.
- **A contributor-setup gap, separate from this change.** `pnpm install --force` alone leaves a fresh worktree in a state where oxlint reports type errors in untouched files, holodeck's `check:types` cannot resolve `@warp-drive/legacy` subpaths, and every browser suite dies at `Diagnostic Watchdog: No browser reported in within 45s`. The `pnpm run sync` step CI runs after install clears all three. The watchdog message in particular looks like a broken browser and is not one. Happy to add that to the worktree setup skill.

<sub>**AI attribution:** :robot: _Claude using Opus 5 (1M context). Root cause established by isolated reproduction; before/after rates measured over suite runs on both framework packages. The code change has been reviewed by the author._</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
