### PR TITLE
fix(json-api): keep relationship data out of `remoteAttrs`

### DIFF
--- a/tests/json-api/tests/integration/cache/remote-attrs-field-kinds-test.ts
+++ b/tests/json-api/tests/integration/cache/remote-attrs-field-kinds-test.ts
@@ -1,0 +1,131 @@
+import { Store } from '@warp-drive/core';
+import { registerDerivations, SchemaService, withDefaults } from '@warp-drive/core/reactive';
+import type { CacheCapabilitiesManager, ResourceKey } from '@warp-drive/core/types';
+import type { ResourceObject } from '@warp-drive/core/types/spec/json-api-raw';
+import { module, test } from '@warp-drive/diagnostic';
+import { JSONAPICache as Cache } from '@warp-drive/json-api';
+import { serializeResources } from '@warp-drive/utilities/json-api';
+
+/**
+ * Uses the real `SchemaService` rather than the test app's `TestSchema`
+ * because only the real one implements `cacheFields`. The filter consults
+ * whatever `getCacheFields` returns, and that falls back to the much broader
+ * `fields()` map for a schema service without `cacheFields` — a field set no
+ * application actually sees.
+ */
+class TestStore extends Store {
+  createSchemaService() {
+    const schema = new SchemaService();
+    registerDerivations(schema);
+    schema.registerResource(
+      withDefaults({
+        type: 'user',
+        fields: [
+          { name: 'name', kind: 'field' },
+          {
+            name: 'bestFriend',
+            kind: 'belongsTo',
+            type: 'user',
+            options: { inverse: null, async: false, linksMode: true },
+          },
+        ],
+      })
+    );
+    return schema;
+  }
+
+  override createCache(wrapper: CacheCapabilitiesManager) {
+    return new Cache(wrapper);
+  }
+}
+
+/**
+ * {json:api} requires a resource's fields to share one namespace, so this
+ * payload — carrying `bestFriend` in `attributes` *and* `relationships` — is
+ * invalid. It is the realistic shape of the mistake: a serializer emitting
+ * linkage into the wrong bucket alongside the right one.
+ *
+ * https://jsonapi.org/format/#document-resource-object-fields
+ */
+function malformedPayload(): ResourceObject {
+  return {
+    type: 'user',
+    id: '1',
+    attributes: { name: 'Chris', bestFriend: { type: 'user', id: '2' } },
+    relationships: { bestFriend: { data: { type: 'user', id: '2' } } },
+  };
+}
+
+module('Integration | JSONAPICache | relationship data never enters `remoteAttrs`', function () {
+  test('`upsert` does not merge a relationship name from `attributes` into the cached attributes', function (assert) {
+    const store = new TestStore();
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    store.cache.upsert(key, malformedPayload(), false);
+
+    const peeked = store.cache.peek(key) as ResourceObject;
+    assert.deepEqual(peeked.attributes, { name: 'Chris' }, 'only the genuine attribute is in `attributes`');
+    assert.deepEqual(
+      peeked.relationships,
+      { bestFriend: { data: { type: 'user', id: '2', lid: '@lid:user-2' } } },
+      'the relationship is still established from the `relationships` member'
+    );
+  });
+
+  // This is the consequence that reaches the network. `serializeResources`
+  // builds its body from `cache.peek`, and post-processes only the
+  // `relationships` member — so anything left in `attributes` is sent as-is.
+  // Before this change the request body carried `bestFriend` in both buckets,
+  // making the *outgoing* document invalid too.
+  test('a subsequent save does not echo the phantom attribute back to the API', function (assert) {
+    const store = new TestStore();
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    store.cache.upsert(key, malformedPayload(), false);
+
+    const body = serializeResources(store.cache, key);
+    assert.deepEqual(
+      body.data,
+      {
+        type: 'user',
+        id: '1',
+        attributes: { name: 'Chris' },
+        relationships: { bestFriend: { data: { id: '2', type: 'user' } } },
+      },
+      'the serialized document carries `bestFriend` only under `relationships`'
+    );
+  });
+
+  test('`didCommit` does not merge a relationship name from the save response into the cached attributes', function (assert) {
+    const store = new TestStore();
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    store.cache.upsert(key, { type: 'user', id: '1', attributes: { name: 'Chris' } }, false);
+    store.cache.willCommit(key, null);
+    store.cache.didCommit(key, {
+      request: {},
+      response: new Response(),
+      content: { data: malformedPayload() },
+    } as unknown as Parameters<typeof store.cache.didCommit>[1]);
+
+    const peeked = store.cache.peek(key) as ResourceObject;
+    assert.deepEqual(peeked.attributes, { name: 'Chris' }, 'the save response did not add a phantom attribute');
+  });
+
+  // Control: the filter must not touch anything that legitimately belongs in
+  // `attributes`, including a field the schema does not declare — those are
+  // already tolerated by the cache and this change does not alter that.
+  test('genuine attributes are unaffected', function (assert) {
+    const store = new TestStore();
+    const key: ResourceKey = store.cacheKeyManager.getOrCreateRecordIdentifier({ type: 'user', id: '1' });
+
+    store.cache.upsert(key, { type: 'user', id: '1', attributes: { name: 'Chris', notInSchema: 'kept' } }, false);
+
+    const peeked = store.cache.peek(key) as ResourceObject;
+    assert.deepEqual(
+      peeked.attributes,
+      { name: 'Chris', notInSchema: 'kept' },
+      'declared and undeclared attributes both survive'
+    );
+  });
+});

