### PR TITLE
fix(legacy): route PolarisMode relationship preloads to `relationships`

### DIFF
--- a/tests/legacy/tests/integration/preload-routing-test.ts
+++ b/tests/legacy/tests/integration/preload-routing-test.ts
@@ -1,0 +1,182 @@
+import { setOwner } from '@ember/owner';
+
+import { withDefaults } from '@warp-drive/core/reactive';
+import type { ResourceKey } from '@warp-drive/core/types';
+import type { Type } from '@warp-drive/core/types/symbols';
+import { module, setupTest, test } from '@warp-drive/diagnostic/ember';
+import { JSONAPICache } from '@warp-drive/json-api';
+import { useLegacyStore } from '@warp-drive/legacy';
+import { withRestoredDeprecatedModelRequestBehaviors as withLegacy } from '@warp-drive/legacy/model/migration-support';
+
+type User = {
+  id: string | null;
+  $type: 'user';
+  name: string;
+  [Type]: 'user';
+};
+
+const Store = useLegacyStore({
+  linksMode: false,
+  cache: JSONAPICache,
+});
+
+interface TestStore {
+  findRecord: (type: string, id: string, options: object) => Promise<unknown>;
+}
+
+/**
+ * `preloadData` runs synchronously inside `findRecord`, before the request is
+ * issued, so the request never has to resolve for the preload to be observable.
+ * No adapter or handler is registered here; the rejection is expected and
+ * swallowed.
+ */
+function preloadViaFindRecord(store: unknown, id: string, preload: Record<string, unknown>): void {
+  void (store as TestStore).findRecord('user', id, { preload }).catch(() => undefined);
+}
+
+function setupStore(context: { owner: object }): InstanceType<typeof Store> {
+  const store = new Store();
+  setOwner(store, context.owner as Parameters<typeof setOwner>[1]);
+  return store;
+}
+
+module('Integration | preload | relationship data is routed to `relationships`', function (hooks) {
+  setupTest(hooks);
+
+  // A resource can be in PolarisMode while the store it lives in still offers
+  // the legacy `preload` option — that is the incremental-migration path. The
+  // routing in `preloadData` originally recognized only LegacyMode's
+  // `belongsTo`/`hasMany`, so PolarisMode's `resource`/`collection` fell
+  // through to the `attributes` branch: the raw preload value was written into
+  // the cache as an attribute and the relationship was never established.
+  test('a PolarisMode `resource` preloaded by id becomes a relationship, not an attribute', function (assert) {
+    const store = setupStore(this);
+    store.schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          { name: 'bestFriend', kind: 'resource', type: 'user', options: { inverse: null, async: false } },
+        ],
+      })
+    );
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    preloadViaFindRecord(store, '1', { bestFriend: '2' });
+
+    const peeked = store.cache.peek(key);
+    assert.deepEqual(peeked?.attributes, {}, 'the relationship id was not written into `attributes`');
+    assert.deepEqual(
+      peeked?.relationships,
+      { bestFriend: { data: { type: 'user', id: '2', lid: '@lid:user-2' } } },
+      'the relationship was established in the graph'
+    );
+  });
+
+  test('a PolarisMode `collection` preloaded by ids becomes a relationship, not an attribute', function (assert) {
+    const store = setupStore(this);
+    store.schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          { name: 'friends', kind: 'collection', type: 'user', options: { inverse: null, async: false } },
+        ],
+      })
+    );
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    preloadViaFindRecord(store, '1', { friends: ['2', '3'] });
+
+    const peeked = store.cache.peek(key);
+    assert.deepEqual(peeked?.attributes, {}, 'the relationship ids were not written into `attributes`');
+    assert.deepEqual(
+      peeked?.relationships,
+      {
+        friends: {
+          data: [
+            { type: 'user', id: '2', lid: '@lid:user-2' },
+            { type: 'user', id: '3', lid: '@lid:user-3' },
+          ],
+        },
+      },
+      'the collection was established in the graph, in order'
+    );
+  });
+
+  test('a PolarisMode `resource` preloaded by record instance becomes a relationship', function (assert) {
+    const store = setupStore(this);
+    store.schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          { name: 'bestFriend', kind: 'resource', type: 'user', options: { inverse: null, async: false } },
+        ],
+      })
+    );
+    const friend = store.push<User>({ data: { type: 'user', id: '2', attributes: { name: 'Wes' } } });
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    preloadViaFindRecord(store, '1', { bestFriend: friend });
+
+    const peeked = store.cache.peek(key);
+    assert.deepEqual(peeked?.attributes, {}, 'the record was not written into `attributes`');
+    assert.deepEqual(
+      peeked?.relationships,
+      { bestFriend: { data: { type: 'user', id: '2', lid: '@lid:user-2' } } },
+      'the identifier was extracted from the record instance'
+    );
+  });
+
+  // Controls. These pass before and after the fix, and exist so that a change
+  // which over-corrects — routing attributes into `relationships`, or breaking
+  // the LegacyMode kinds that already worked — fails here.
+  test('LegacyMode `belongsTo` and `hasMany` still route to `relationships`', function (assert) {
+    const store = setupStore(this);
+    store.schema.registerResource(
+      withLegacy({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'attribute', type: null },
+          { name: 'bestFriend', kind: 'belongsTo', type: 'user', options: { inverse: null, async: false } },
+          { name: 'friends', kind: 'hasMany', type: 'user', options: { inverse: null, async: false } },
+        ],
+      })
+    );
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    preloadViaFindRecord(store, '1', { bestFriend: '2', friends: ['3'] });
+
+    const peeked = store.cache.peek(key);
+    assert.deepEqual(peeked?.attributes, {}, 'no relationship data leaked into `attributes`');
+    assert.deepEqual(
+      peeked?.relationships,
+      {
+        bestFriend: { data: { type: 'user', id: '2', lid: '@lid:user-2' } },
+        friends: { data: [{ type: 'user', id: '3', lid: '@lid:user-3' }] },
+      },
+      'both legacy relationship kinds were established in the graph'
+    );
+  });
+
+  test('a genuine attribute is still preloaded into `attributes`', function (assert) {
+    const store = setupStore(this);
+    store.schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          { name: 'bestFriend', kind: 'resource', type: 'user', options: { inverse: null, async: false } },
+        ],
+      })
+    );
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    preloadViaFindRecord(store, '1', { name: 'Chris' });
+
+    const peeked = store.cache.peek(key);
+    assert.deepEqual(peeked?.attributes, { name: 'Chris' }, 'the attribute was preloaded as an attribute');
+    assert.deepEqual(peeked?.relationships, {}, 'no relationship was invented for it');
+  });
+});