--- a/warp-drive-packages/json-api/src/-private/cache.ts
+++ b/warp-drive-packages/json-api/src/-private/cache.ts
@@ -1948,6 +1948,36 @@ function setupRelationships(
   }
 }
 
+/**
+ * {json:api} requires a resource's fields to share one namespace, so a
+ * relationship's data never legitimately appears in `data.attributes`. When a
+ * payload violates that, the offending key must not be merged into
+ * `remoteAttrs`: `Cache#peek` composes its `attributes` from those buckets and
+ * `serializeResources` builds outgoing request bodies from `peek`, so the
+ * phantom key is otherwise echoed back to the API inside a document that is
+ * itself invalid — carrying the same field name in both `attributes` and
+ * `relationships`.
+ *
+ * Returns `updates` unchanged when there is nothing to strip, so the ordinary
+ * path allocates nothing.
+ */
+function withoutRelationshipFields(
+  updates: Exclude<ExistingResourceObject['attributes'], undefined>,
+  fields: ReturnType<Store['schema']['fields']>
+): Exclude<ExistingResourceObject['attributes'], undefined> {
+  let filtered: Exclude<ExistingResourceObject['attributes'], undefined> | undefined;
+
+  for (const key of Object.keys(updates)) {
+    const field = fields.get(key);
+    if (field && isRelationship(field)) {
+      filtered = filtered || Object.assign({}, updates);
+      delete filtered[key];
+    }
+  }
+
+  return filtered || updates;
+}
+
 function isRelationship(field: FieldSchema): field is LegacyRelationshipField | CollectionField | ResourceField {
   const { kind } = field;
   return kind === 'hasMany' || kind === 'belongsTo' || kind === 'resource' || kind === 'collection';
@@ -2192,7 +2222,7 @@ function cacheUpsert(
 
   cached.remoteAttrs = Object.assign(
     cached.remoteAttrs || (Object.create(null) as Record<string, unknown>),
-    data.attributes
+    data.attributes && withoutRelationshipFields(data.attributes, fields)
   );
 
   if (cached.localAttrs) {
@@ -2497,7 +2527,7 @@ function didCommit(
   cached.remoteAttrs = Object.assign(
     cached.remoteAttrs || (Object.create(null) as Record<string, unknown>),
     cached.inflightAttrs,
-    newCanonicalAttributes
+    newCanonicalAttributes && withoutRelationshipFields(newCanonicalAttributes, fields)
   );
   cached.inflightAttrs = null;
   patchLocalAttributes(cached, changedKeys);


### PR DESCRIPTION
## The bug

**A relationship's data arriving in `data.attributes` is cached as an attribute, and then sent back to the API on the next save.**

{json:api} requires a resource's fields to [share one namespace](https://jsonapi.org/format/#document-resource-object-fields), so a relationship's data never legitimately appears in `attributes`. When a payload violates that, the cache does not merely tolerate it — it launders it back out.

```ts
cache.upsert(key, {
  type: 'user', id: '1',
  attributes: { name: 'Chris', bestFriend: { type: 'user', id: '2' } },  // ← wrong bucket
  relationships: { bestFriend: { data: { type: 'user', id: '2' } } },    // ← right bucket
});

serializeResources(cache, key).data;
```

Measured, before this change:

```json
{"type":"user","id":"1",
 "attributes":{"name":"Chris","bestFriend":{"type":"user","id":"2"}},
 "relationships":{"bestFriend":{"data":{"id":"2","type":"user"}}}}
```

The client emits a document with `bestFriend` in **both** buckets — the same violation it received, now outbound. After this change `attributes` is `{"name":"Chris"}` and the relationship appears only under `relationships`.

## Why it reaches the network

Three steps, none of which filter by field kind.

**1.** Both `remoteAttrs` writes merge `data.attributes` wholesale — in `upsert`:

```js
cached.remoteAttrs = Object.assign(cached.remoteAttrs || {}, data.attributes);
```

and in `didCommit`, with the save response's attributes.

**2.** `Cache#peek` composes its `attributes` straight from those buckets:

```js
const attributes = structuredClone(
  Object.assign({}, peeked.remoteAttrs, peeked.inflightAttrs, peeked.localAttrs)
);
```

**3.** `serializeResources` builds request bodies from `peek`, and post-processes only the `relationships` member — `attributes` is passed through untouched:

```js
const record = structuredClone(cache.peek(identifier)) as ResourceObject;
…
if (record.relationships) { /* fixRef, slice arrays */ }
```

So the phantom key survives from response → cache → `peek` → request body. Nothing along the way asks whether the key is an attribute.

## The fix

```js
function withoutRelationshipFields(updates, fields) {
  let filtered;
  for (const key of Object.keys(updates)) {
    const field = fields.get(key);
    if (field && isRelationship(field)) {
      filtered = filtered || Object.assign({}, updates);
      delete filtered[key];
    }
  }
  return filtered || updates;
}
```

Applied at both write sites. It consults the same cache-field map they already hold, and reuses the `isRelationship` predicate already defined in this file (used by `setupRelationships` and `patchCache`), so "is a relationship" is not restated.

It returns its input unchanged when there is nothing to strip, so the ordinary path allocates nothing — only a malformed payload pays for a copy.

### Deliberately narrow

- **Only relationship kinds are stripped.** Keys absent from the schema are left alone. The cache already tolerates undeclared attributes, and whether it should is a separate question from this one — there is a control test pinning that behavior so this change cannot quietly alter it.
- **Only the write is changed.** Notification filtering for the same class of payload is [#11089](https://github.com/warp-drive-data/warp-drive/pull/11089), which narrows `calculateChangedKeys`. The two are independent; either stands without the other.

## Tests

`tests/json-api/tests/integration/cache/remote-attrs-field-kinds-test.ts` — 4 tests, committed failing ahead of the fix.

| test | fails pre-fix? |
| --- | --- |
| `upsert` does not merge the relationship name into cached attributes | ✅ yes |
| a subsequent save does not echo it back to the API | ✅ yes |
| `didCommit` does not merge it from the save response | ✅ yes |
| genuine attributes are unaffected, declared or not | no — control |

Both write sites are covered, since the fix touches both. The serialization test is the one that states the user-visible consequence rather than a cache internal.

They use the real `SchemaService` rather than the test app's `TestSchema`: only the real one implements `cacheFields`, and `getCacheFields` otherwise falls back to the much broader `fields()` map — a field set no application actually sees, so asserting against it would encode a test-harness gap as product behavior.

<details>
<summary><b>Verification</b></summary>

All on the pinned toolchain (node 26.8.1, bun 1.4.2) after `pnpm install --force` and `pnpm run sync`:

- `tests/json-api` — 97 pass / 0 fail / 6 todo, against 94 pass / 3 fail without the source change
- `tests/core` 206, `tests/legacy` 134, `tests/ember-data__graph` 143, `tests/utilities` 105, `tests/dont-write-new-tests-here` 5344, `tests/ember-data__model` 2, `tests/ember-data__adapter` 67 — all green
- `check:types` clean on `@warp-drive/json-api`; `lint:oxfmt` and `lint:oxlint` clean from the repo root, and also clean at the test-only commit in isolation

`framework-ember` and `framework-react` are excluded deliberately — currently flaky for an unrelated reason (the holodeck mock server dies on an aborted request, taking every later request in the run with it). Fix in flight in #11092.

</details>

## Behavior change and sequencing

Applications whose API returns relationship data inside `attributes` will stop seeing that key in `cache.peek()`, and will stop sending it back on save. If anything downstream was reading the phantom value out of `peek` — cache dumps, forking, the data-worker cache handler — it disappears. That value was never readable through the field itself, which resolves through the graph.

**Sequencing:** this touches `warp-drive-packages/json-api/src/-private/cache.ts`, the same file as [#11088](https://github.com/warp-drive-data/warp-drive/pull/11088), though a different part of it — that PR reworks `calculateChangedKeys` and `didCommit`'s notification path, this one changes the `remoteAttrs` assignment. No semantic conflict, but whoever lands second rebases, and #11088 is further along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