--- a/warp-drive-packages/core/src/store/deprecated/-private.ts
+++ b/warp-drive-packages/core/src/store/deprecated/-private.ts
@@ -9,9 +9,11 @@ import type { NewResourceKey, ResourceKey } from '../../types/identifier.ts';
 import type { Value } from '../../types/json/raw';
 import type { OpaqueRecordInstance, TypedRecordInstance, TypeFromInstance } from '../../types/record.ts';
 import type {
+  CollectionField,
+  FieldSchema,
   LegacyAttributeField,
   LegacyRelationshipField,
-  LegacyRelationshipField as RelationshipSchema,
+  ResourceField,
 } from '../../types/schema/fields.ts';
 import type {
   ExistingResourceIdentifierObject,
@@ -33,6 +35,13 @@ import type { Store } from './store.ts';
     models.
   */
 type PreloadRelationshipValue = OpaqueRecordInstance | string;
+
+/**
+ * Every field kind whose data belongs in a ResourceObject's `relationships`:
+ * LegacyMode's `belongsTo`/`hasMany` and their PolarisMode counterparts
+ * `resource`/`collection`.
+ */
+type RelationshipSchema = LegacyRelationshipField | ResourceField | CollectionField;
 export function preloadData(store: Store, identifier: NewResourceKey, preload: Record<string, Value>): void {
   const jsonPayload: Partial<ExistingResourceObject> = {};
   //TODO(Igor) consider the polymorphic case
@@ -42,7 +51,7 @@ export function preloadData(store: Store, identifier: NewResourceKey, preload: R
     const preloadValue = preload[key];
 
     const field = fields.get(key);
-    if (field && (field.kind === 'hasMany' || field.kind === 'belongsTo')) {
+    if (field && isPreloadableRelationship(field)) {
       if (!jsonPayload.relationships) {
         jsonPayload.relationships = {};
       }
@@ -59,18 +68,32 @@ export function preloadData(store: Store, identifier: NewResourceKey, preload: R
   cache.upsert(identifier, jsonPayload, hasRecord);
 }
 
+/**
+ * Relationship data belongs in `relationships`, never in `attributes`. Both
+ * field-kind vocabularies have to be recognized here: LegacyMode's
+ * `belongsTo`/`hasMany` and PolarisMode's `resource`/`collection`. A resource
+ * can be in PolarisMode while its store still offers the legacy `preload`
+ * option, so only checking the legacy pair silently routed `resource` and
+ * `collection` preloads into `attributes`.
+ */
+function isPreloadableRelationship(field: FieldSchema): field is RelationshipSchema {
+  const { kind } = field;
+  return kind === 'belongsTo' || kind === 'hasMany' || kind === 'resource' || kind === 'collection';
+}
+
 function preloadRelationship(
   schema: RelationshipSchema,
   preloadValue: PreloadRelationshipValue | null | Array<PreloadRelationshipValue>
 ): InnerRelationshipDocument<ExistingResourceIdentifierObject> {
   const relatedType = schema.type;
+  const { kind } = schema;
 
-  if (schema.kind === 'hasMany') {
-    assert('You need to pass in an array to set a hasMany property on a record', Array.isArray(preloadValue));
+  if (kind === 'hasMany' || kind === 'collection') {
+    assert(`You need to pass in an array to set a ${kind} property on a record`, Array.isArray(preloadValue));
     return { data: preloadValue.map((value) => _convertPreloadRelationshipToJSON(value, relatedType)) };
   }
 
-  assert('You should not pass in an array to set a belongsTo property on a record', !Array.isArray(preloadValue));
+  assert(`You should not pass in an array to set a ${kind} property on a record`, !Array.isArray(preloadValue));
   return { data: preloadValue ? _convertPreloadRelationshipToJSON(preloadValue, relatedType) : null };
 }
 

--- a/warp-drive-packages/legacy/src/store/-private.ts
+++ b/warp-drive-packages/legacy/src/store/-private.ts
@@ -13,9 +13,11 @@ import type { NewResourceKey, ResourceKey } from '@warp-drive/core/types/identif
 import type { Value } from '@warp-drive/core/types/json/raw';
 import type { OpaqueRecordInstance, TypedRecordInstance, TypeFromInstance } from '@warp-drive/core/types/record';
 import type {
+  CollectionField,
+  FieldSchema,
   LegacyAttributeField,
   LegacyRelationshipField,
-  LegacyRelationshipField as RelationshipSchema,
+  ResourceField,
 } from '@warp-drive/core/types/schema/fields';
 import type {
   ExistingResourceIdentifierObject,
@@ -38,6 +40,13 @@ import type { Store } from '../store.ts';
     models.
   */
 type PreloadRelationshipValue = OpaqueRecordInstance | string;
+
+/**
+ * Every field kind whose data belongs in a ResourceObject's `relationships`:
+ * LegacyMode's `belongsTo`/`hasMany` and their PolarisMode counterparts
+ * `resource`/`collection`.
+ */
+type RelationshipSchema = LegacyRelationshipField | ResourceField | CollectionField;
 export function preloadData(store: Store, identifier: NewResourceKey, preload: Record<string, Value>): void {
   const jsonPayload: Partial<ExistingResourceObject> = {};
   //TODO(Igor) consider the polymorphic case
@@ -47,7 +56,7 @@ export function preloadData(store: Store, identifier: NewResourceKey, preload: R
     const preloadValue = preload[key];
 
     const field = fields.get(key);
-    if (field && (field.kind === 'hasMany' || field.kind === 'belongsTo')) {
+    if (field && isPreloadableRelationship(field)) {
       if (!jsonPayload.relationships) {
         jsonPayload.relationships = {};
       }
@@ -65,18 +74,32 @@ export function preloadData(store: Store, identifier: NewResourceKey, preload: R
   cache.upsert(identifier, jsonPayload, hasRecord);
 }
 
+/**
+ * Relationship data belongs in `relationships`, never in `attributes`. Both
+ * field-kind vocabularies have to be recognized here: LegacyMode's
+ * `belongsTo`/`hasMany` and PolarisMode's `resource`/`collection`. A resource
+ * can be in PolarisMode while its store still offers the legacy `preload`
+ * option, so only checking the legacy pair silently routed `resource` and
+ * `collection` preloads into `attributes`.
+ */
+function isPreloadableRelationship(field: FieldSchema): field is RelationshipSchema {
+  const { kind } = field;
+  return kind === 'belongsTo' || kind === 'hasMany' || kind === 'resource' || kind === 'collection';
+}
+
 function preloadRelationship(
   schema: RelationshipSchema,
   preloadValue: PreloadRelationshipValue | null | Array<PreloadRelationshipValue>
 ): InnerRelationshipDocument<ExistingResourceIdentifierObject> {
   const relatedType = schema.type;
+  const { kind } = schema;
 
-  if (schema.kind === 'hasMany') {
-    assert('You need to pass in an array to set a hasMany property on a record', Array.isArray(preloadValue));
+  if (kind === 'hasMany' || kind === 'collection') {
+    assert(`You need to pass in an array to set a ${kind} property on a record`, Array.isArray(preloadValue));
     return { data: preloadValue.map((value) => _convertPreloadRelationshipToJSON(value, relatedType)) };
   }
 
-  assert('You should not pass in an array to set a belongsTo property on a record', !Array.isArray(preloadValue));
+  assert(`You should not pass in an array to set a ${kind} property on a record`, !Array.isArray(preloadValue));
   return { data: preloadValue ? _convertPreloadRelationshipToJSON(preloadValue, relatedType) : null };
 }
 


### PR DESCRIPTION
## What you would notice

**You preload a relationship, and the relationship is still empty.**

`preload` exists so you can tell the store about a record you already have, without fetching it — most often so a nested URL like `/users/2/posts/1` can be built. If the relationship is declared with PolarisMode's `resource` or `collection`, the preload silently does nothing for that field.

```ts
// `bestFriend` is declared `kind: 'resource'`, and user 2 is already loaded
store.findRecord('user', '1', { preload: { bestFriend: '2' } });

const user = store.peekRecord('user', '1');
user.bestFriend.data;          // => null   ← you just preloaded this
```

| | `user.bestFriend.data` |
| --- | --- |
| before | `null` — the preload was silently discarded |
| after | the related record, `.name === 'Wes'` |

No error, no warning, nothing in the console. The symptoms you would actually chase:

- a relationship you explicitly preloaded reads as empty, so a template bound to it renders nothing
- the fetch you were trying to avoid happens anyway, because the data you supplied never landed where the relationship reads from
- if the relationship is `async`, you get a network request for a record that is already in the store
- saving the record later sends a junk attribute to your API — a field named after your relationship, whose value is the id string or the serialized record you passed to `preload`

It only affects relationships declared in PolarisMode. The same code in LegacyMode (`belongsTo`/`hasMany`) has always worked, which is why this survived: it breaks exactly when a resource is migrated to the newer field kinds while the app still uses `preload`.

## What goes wrong internally

The preload value is written into the resource's `attributes` instead of its `relationships`, so the graph never learns about the link:

| | `peek().attributes` | `peek().relationships` |
| --- | --- | --- |
| before | `{"bestFriend":"2"}` | `{}` |
| after | `{}` | `{"bestFriend":{"data":{"type":"user","id":"2","lid":"@lid:user-2"}}}` |

No misbehaving API is involved — this payload is generated by WarpDrive itself, in dev and production alike.

## Why it happens

`preloadData` decides which bucket a preload value belongs in by testing the field's kind:

```js
const field = fields.get(key);
if (field && (field.kind === 'hasMany' || field.kind === 'belongsTo')) {
  jsonPayload.relationships[key] = preloadRelationship(field, preloadValue);
} else {
  jsonPayload.attributes[key] = preloadValue;   // ← everything else
}
```

Those are LegacyMode's two relationship kinds. PolarisMode names the same two shapes `resource` and `collection`, and neither is recognized, so both fall through to the `attributes` branch. The resulting ResourceObject goes straight to `cache.upsert`.

**This is reachable because the store and the schema can be in different modes.** A resource can be in PolarisMode while the store it lives in still offers the legacy `preload` option — that is the incremental-migration path, not a misconfiguration. `preloadData` reads `store.schema.fields(identifier)`, which returns whatever kinds the schema declares, so a PolarisMode schema on `@warp-drive/legacy`'s store (or core's deprecated store) lands here.

It also produces a ResourceObject that violates {json:api}'s [shared-namespace rule for fields](https://jsonapi.org/format/#document-resource-object-fields) whenever the same name is later returned in `relationships` by the actual request.

## The fix

```js
function isPreloadableRelationship(field: FieldSchema): field is RelationshipSchema {
  const { kind } = field;
  return kind === 'belongsTo' || kind === 'hasMany' || kind === 'resource' || kind === 'collection';
}
```

and `preloadRelationship` now branches on the array-shaped kinds rather than on `hasMany` alone:

```js
if (kind === 'hasMany' || kind === 'collection') { … }
```

Its two asserts interpolate the field's actual kind, so misusing a `collection` no longer reports *"you need to pass in an array to set a hasMany property on a record"*.

`RelationshipSchema` was an import alias for `LegacyRelationshipField`; it is now `LegacyRelationshipField | ResourceField | CollectionField`. It is referenced only by these two functions, so the widening is contained.

### Applied to both copies

This code exists twice, byte-identical in this region apart from one `assertPrivateStore` call:

- `warp-drive-packages/legacy/src/store/-private.ts`
- `warp-drive-packages/core/src/store/deprecated/-private.ts`

Both are fixed. I did not attempt to deduplicate them — that is a larger change than this bug warrants, and the two live in different packages with different import styles.

<details>
<summary><b>Considered and rejected: reusing the graph's helpers</b></summary>

`core/src/graph/-private/-edge-definition.ts` already exports `isRelationshipField` and `temporaryConvertToLegacy`, and core itself uses the `isLegacyField(x) ? x : temporaryConvertToLegacy(x)` idiom in four places. That was my first implementation.

It does not build: neither helper is re-exported from the `graph/-private.ts` barrel, which is a curated surface carrying an explicit warning that it is unstable and "not fit for direct application or 3rd party library usage". Adding three runtime exports to it so that `preloadData` can borrow them trades a four-line local predicate for a widened cross-package commitment on a surface the team has deliberately kept small.

If those helpers are promoted later, `isPreloadableRelationship` is the obvious thing to delete.

</details>

## Tests

`tests/legacy/tests/integration/preload-routing-test.ts` — 5 tests. Three fail without the source change:

| test | fails pre-fix? |
| --- | --- |
| PolarisMode `resource` preloaded by id | ✅ yes |
| PolarisMode `collection` preloaded by ids | ✅ yes |
| PolarisMode `resource` preloaded by record instance | ✅ yes |
| LegacyMode `belongsTo`/`hasMany` still route to `relationships` | no — control |
| a genuine attribute still routes to `attributes` | no — control |

The two controls exist so an over-correction fails here too: one pins the LegacyMode kinds that already worked, the other pins that an ordinary attribute does not get a relationship invented for it.

Assertions are against `cache.peek()` rather than a property read, so they state which bucket the data actually landed in rather than what a getter resolves to. The commits are ordered tests-then-fix, so the defect is recorded in history independently of the fix.

There was no existing preload coverage outside `tests/dont-write-new-tests-here`, and none anywhere for PolarisMode preloads.

<details>
<summary><b>Verification</b></summary>

All on the pinned toolchain (node 26.8.1, bun 1.4.2) after `pnpm install --force` and `pnpm run sync`:

- `tests/legacy` — 139 pass / 0 fail, against 136 pass / 3 fail without the source change
- `tests/core` 206, `tests/json-api` 93, `tests/ember-data__graph` 143, `tests/utilities` 105, `tests/dont-write-new-tests-here` 5344, `tests/ember-data__model` 2, `tests/ember-data__adapter` 67 — all green
- `check:types` clean on `@warp-drive/core` and `@warp-drive/legacy`; `lint:oxfmt` and `lint:oxlint` clean from the repo root

`framework-ember` and `framework-react` are excluded deliberately: they are currently flaky for an unrelated reason (the holodeck mock server dies on an aborted request, taking every later request in the run with it). A fix for that is in flight in #11092.

</details>

## Behavior change

Any codebase that preloads a PolarisMode `resource`/`collection` field currently gets the raw value stored as an attribute. After this change it becomes a relationship. Two consequences worth naming:

- Anything reading the bogus attribute value back out of the cache stops seeing it. That value was never readable through the field itself — the field resolves through the graph — so this is only reachable via `cache.peek()` or similar raw inspection.
- `preloadRelationship`'s asserts now fire for `collection` preloads that pass a non-array (and `resource` preloads that pass an array). Previously those silently became attributes. This surfaces existing mistakes rather than introducing new ones, but it will surface them as assertion failures in development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
